### PR TITLE
ci(security): reuse fresh npm audit evidence

### DIFF
--- a/.github/actions/build-base-image-platform/action.yaml
+++ b/.github/actions/build-base-image-platform/action.yaml
@@ -98,12 +98,15 @@ runs:
           fi
         fi
         audit_build_args=""
-        if [ "$AGENT" = "openclaw" ]; then
+        if [ "$AGENT" = "openclaw" ] && [ -n "${MCPORTER_AUDIT_RECEIPT:-}" ]; then
           test -f "$MCPORTER_AUDIT_RECEIPT"
-          test -f "$MCPORTER_AUDIT_RAW_REPORT"
-          audit_build_args="NEMOCLAW_MCPORTER_AUDIT_RECEIPT_SHA256=$(sha256sum "$MCPORTER_AUDIT_RECEIPT" | cut -d' ' -f1)"$'\n'"NEMOCLAW_MCPORTER_AUDIT_RAW_REPORT_SHA256=$(sha256sum "$MCPORTER_AUDIT_RAW_REPORT" | cut -d' ' -f1)"
+          test -f "${MCPORTER_AUDIT_RAW_REPORT:-}"
+          audit_build_args="NEMOCLAW_MCPORTER_AUDIT_RECEIPT_SHA256=$(sha256sum "$MCPORTER_AUDIT_RECEIPT" | cut -d' ' -f1)"
         fi
-        printf 'openclaw_build_arg=%s\naudit_build_args<<EOF\n%s\nEOF\n' "$openclaw_build_arg" "$audit_build_args" >> "$GITHUB_OUTPUT"
+        printf 'openclaw_build_arg=%s\n' "$openclaw_build_arg" >> "$GITHUB_OUTPUT"
+        if [ -n "$audit_build_args" ]; then
+          printf 'audit_build_args<<EOF\n%s\nEOF\n' "$audit_build_args" >> "$GITHUB_OUTPUT"
+        fi
 
     - name: Build and push platform digest
       id: build

--- a/.github/actions/build-base-image-platform/action.yaml
+++ b/.github/actions/build-base-image-platform/action.yaml
@@ -44,6 +44,14 @@ inputs:
     description: Optional OpenClaw version build argument.
     required: false
     default: ""
+  mcporter-audit-receipt:
+    description: Optional same-run reviewed mcporter audit receipt path.
+    required: false
+    default: ""
+  mcporter-audit-raw-report:
+    description: Optional same-run reviewed mcporter raw audit report path.
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -64,6 +72,8 @@ runs:
       env:
         AGENT: ${{ inputs.agent }}
         OPENCLAW_VERSION_INPUT: ${{ inputs.openclaw-version }}
+        MCPORTER_AUDIT_RECEIPT: ${{ inputs.mcporter-audit-receipt }}
+        MCPORTER_AUDIT_RAW_REPORT: ${{ inputs.mcporter-audit-raw-report }}
       run: |
         set -euo pipefail
         build_args=()
@@ -87,7 +97,13 @@ runs:
             exit 1
           fi
         fi
-        printf 'openclaw_build_arg=%s\n' "$openclaw_build_arg" >> "$GITHUB_OUTPUT"
+        audit_build_args=""
+        if [ "$AGENT" = "openclaw" ]; then
+          test -f "$MCPORTER_AUDIT_RECEIPT"
+          test -f "$MCPORTER_AUDIT_RAW_REPORT"
+          audit_build_args="NEMOCLAW_MCPORTER_AUDIT_RECEIPT_SHA256=$(sha256sum "$MCPORTER_AUDIT_RECEIPT" | cut -d' ' -f1)"$'\n'"NEMOCLAW_MCPORTER_AUDIT_RAW_REPORT_SHA256=$(sha256sum "$MCPORTER_AUDIT_RAW_REPORT" | cut -d' ' -f1)"
+        fi
+        printf 'openclaw_build_arg=%s\naudit_build_args<<EOF\n%s\nEOF\n' "$openclaw_build_arg" "$audit_build_args" >> "$GITHUB_OUTPUT"
 
     - name: Build and push platform digest
       id: build
@@ -102,7 +118,12 @@ runs:
         outputs: type=image,name=${{ inputs.registry }}/${{ inputs.image }},push-by-digest=true,name-canonical=true,push=true
         cache-from: type=registry,ref=${{ inputs.registry }}/${{ inputs.image }}:buildcache-${{ inputs.arch }}
         cache-to: type=registry,ref=${{ inputs.registry }}/${{ inputs.image }}:buildcache-${{ inputs.arch }},mode=max
-        build-args: ${{ steps.production-build-args.outputs.openclaw_build_arg }}
+        build-args: |
+          ${{ steps.production-build-args.outputs.openclaw_build_arg }}
+          ${{ steps.production-build-args.outputs.audit_build_args }}
+        secret-files: |
+          ${{ inputs.agent == 'openclaw' && format('nemoclaw-mcporter-audit-receipt={0}', inputs.mcporter-audit-receipt) || '' }}
+          ${{ inputs.agent == 'openclaw' && format('nemoclaw-mcporter-audit-raw-report={0}', inputs.mcporter-audit-raw-report) || '' }}
 
     - name: Validate Deep Agents Code dos2unix executable
       if: ${{ inputs.agent == 'langchain-deepagents-code' }}

--- a/.github/actions/ci-reviewed-npm-audit/action.yaml
+++ b/.github/actions/ci-reviewed-npm-audit/action.yaml
@@ -11,6 +11,13 @@ inputs:
   report-dir:
     description: Report directory relative to target-root.
     required: true
+  cache-directory:
+    description: Absolute directory used for identity-bound reviewed npm audit records.
+    required: true
+  trusted-cache-write:
+    description: Whether this trusted caller may publish reusable audit records.
+    required: false
+    default: "false"
 
 runs:
   using: composite
@@ -20,22 +27,75 @@ runs:
       with:
         node-version: "22.23.2"
 
+    - name: Resolve reviewed npm audit cache buckets
+      id: cache-buckets
+      shell: bash
+      run: |
+        set -euo pipefail
+        current_bucket="$(( $(date -u +%s) / 43200 ))"
+        previous_bucket="$(( current_bucket - 1 ))"
+        input_digest="$(node --input-type=module - '${{ inputs.target-root }}' "$GITHUB_ACTION_PATH/../../../ci/reviewed-npm-audit.json" <<'NODE'
+        import { createHash } from "node:crypto";
+        import { readFileSync } from "node:fs";
+        import { join } from "node:path";
+        const [targetRoot, configFile] = process.argv.slice(2);
+        const configSource = readFileSync(configFile, "utf8");
+        const config = JSON.parse(configSource);
+        const directories = ["", ...config.lockedGraphs.map((graph) => graph.directory)].sort();
+        const hash = createHash("sha256");
+        hash.update(configSource);
+        hash.update(JSON.stringify({ argv: ["audit", "--omit=dev", "--json"], npmVersion: "10.9.4", registry: "https://registry.npmjs.org/", schemaVersion: 1 }));
+        for (const directory of directories) {
+          for (const file of ["package.json", "package-lock.json"]) {
+            const relative = join(directory, file);
+            hash.update(relative);
+            hash.update(readFileSync(join(targetRoot, relative)));
+          }
+        }
+        process.stdout.write(hash.digest("hex"));
+        NODE
+        )"
+        printf 'current=%s\nprevious=%s\ninput-digest=%s\n' "$current_bucket" "$previous_bucket" "$input_digest" >> "$GITHUB_OUTPUT"
+        mkdir -p "${{ inputs.cache-directory }}"
+
+    - name: Restore current reviewed npm audit cache bucket
+      id: cache-current
+      uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      with:
+        path: ${{ inputs.cache-directory }}
+        key: reviewed-npm-audit-v1-${{ runner.os }}-${{ steps.cache-buckets.outputs.input-digest }}-${{ steps.cache-buckets.outputs.current }}
+
+    - name: Restore previous reviewed npm audit cache bucket
+      if: steps.cache-current.outputs.cache-hit != 'true'
+      uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      with:
+        path: ${{ inputs.cache-directory }}
+        key: reviewed-npm-audit-v1-${{ runner.os }}-${{ steps.cache-buckets.outputs.input-digest }}-${{ steps.cache-buckets.outputs.previous }}
+
     - name: Download and verify production npm
       shell: bash
       env:
         NEMOCLAW_REVIEWED_NPM_VERSION: "10.9.4"
         NEMOCLAW_REVIEWED_NPM_INTEGRITY: >-
           sha512-OnUG836FwboQIbqtefDNlyR0gTHzIfwRfE3DuiNewBvnMnWEpB0VEXwBlFVgqpNzIgYo/MHh3d2Hel/pszapAA==
-      run: '"$GITHUB_ACTION_PATH/verify-and-install-npm.sh"'
+      run: env -u NODE_AUTH_TOKEN -u NPM_TOKEN -u NPM_CONFIG__AUTH_TOKEN "$GITHUB_ACTION_PATH/verify-and-install-npm.sh"
 
     - name: Materialize and audit reviewed npm graphs
       shell: bash
       env:
         NEMOCLAW_REVIEWED_NPM_AUDIT_TARGET_ROOT: ${{ inputs.target-root }}
         NEMOCLAW_REVIEWED_NPM_AUDIT_REPORT_DIR: ${{ inputs.report-dir }}
+        NEMOCLAW_REVIEWED_NPM_AUDIT_CACHE_DIR: ${{ inputs.cache-directory }}
         NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
         NPM_CONFIG_USERCONFIG: /dev/null
-      run: node --experimental-strip-types "$GITHUB_ACTION_PATH/../../../scripts/audit-reviewed-npm-graph.mts"
+      run: env -u NODE_AUTH_TOKEN -u NPM_TOKEN -u NPM_CONFIG__AUTH_TOKEN node --experimental-strip-types "$GITHUB_ACTION_PATH/../../../scripts/audit-reviewed-npm-graph.mts"
+
+    - name: Save current reviewed npm audit cache bucket
+      if: inputs.trusted-cache-write == 'true' && steps.cache-current.outputs.cache-hit != 'true'
+      uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      with:
+        path: ${{ inputs.cache-directory }}
+        key: reviewed-npm-audit-v1-${{ runner.os }}-${{ steps.cache-buckets.outputs.input-digest }}-${{ steps.cache-buckets.outputs.current }}
 
     - name: Upload reviewed npm audit reports
       if: always()

--- a/.github/actions/publish-managed-image-digest/action.yaml
+++ b/.github/actions/publish-managed-image-digest/action.yaml
@@ -30,6 +30,9 @@ inputs:
   build-args:
     description: Docker build arguments.
     required: true
+  secret-files:
+    description: Optional Docker BuildKit secret files.
+    required: false
   cache-from:
     description: Optional Buildx cache source.
     required: false
@@ -72,6 +75,7 @@ runs:
         outputs: type=image,name=${{ inputs.image }},push-by-digest=true,name-canonical=true,push=true
         labels: ${{ inputs.labels }}
         build-args: ${{ inputs.build-args }}
+        secret-files: ${{ inputs.secret-files }}
         cache-from: ${{ inputs.cache-from }}
         cache-to: ${{ inputs.cache-to }}
         provenance: ${{ inputs.provenance }}

--- a/.github/workflows/base-image-platform.yaml
+++ b/.github/workflows/base-image-platform.yaml
@@ -64,6 +64,13 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Download same-run reviewed npm audit evidence
+        if: inputs.agent == 'openclaw'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: reviewed-npm-audit
+          path: ${{ runner.temp }}/reviewed-npm-audit
+
       - name: Build and publish platform digest
         id: platform
         uses: ./.github/actions/build-base-image-platform
@@ -77,3 +84,5 @@ jobs:
           registry-username: ${{ github.actor }}
           registry-password: ${{ secrets.registry_password }}
           openclaw-version: ${{ inputs.openclaw-version }}
+          mcporter-audit-receipt: ${{ inputs.agent == 'openclaw' && format('{0}/reviewed-npm-audit/mcporter-runtime.receipt.json', runner.temp) || '' }}
+          mcporter-audit-raw-report: ${{ inputs.agent == 'openclaw' && format('{0}/reviewed-npm-audit/mcporter-runtime.raw.json', runner.temp) || '' }}

--- a/.github/workflows/base-image.yaml
+++ b/.github/workflows/base-image.yaml
@@ -122,6 +122,8 @@ jobs:
         with:
           target-root: ${{ github.workspace }}
           report-dir: artifacts/reviewed-npm-audit
+          cache-directory: ${{ runner.temp }}/reviewed-npm-audit-cache
+          trusted-cache-write: ${{ github.repository == 'NVIDIA/NemoClaw' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
 
   # A failed-job rerun can reuse either successful platform job from an earlier
   # attempt. Keep each digest on a distinct job output so completion order cannot

--- a/.github/workflows/base-image.yaml
+++ b/.github/workflows/base-image.yaml
@@ -75,6 +75,7 @@ on:
       # Dockerfile.base validates min_openclaw_version from this file at build time.
       - "nemoclaw-blueprint/blueprint.yaml"
       - "scripts/lib/openclaw-npm-remediation.mts"
+      - "scripts/lib/npm-audit-receipt.mts"
       - "scripts/lib/reviewed-npm-audit.mts"
       - "scripts/security/build-native-security-packages.sh"
       - "scripts/security/build-perl-security-packages.sh"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -136,6 +136,7 @@ jobs:
             scripts/lib/openclaw-npm-remediation.mts
             scripts/lib/reviewed-npm-archive.mts
             scripts/lib/reviewed-npm-audit.mts
+            scripts/lib/npm-audit-receipt.mts
           sparse-checkout-cone-mode: false
 
       - name: Set up Node for reviewed package download

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -135,6 +135,8 @@ jobs:
         with:
           target-root: ${{ github.workspace }}
           report-dir: artifacts/reviewed-npm-audit
+          cache-directory: ${{ runner.temp }}/reviewed-npm-audit-cache
+          trusted-cache-write: "true"
 
   real-openclaw-dist-harness:
     runs-on: ubuntu-latest

--- a/.github/workflows/managed-images.yaml
+++ b/.github/workflows/managed-images.yaml
@@ -99,6 +99,7 @@ jobs:
             ci/npm-audit-exceptions.json
             ci/reviewed-npm-audit.json
             scripts/audit-reviewed-npm-graph.mts
+            scripts/lib/npm-audit-receipt.mts
             scripts/lib/openclaw-npm-remediation.mts
             scripts/lib/reviewed-npm-archive.mts
             scripts/lib/reviewed-npm-audit.mts
@@ -121,6 +122,7 @@ jobs:
         with:
           target-root: ${{ github.workspace }}/candidate
           report-dir: artifacts/reviewed-npm-audit
+          cache-directory: ${{ runner.temp }}/reviewed-npm-audit-cache
 
   pr-staging-qa-deep-code:
     name: Staging QA base permission regression (Deep Agents Code)
@@ -459,6 +461,24 @@ jobs:
             chmod 0664 "$artifact_path"
           done
 
+      - name: Download same-run reviewed npm audit evidence
+        if: matrix.agent == 'openclaw'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: reviewed-npm-audit
+          path: ${{ runner.temp }}/reviewed-npm-audit
+
+      - name: Prepare same-run mcporter audit evidence
+        if: matrix.agent == 'openclaw'
+        id: mcporter-audit
+        shell: bash
+        run: |
+          set -euo pipefail
+          receipt="$RUNNER_TEMP/reviewed-npm-audit/mcporter-runtime.receipt.json"
+          raw="$RUNNER_TEMP/reviewed-npm-audit/mcporter-runtime.raw.json"
+          test -f "$receipt"; test -f "$raw"
+          printf 'receipt=%s\nraw=%s\nreceipt_sha256=%s\nraw_sha256=%s\n' "$receipt" "$raw" "$(sha256sum "$receipt" | cut -d' ' -f1)" "$(sha256sum "$raw" | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
@@ -571,6 +591,11 @@ jobs:
             BASE_IMAGE=${{ steps.base.outputs.ref }}
             NEMOCLAW_MANAGED_IMAGE_CAPABILITY_UNION=1
             NEMOCLAW_MANAGED_IMAGE_RUNTIME_USER=root
+            ${{ matrix.agent == 'openclaw' && format('NEMOCLAW_MCPORTER_AUDIT_RECEIPT_SHA256={0}', steps.mcporter-audit.outputs.receipt_sha256) || '' }}
+            ${{ matrix.agent == 'openclaw' && format('NEMOCLAW_MCPORTER_AUDIT_RAW_REPORT_SHA256={0}', steps.mcporter-audit.outputs.raw_sha256) || '' }}
+          secret-files: |
+            ${{ matrix.agent == 'openclaw' && format('nemoclaw-mcporter-audit-receipt={0}', steps.mcporter-audit.outputs.receipt) || '' }}
+            ${{ matrix.agent == 'openclaw' && format('nemoclaw-mcporter-audit-raw-report={0}', steps.mcporter-audit.outputs.raw) || '' }}
           cache-from: type=registry,ref=ghcr.io/nvidia/nemoclaw/${{ matrix.agent }}-sandbox:buildcache-linux-amd64
           provenance: false
           sbom: false
@@ -783,6 +808,11 @@ jobs:
             BASE_IMAGE=${{ steps.base.outputs.local == 'true' && 'nemoclaw-pr-base' || steps.base.outputs.ref }}
             NEMOCLAW_MANAGED_IMAGE_CAPABILITY_UNION=1
             NEMOCLAW_MANAGED_IMAGE_RUNTIME_USER=root
+            ${{ matrix.agent == 'openclaw' && format('NEMOCLAW_MCPORTER_AUDIT_RECEIPT_SHA256={0}', steps.mcporter-audit.outputs.receipt_sha256) || '' }}
+            ${{ matrix.agent == 'openclaw' && format('NEMOCLAW_MCPORTER_AUDIT_RAW_REPORT_SHA256={0}', steps.mcporter-audit.outputs.raw_sha256) || '' }}
+          secret-files: |
+            ${{ matrix.agent == 'openclaw' && format('nemoclaw-mcporter-audit-receipt={0}', steps.mcporter-audit.outputs.receipt) || '' }}
+            ${{ matrix.agent == 'openclaw' && format('nemoclaw-mcporter-audit-raw-report={0}', steps.mcporter-audit.outputs.raw) || '' }}
           cache-from: type=registry,ref=ghcr.io/nvidia/nemoclaw/${{ matrix.agent }}-sandbox:buildcache-linux-amd64
           provenance: false
           sbom: false
@@ -1804,6 +1834,11 @@ jobs:
             TARGETARCH=${{ matrix.arch }}
             NEMOCLAW_MANAGED_IMAGE_CAPABILITY_UNION=1
             NEMOCLAW_MANAGED_IMAGE_RUNTIME_USER=root
+            ${{ matrix.agent == 'openclaw' && format('NEMOCLAW_MCPORTER_AUDIT_RECEIPT_SHA256={0}', steps.mcporter-audit.outputs.receipt_sha256) || '' }}
+            ${{ matrix.agent == 'openclaw' && format('NEMOCLAW_MCPORTER_AUDIT_RAW_REPORT_SHA256={0}', steps.mcporter-audit.outputs.raw_sha256) || '' }}
+          secret-files: |
+            ${{ matrix.agent == 'openclaw' && format('nemoclaw-mcporter-audit-receipt={0}', steps.mcporter-audit.outputs.receipt) || '' }}
+            ${{ matrix.agent == 'openclaw' && format('nemoclaw-mcporter-audit-raw-report={0}', steps.mcporter-audit.outputs.raw) || '' }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ matrix.image }}:buildcache-${{ matrix.artifact_platform }}
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ matrix.image }}:buildcache-${{ matrix.artifact_platform }},mode=max
           provenance: mode=max

--- a/.github/workflows/managed-images.yaml
+++ b/.github/workflows/managed-images.yaml
@@ -477,7 +477,7 @@ jobs:
           receipt="$RUNNER_TEMP/reviewed-npm-audit/mcporter-runtime.receipt.json"
           raw="$RUNNER_TEMP/reviewed-npm-audit/mcporter-runtime.raw.json"
           test -f "$receipt"; test -f "$raw"
-          printf 'receipt=%s\nraw=%s\nreceipt_sha256=%s\nraw_sha256=%s\n' "$receipt" "$raw" "$(sha256sum "$receipt" | cut -d' ' -f1)" "$(sha256sum "$raw" | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+          printf 'receipt=%s\nraw=%s\nreceipt_sha256=%s\n' "$receipt" "$raw" "$(sha256sum "$receipt" | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         id: buildx
@@ -534,12 +534,23 @@ jobs:
           RELEASE: ${{ steps.release.outputs.value }}
           RESOLUTION_KEY: ${{ steps.base.outputs.resolution_key }}
           RESOLUTION_LABEL: ${{ steps.base.outputs.resolution_label }}
+          MCPORTER_AUDIT_RECEIPT: ${{ steps.mcporter-audit.outputs.receipt }}
+          MCPORTER_AUDIT_RAW_REPORT: ${{ steps.mcporter-audit.outputs.raw }}
+          MCPORTER_AUDIT_RECEIPT_SHA256: ${{ steps.mcporter-audit.outputs.receipt_sha256 }}
         run: |
           set -euo pipefail
           # The base resolver loads a changed base into Docker's local image
           # store. Keep this consumer on that same store: a Buildx container
           # builder otherwise treats the local-only reference as Docker Hub.
           resolution_labels=()
+          audit_options=()
+          if [ "$AGENT" = "openclaw" ]; then
+            audit_options+=(
+              --build-arg "NEMOCLAW_MCPORTER_AUDIT_RECEIPT_SHA256=${MCPORTER_AUDIT_RECEIPT_SHA256}"
+              --secret "id=nemoclaw-mcporter-audit-receipt,src=${MCPORTER_AUDIT_RECEIPT}"
+              --secret "id=nemoclaw-mcporter-audit-raw-report,src=${MCPORTER_AUDIT_RAW_REPORT}"
+            )
+          fi
           if [ "$AGENT" = "langchain-deepagents-code" ]; then
             resolution_labels+=(
               --label "com.nvidia.nemoclaw.base-resolution-key=${RESOLUTION_KEY}"
@@ -560,6 +571,7 @@ jobs:
             --label "io.nvidia.nemoclaw.managed-image.capabilities=1" \
             --label "io.nvidia.nemoclaw.managed-image.cohort=${PUBLICATION_COHORT}" \
             "${resolution_labels[@]}" \
+            "${audit_options[@]}" \
             --build-arg "BASE_IMAGE=${BASE_IMAGE}" \
             --build-arg "NEMOCLAW_MANAGED_IMAGE_CAPABILITY_UNION=1" \
             --build-arg "NEMOCLAW_MANAGED_IMAGE_RUNTIME_USER=root" \
@@ -592,7 +604,6 @@ jobs:
             NEMOCLAW_MANAGED_IMAGE_CAPABILITY_UNION=1
             NEMOCLAW_MANAGED_IMAGE_RUNTIME_USER=root
             ${{ matrix.agent == 'openclaw' && format('NEMOCLAW_MCPORTER_AUDIT_RECEIPT_SHA256={0}', steps.mcporter-audit.outputs.receipt_sha256) || '' }}
-            ${{ matrix.agent == 'openclaw' && format('NEMOCLAW_MCPORTER_AUDIT_RAW_REPORT_SHA256={0}', steps.mcporter-audit.outputs.raw_sha256) || '' }}
           secret-files: |
             ${{ matrix.agent == 'openclaw' && format('nemoclaw-mcporter-audit-receipt={0}', steps.mcporter-audit.outputs.receipt) || '' }}
             ${{ matrix.agent == 'openclaw' && format('nemoclaw-mcporter-audit-raw-report={0}', steps.mcporter-audit.outputs.raw) || '' }}
@@ -809,7 +820,6 @@ jobs:
             NEMOCLAW_MANAGED_IMAGE_CAPABILITY_UNION=1
             NEMOCLAW_MANAGED_IMAGE_RUNTIME_USER=root
             ${{ matrix.agent == 'openclaw' && format('NEMOCLAW_MCPORTER_AUDIT_RECEIPT_SHA256={0}', steps.mcporter-audit.outputs.receipt_sha256) || '' }}
-            ${{ matrix.agent == 'openclaw' && format('NEMOCLAW_MCPORTER_AUDIT_RAW_REPORT_SHA256={0}', steps.mcporter-audit.outputs.raw_sha256) || '' }}
           secret-files: |
             ${{ matrix.agent == 'openclaw' && format('nemoclaw-mcporter-audit-receipt={0}', steps.mcporter-audit.outputs.receipt) || '' }}
             ${{ matrix.agent == 'openclaw' && format('nemoclaw-mcporter-audit-raw-report={0}', steps.mcporter-audit.outputs.raw) || '' }}
@@ -1558,10 +1568,32 @@ jobs:
           [[ "$GITHUB_RUN_ATTEMPT" =~ ^[1-9][0-9]{0,9}$ ]]
           printf 'cohort=ghrun-%s-%s\n' "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT" >> "$GITHUB_OUTPUT"
 
+  reviewed-npm-audit:
+    name: Reviewed npm audit for managed image publication
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Audit reviewed production npm graphs
+        uses: ./.github/actions/ci-reviewed-npm-audit
+        with:
+          target-root: ${{ github.workspace }}
+          report-dir: artifacts/reviewed-npm-audit
+          cache-directory: ${{ runner.temp }}/reviewed-npm-audit-cache
+          trusted-cache-write: true
+
   build-and-validate:
     name: Build and validate ${{ matrix.display_name }} managed image (${{ matrix.arch }})
     if: github.event_name != 'pull_request'
-    needs: publication-identity
+    needs:
+      - publication-identity
+      - reviewed-npm-audit
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
     strategy:
@@ -1653,6 +1685,24 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Download same-run reviewed npm audit evidence
+        if: matrix.agent == 'openclaw'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: reviewed-npm-audit
+          path: ${{ runner.temp }}/reviewed-npm-audit
+
+      - name: Prepare same-run mcporter audit evidence
+        if: matrix.agent == 'openclaw'
+        id: mcporter-audit
+        shell: bash
+        run: |
+          set -euo pipefail
+          receipt="$RUNNER_TEMP/reviewed-npm-audit/mcporter-runtime.receipt.json"
+          raw="$RUNNER_TEMP/reviewed-npm-audit/mcporter-runtime.raw.json"
+          test -f "$receipt"; test -f "$raw"
+          printf 'receipt=%s\nraw=%s\nreceipt_sha256=%s\n' "$receipt" "$raw" "$(sha256sum "$receipt" | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
 
       - name: Restore exact base image contract
         shell: bash
@@ -1835,7 +1885,6 @@ jobs:
             NEMOCLAW_MANAGED_IMAGE_CAPABILITY_UNION=1
             NEMOCLAW_MANAGED_IMAGE_RUNTIME_USER=root
             ${{ matrix.agent == 'openclaw' && format('NEMOCLAW_MCPORTER_AUDIT_RECEIPT_SHA256={0}', steps.mcporter-audit.outputs.receipt_sha256) || '' }}
-            ${{ matrix.agent == 'openclaw' && format('NEMOCLAW_MCPORTER_AUDIT_RAW_REPORT_SHA256={0}', steps.mcporter-audit.outputs.raw_sha256) || '' }}
           secret-files: |
             ${{ matrix.agent == 'openclaw' && format('nemoclaw-mcporter-audit-receipt={0}', steps.mcporter-audit.outputs.receipt) || '' }}
             ${{ matrix.agent == 'openclaw' && format('nemoclaw-mcporter-audit-raw-report={0}', steps.mcporter-audit.outputs.raw) || '' }}

--- a/.github/workflows/managed-images.yaml
+++ b/.github/workflows/managed-images.yaml
@@ -122,7 +122,6 @@ jobs:
         with:
           target-root: ${{ github.workspace }}/candidate
           report-dir: artifacts/reviewed-npm-audit
-          cache-directory: ${{ runner.temp }}/reviewed-npm-audit-cache
 
   pr-staging-qa-deep-code:
     name: Staging QA base permission regression (Deep Agents Code)

--- a/.github/workflows/openshell-sdk-package-pr.yaml
+++ b/.github/workflows/openshell-sdk-package-pr.yaml
@@ -39,6 +39,7 @@ jobs:
             scripts/lib/openclaw-npm-remediation.mts
             scripts/lib/reviewed-npm-archive.mts
             scripts/lib/reviewed-npm-audit.mts
+            scripts/lib/npm-audit-receipt.mts
           sparse-checkout-cone-mode: false
 
       - name: Setup Node.js for reviewed package download

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -552,7 +552,6 @@ jobs:
         with:
           target-root: ${{ github.workspace }}
           report-dir: artifacts/reviewed-npm-audit
-          cache-directory: ${{ runner.temp }}/reviewed-npm-audit-cache
 
   cli-test-shards:
     needs: [changes, compile-artifacts, openshell-sdk-package]

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -131,6 +131,7 @@ jobs:
             scripts/lib/openclaw-npm-remediation.mts
             scripts/lib/reviewed-npm-archive.mts
             scripts/lib/reviewed-npm-audit.mts
+            scripts/lib/npm-audit-receipt.mts
           sparse-checkout-cone-mode: false
 
       - name: Download verified OpenShell SDK archive
@@ -200,6 +201,7 @@ jobs:
             scripts/lib/openclaw-npm-remediation.mts
             scripts/lib/reviewed-npm-archive.mts
             scripts/lib/reviewed-npm-audit.mts
+            scripts/lib/npm-audit-receipt.mts
           sparse-checkout-cone-mode: false
 
       - name: Locate exact base-controlled SDK package run
@@ -385,6 +387,7 @@ jobs:
             scripts/lib/openclaw-npm-remediation.mts
             scripts/lib/reviewed-npm-archive.mts
             scripts/lib/reviewed-npm-audit.mts
+            scripts/lib/npm-audit-receipt.mts
           sparse-checkout-cone-mode: false
 
       - name: Download verified OpenShell SDK archive
@@ -444,6 +447,7 @@ jobs:
             scripts/lib/openclaw-npm-remediation.mts
             scripts/lib/reviewed-npm-archive.mts
             scripts/lib/reviewed-npm-audit.mts
+            scripts/lib/npm-audit-receipt.mts
           sparse-checkout-cone-mode: false
 
       - name: Download verified OpenShell SDK archive
@@ -502,6 +506,7 @@ jobs:
             scripts/lib/openclaw-npm-remediation.mts
             scripts/lib/reviewed-npm-archive.mts
             scripts/lib/reviewed-npm-audit.mts
+            scripts/lib/npm-audit-receipt.mts
           sparse-checkout-cone-mode: false
 
       - name: Download verified OpenShell SDK archive
@@ -539,6 +544,7 @@ jobs:
             scripts/lib/openclaw-npm-remediation.mts
             scripts/lib/reviewed-npm-archive.mts
             scripts/lib/reviewed-npm-audit.mts
+            scripts/lib/npm-audit-receipt.mts
           sparse-checkout-cone-mode: false
 
       - name: Audit reviewed production npm graphs
@@ -546,6 +552,7 @@ jobs:
         with:
           target-root: ${{ github.workspace }}
           report-dir: artifacts/reviewed-npm-audit
+          cache-directory: ${{ runner.temp }}/reviewed-npm-audit-cache
 
   cli-test-shards:
     needs: [changes, compile-artifacts, openshell-sdk-package]
@@ -589,6 +596,7 @@ jobs:
             scripts/lib/openclaw-npm-remediation.mts
             scripts/lib/reviewed-npm-archive.mts
             scripts/lib/reviewed-npm-audit.mts
+            scripts/lib/npm-audit-receipt.mts
           sparse-checkout-cone-mode: false
 
       - name: Download verified OpenShell SDK archive
@@ -715,6 +723,7 @@ jobs:
             scripts/lib/openclaw-npm-remediation.mts
             scripts/lib/reviewed-npm-archive.mts
             scripts/lib/reviewed-npm-audit.mts
+            scripts/lib/npm-audit-receipt.mts
           sparse-checkout-cone-mode: false
 
       - name: Download verified OpenShell SDK archive
@@ -765,6 +774,7 @@ jobs:
             scripts/lib/openclaw-npm-remediation.mts
             scripts/lib/reviewed-npm-archive.mts
             scripts/lib/reviewed-npm-audit.mts
+            scripts/lib/npm-audit-receipt.mts
           sparse-checkout-cone-mode: false
 
       - name: Download verified OpenShell SDK archive

--- a/Dockerfile
+++ b/Dockerfile
@@ -817,8 +817,8 @@ RUN command -v codex-acp >/dev/null
 
 # Upgrade stale bases. Reuse is restricted to matching provenance from an
 # official digest-pinned base; mutable/custom bases reinstall the locked graphs.
-# OPENCLAW_VERSION must meet the blueprint minimum. Reviewed archives retain
-# registry and packed-byte SRI, basename, local-only install, and cleanup gates.
+# OPENCLAW_VERSION is the NemoClaw runtime build target and must meet the blueprint minimum.
+# Reviewed archives retain registry and packed-byte SRI, basename, local-only install, and cleanup gates.
 # hadolint ignore=DL3059,DL4006,DL3016,SC2015
 RUN --network=default \
     --mount=type=secret,id=nemoclaw-mcporter-audit-receipt,required=false \
@@ -985,24 +985,24 @@ RUN --network=default \
             'const { StreamableHTTPServerTransport } = await import("file:///usr/local/lib/nemoclaw/mcporter-runtime/node_modules/@modelcontextprotocol/sdk/dist/esm/server/streamableHttp.js"); const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined }); await transport.close();'; \
         ln -s /usr/local/lib/nemoclaw/mcporter-runtime/node_modules/.bin/mcporter /usr/local/bin/mcporter; \
         test "$(mcporter --version)" = "$MCPORTER_VERSION"; \
-        MCPORTER_RECEIPT=/run/secrets/nemoclaw-mcporter-audit-receipt; \
-        MCPORTER_RAW_REPORT=/run/secrets/nemoclaw-mcporter-audit-raw-report; \
-        if [ -f "$MCPORTER_RECEIPT" ] || [ -f "$MCPORTER_RAW_REPORT" ] || [ -n "$NEMOCLAW_MCPORTER_AUDIT_RECEIPT_SHA256" ]; then \
-            [ -f "$MCPORTER_RECEIPT" ] && [ -f "$MCPORTER_RAW_REPORT" ] && printf %s "$NEMOCLAW_MCPORTER_AUDIT_RECEIPT_SHA256" | grep -qxE '[0-9a-f]{64}' \
-                || { echo "ERROR: cached mcporter audit requires paired receipt, raw report, and receipt SHA-256" >&2; exit 1; }; \
-            printf '%s  %s\n' "$NEMOCLAW_MCPORTER_AUDIT_RECEIPT_SHA256" "$MCPORTER_RECEIPT" | sha256sum -c -; \
-            node --experimental-strip-types /scripts/lib/npm-audit-receipt.mts \
-                --receipt "$MCPORTER_RECEIPT" \
-                --package-json /usr/local/lib/nemoclaw/mcporter-runtime/package.json \
-                --package-lock /usr/local/lib/nemoclaw/mcporter-runtime/package-lock.json \
-                --raw-report "$MCPORTER_RAW_REPORT" --exceptions /scripts/npm-audit-exceptions.json \
-                --graph mcporter-runtime --npm-version "$(npm --version)" \
-                --registry https://registry.npmjs.org/ --threshold high; \
-        else \
-            node --experimental-strip-types /scripts/lib/reviewed-npm-audit.mts \
-                --directory /usr/local/lib/nemoclaw/mcporter-runtime \
-                --exceptions /scripts/npm-audit-exceptions.json --graph mcporter-runtime --threshold high; \
-        fi; \
+    fi; \
+    MCPORTER_RECEIPT=/run/secrets/nemoclaw-mcporter-audit-receipt; \
+    MCPORTER_RAW_REPORT=/run/secrets/nemoclaw-mcporter-audit-raw-report; \
+    if [ -f "$MCPORTER_RECEIPT" ] || [ -f "$MCPORTER_RAW_REPORT" ] || [ -n "${NEMOCLAW_MCPORTER_AUDIT_RECEIPT_SHA256:-}" ]; then \
+        [ -f "$MCPORTER_RECEIPT" ] && [ -f "$MCPORTER_RAW_REPORT" ] && printf %s "$NEMOCLAW_MCPORTER_AUDIT_RECEIPT_SHA256" | grep -qxE '[0-9a-f]{64}' \
+            || { echo "ERROR: cached mcporter audit requires paired receipt, raw report, and receipt SHA-256" >&2; exit 1; }; \
+        printf '%s  %s\n' "$NEMOCLAW_MCPORTER_AUDIT_RECEIPT_SHA256" "$MCPORTER_RECEIPT" | sha256sum -c -; \
+        node --experimental-strip-types /scripts/lib/npm-audit-receipt.mts \
+            --receipt "$MCPORTER_RECEIPT" \
+            --package-json /usr/local/lib/nemoclaw/mcporter-runtime/package.json \
+            --package-lock /usr/local/lib/nemoclaw/mcporter-runtime/package-lock.json \
+            --raw-report "$MCPORTER_RAW_REPORT" --exceptions /scripts/npm-audit-exceptions.json \
+            --graph mcporter-runtime --npm-version "$(npm --version)" \
+            --registry https://registry.npmjs.org/ --threshold high; \
+    else \
+        node --experimental-strip-types /scripts/lib/reviewed-npm-audit.mts \
+            --directory /usr/local/lib/nemoclaw/mcporter-runtime \
+            --exceptions /scripts/npm-audit-exceptions.json --graph mcporter-runtime --threshold high; \
     fi
 
 # Patch OpenClaw media fetch for proxy-only sandbox (NVIDIA/NemoClaw#1755).

--- a/Dockerfile
+++ b/Dockerfile
@@ -544,6 +544,7 @@ COPY ci/npm-audit-exceptions.json /scripts/npm-audit-exceptions.json
 COPY scripts/lib/reviewed-npm-archive.mts /scripts/lib/reviewed-npm-archive.mts
 COPY scripts/lib/bundled-npm-package.mts /scripts/lib/bundled-npm-package.mts
 COPY scripts/lib/reviewed-npm-audit.mts /scripts/lib/reviewed-npm-audit.mts
+COPY scripts/lib/npm-audit-receipt.mts /scripts/lib/npm-audit-receipt.mts
 COPY scripts/lib/openclaw-npm-remediation.mts /scripts/lib/openclaw-npm-remediation.mts
 COPY scripts/patch-bundled-npm-brace-expansion.mts /scripts/patch-bundled-npm-brace-expansion.mts
 COPY scripts/lib/patch-bundled-npm-ip-address.mts /scripts/lib/patch-bundled-npm-ip-address.mts
@@ -635,6 +636,7 @@ ARG OPENCLAW_2026_4_24_TARBALL=https://registry.npmjs.org/openclaw/-/openclaw-20
 ARG MCPORTER_VERSION=0.7.3
 ARG MCPORTER_0_7_3_INTEGRITY=sha512-egoPVYqTnWb3NjRIxo+xc8OrAI0dlPrJm9pAiZx0pImuNIV5rKhGtTnIfH/Y1ldGPVu74ibj3KR5c9U/QSdQFA==
 ARG MCPORTER_0_7_3_TARBALL=https://registry.npmjs.org/mcporter/-/mcporter-0.7.3.tgz
+ARG NEMOCLAW_MCPORTER_AUDIT_RECEIPT_SHA256=
 
 # A cross-stage root copy is accepted by Docker's legacy builder and creates one
 # final-image layer while preserving metadata on existing parent directories.
@@ -807,45 +809,21 @@ RUN chmod 755 /usr/local/lib/nemoclaw/patch-openclaw-tool-catalog.mts \
         /usr/local/lib/nemoclaw/patch-openclaw-shared-state-permissions.mts \
         /usr/local/lib/nemoclaw/verify-wechat-runtime-lock.mts
 
-# Pre-install the codex-acp package so the embedded ACPx runtime can
-# call the local binary instead of `npx @zed-industries/codex-acp`.
-#
-# The sandbox's L7 proxy denies @zed-industries/* package URLs
-# (403 policy_denied), and npm still refreshes registry metadata for
-# versioned npx package specs even when the package is globally installed.
-# Installing the binary at build time and configuring ACPx to use it
-# directly keeps TC-SBX-02 off the runtime npm path.
-# The architecture-selected installer stage consumes checksum-addressed local
-# archives with the network disabled, verifies their committed SRI values, and
-# installs both the launcher and its native package together.
-#
+# Install SRI-verified ACP offline; runtime registry access is blocked.
 # hadolint ignore=DL3059,DL4006,DL3016
 COPY --from=codex-acp-runtime /usr/local/lib/node_modules/@zed-industries/ /usr/local/lib/node_modules/@zed-industries/
 COPY --from=codex-acp-runtime /usr/local/bin/codex-acp /usr/local/bin/codex-acp
 RUN command -v codex-acp >/dev/null
 
-# Upgrade OpenClaw if the base image is stale.
-# Reuse pinned OpenClaw and locked-mcporter base installs only from a published
-# NemoClaw base whose package provenance marker matches this build target;
-# otherwise reinstall both.
-#
-# The GHCR base image (sandbox-base:latest) may lag behind the version pinned in
-# Dockerfile.base, and legacy/custom bases may report the target version without
-# proving which archive and lifecycle produced it. The marker records package
-# and advisory-audit metadata, not trusted-CI signature attestation. Only a
-# digest-pinned base from the official GHCR publication path supplies that
-# independent gate. Mutable tags and local bases cannot authorize reuse even
-# when their marker matches; the existing version checks reinstall the locked
-# runtimes or reject a newer base. The final image consumes the marker before
-# applying NemoClaw patches so a custom base cannot masquerade as a pristine
-# published base.
-#
-# OPENCLAW_VERSION is the NemoClaw runtime build target. It must be at least the
-# blueprint minimum, which also supports the legacy direct-blueprint image path.
-# Reviewed-archive invariants (#5896): registry SRI, packed-byte SRI, contained
-# basename in a fresh directory, local-archive-only install, and cleanup.
-# hadolint ignore=DL3059,DL4006,DL3016
-RUN --network=default set -eu; \
+# Upgrade stale bases. Reuse is restricted to matching provenance from an
+# official digest-pinned base; mutable/custom bases reinstall the locked graphs.
+# OPENCLAW_VERSION must meet the blueprint minimum. Reviewed archives retain
+# registry and packed-byte SRI, basename, local-only install, and cleanup gates.
+# hadolint ignore=DL3059,DL4006,DL3016,SC2015
+RUN --network=default \
+    --mount=type=secret,id=nemoclaw-mcporter-audit-receipt,required=false \
+    --mount=type=secret,id=nemoclaw-mcporter-audit-raw-report,required=false \
+    set -eu; \
     if [ -f /usr/local/share/nemoclaw/corporate-ca.pem ]; then \
         export CURL_CA_BUNDLE=/usr/local/share/nemoclaw/corporate-ca.pem; \
         export NODE_EXTRA_CA_CERTS=/usr/local/share/nemoclaw/corporate-ca.pem; \
@@ -1007,9 +985,24 @@ RUN --network=default set -eu; \
             'const { StreamableHTTPServerTransport } = await import("file:///usr/local/lib/nemoclaw/mcporter-runtime/node_modules/@modelcontextprotocol/sdk/dist/esm/server/streamableHttp.js"); const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined }); await transport.close();'; \
         ln -s /usr/local/lib/nemoclaw/mcporter-runtime/node_modules/.bin/mcporter /usr/local/bin/mcporter; \
         test "$(mcporter --version)" = "$MCPORTER_VERSION"; \
-        node --experimental-strip-types /scripts/lib/reviewed-npm-audit.mts \
-            --directory /usr/local/lib/nemoclaw/mcporter-runtime \
-            --exceptions /scripts/npm-audit-exceptions.json --graph mcporter-runtime --threshold high; \
+        MCPORTER_RECEIPT=/run/secrets/nemoclaw-mcporter-audit-receipt; \
+        MCPORTER_RAW_REPORT=/run/secrets/nemoclaw-mcporter-audit-raw-report; \
+        if [ -f "$MCPORTER_RECEIPT" ] || [ -f "$MCPORTER_RAW_REPORT" ] || [ -n "$NEMOCLAW_MCPORTER_AUDIT_RECEIPT_SHA256" ]; then \
+            [ -f "$MCPORTER_RECEIPT" ] && [ -f "$MCPORTER_RAW_REPORT" ] && printf %s "$NEMOCLAW_MCPORTER_AUDIT_RECEIPT_SHA256" | grep -qxE '[0-9a-f]{64}' \
+                || { echo "ERROR: cached mcporter audit requires paired receipt, raw report, and receipt SHA-256" >&2; exit 1; }; \
+            printf '%s  %s\n' "$NEMOCLAW_MCPORTER_AUDIT_RECEIPT_SHA256" "$MCPORTER_RECEIPT" | sha256sum -c -; \
+            node --experimental-strip-types /scripts/lib/npm-audit-receipt.mts \
+                --receipt "$MCPORTER_RECEIPT" \
+                --package-json /usr/local/lib/nemoclaw/mcporter-runtime/package.json \
+                --package-lock /usr/local/lib/nemoclaw/mcporter-runtime/package-lock.json \
+                --raw-report "$MCPORTER_RAW_REPORT" --exceptions /scripts/npm-audit-exceptions.json \
+                --graph mcporter-runtime --npm-version "$(npm --version)" \
+                --registry https://registry.npmjs.org/ --threshold high; \
+        else \
+            node --experimental-strip-types /scripts/lib/reviewed-npm-audit.mts \
+                --directory /usr/local/lib/nemoclaw/mcporter-runtime \
+                --exceptions /scripts/npm-audit-exceptions.json --graph mcporter-runtime --threshold high; \
+        fi; \
     fi
 
 # Patch OpenClaw media fetch for proxy-only sandbox (NVIDIA/NemoClaw#1755).

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -428,9 +428,9 @@ COPY ci/npm-audit-exceptions.json /scripts/npm-audit-exceptions.json
 COPY scripts/lib/reviewed-npm-archive.mts \
     scripts/lib/bundled-npm-package.mts \
     scripts/lib/reviewed-npm-audit.mts \
-    scripts/lib/npm-audit-receipt.mts \
     scripts/lib/openclaw-npm-remediation.mts \
     /scripts/lib/
+COPY scripts/lib/npm-audit-receipt.mts /scripts/lib/npm-audit-receipt.mts
 COPY scripts/patch-bundled-npm-brace-expansion.mts /scripts/patch-bundled-npm-brace-expansion.mts
 COPY scripts/lib/patch-bundled-npm-ip-address.mts /scripts/lib/patch-bundled-npm-ip-address.mts
 COPY scripts/patch-bundled-npm-tar.mts /scripts/patch-bundled-npm-tar.mts
@@ -584,7 +584,7 @@ RUN --mount=type=bind,source=nemoclaw-blueprint/blueprint.yaml,target=/tmp/bluep
     && test "$(mcporter --version)" = "$MCPORTER_VERSION" \
     && MCPORTER_RECEIPT=/run/secrets/nemoclaw-mcporter-audit-receipt \
     && MCPORTER_RAW_REPORT=/run/secrets/nemoclaw-mcporter-audit-raw-report \
-    && if [ -f "$MCPORTER_RECEIPT" ] || [ -f "$MCPORTER_RAW_REPORT" ] || [ -n "$NEMOCLAW_MCPORTER_AUDIT_RECEIPT_SHA256" ]; then \
+    && if [ -f "$MCPORTER_RECEIPT" ] || [ -f "$MCPORTER_RAW_REPORT" ] || [ -n "${NEMOCLAW_MCPORTER_AUDIT_RECEIPT_SHA256:-}" ]; then \
         [ -f "$MCPORTER_RECEIPT" ] && [ -f "$MCPORTER_RAW_REPORT" ] && printf %s "$NEMOCLAW_MCPORTER_AUDIT_RECEIPT_SHA256" | grep -qxE '[0-9a-f]{64}' \
             || { echo "ERROR: cached mcporter audit requires paired receipt, raw report, and receipt SHA-256" >&2; exit 1; }; \
         printf '%s  %s\n' "$NEMOCLAW_MCPORTER_AUDIT_RECEIPT_SHA256" "$MCPORTER_RECEIPT" | sha256sum -c -; \
@@ -594,9 +594,9 @@ RUN --mount=type=bind,source=nemoclaw-blueprint/blueprint.yaml,target=/tmp/bluep
             --package-lock /usr/local/lib/nemoclaw/mcporter-runtime/package-lock.json \
             --raw-report "$MCPORTER_RAW_REPORT" --exceptions /scripts/npm-audit-exceptions.json \
             --graph mcporter-runtime --npm-version "$(npm --version)" \
-            --registry https://registry.npmjs.org/ --threshold high; \
+            --registry https://registry.npmjs.org/ --threshold high \
+            --result /tmp/mcporter-npm-audit-policy.json; \
         cp "$MCPORTER_RAW_REPORT" /tmp/mcporter-npm-audit.json; \
-        node --input-type=module -e 'import fs from "node:fs"; const receipt=JSON.parse(fs.readFileSync(process.argv[1], "utf8")); fs.writeFileSync(process.argv[2], JSON.stringify({status:receipt.acceptedAdvisoryIds.length ? "accepted-exceptions" : "clean", acceptedAdvisories:receipt.acceptedAdvisoryIds, exceptionPolicySha256:receipt.exceptionPolicySha256}));' "$MCPORTER_RECEIPT" /tmp/mcporter-npm-audit-policy.json; \
       else \
         node --experimental-strip-types /scripts/lib/reviewed-npm-audit.mts \
             --directory /usr/local/lib/nemoclaw/mcporter-runtime \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -415,6 +415,7 @@ ARG OPENCLAW_2026_4_24_TARBALL=https://registry.npmjs.org/openclaw/-/openclaw-20
 ARG MCPORTER_VERSION=0.7.3
 ARG MCPORTER_0_7_3_INTEGRITY=sha512-egoPVYqTnWb3NjRIxo+xc8OrAI0dlPrJm9pAiZx0pImuNIV5rKhGtTnIfH/Y1ldGPVu74ibj3KR5c9U/QSdQFA==
 ARG MCPORTER_0_7_3_TARBALL=https://registry.npmjs.org/mcporter/-/mcporter-0.7.3.tgz
+ARG NEMOCLAW_MCPORTER_AUDIT_RECEIPT_SHA256=
 # Keep paired runtime manifests and remediation helpers in grouped layers so
 # the published base retains its established image layout.
 COPY agents/openclaw/openclaw-runtime/package.json \
@@ -427,6 +428,7 @@ COPY ci/npm-audit-exceptions.json /scripts/npm-audit-exceptions.json
 COPY scripts/lib/reviewed-npm-archive.mts \
     scripts/lib/bundled-npm-package.mts \
     scripts/lib/reviewed-npm-audit.mts \
+    scripts/lib/npm-audit-receipt.mts \
     scripts/lib/openclaw-npm-remediation.mts \
     /scripts/lib/
 COPY scripts/patch-bundled-npm-brace-expansion.mts /scripts/patch-bundled-npm-brace-expansion.mts
@@ -476,6 +478,8 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # basename in a fresh directory, local-archive-only install, and cleanup.
 # hadolint ignore=DL3016
 RUN --mount=type=bind,source=nemoclaw-blueprint/blueprint.yaml,target=/tmp/blueprint.yaml \
+    --mount=type=secret,id=nemoclaw-mcporter-audit-receipt,required=false \
+    --mount=type=secret,id=nemoclaw-mcporter-audit-raw-report,required=false \
     echo "$OPENCLAW_VERSION" | grep -qxE '[0-9]+(\.[0-9]+)*' \
     || { echo "Error: OPENCLAW_VERSION='$OPENCLAW_VERSION' is invalid (expected e.g. 2026.3.11)."; exit 1; }; \
     OPENCLAW_MIN_VERSION=$(grep -m 1 'min_openclaw_version' /tmp/blueprint.yaml | awk '{print $2}' | tr -d '"'); \
@@ -578,10 +582,27 @@ RUN --mount=type=bind,source=nemoclaw-blueprint/blueprint.yaml,target=/tmp/bluep
         'const { StreamableHTTPServerTransport } = await import("file:///usr/local/lib/nemoclaw/mcporter-runtime/node_modules/@modelcontextprotocol/sdk/dist/esm/server/streamableHttp.js"); const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined }); await transport.close();' \
     && ln -s /usr/local/lib/nemoclaw/mcporter-runtime/node_modules/.bin/mcporter /usr/local/bin/mcporter \
     && test "$(mcporter --version)" = "$MCPORTER_VERSION" \
-    && node --experimental-strip-types /scripts/lib/reviewed-npm-audit.mts \
-        --directory /usr/local/lib/nemoclaw/mcporter-runtime \
-        --exceptions /scripts/npm-audit-exceptions.json --graph mcporter-runtime --threshold high \
-        --report /tmp/mcporter-npm-audit.json --result /tmp/mcporter-npm-audit-policy.json \
+    && MCPORTER_RECEIPT=/run/secrets/nemoclaw-mcporter-audit-receipt \
+    && MCPORTER_RAW_REPORT=/run/secrets/nemoclaw-mcporter-audit-raw-report \
+    && if [ -f "$MCPORTER_RECEIPT" ] || [ -f "$MCPORTER_RAW_REPORT" ] || [ -n "$NEMOCLAW_MCPORTER_AUDIT_RECEIPT_SHA256" ]; then \
+        [ -f "$MCPORTER_RECEIPT" ] && [ -f "$MCPORTER_RAW_REPORT" ] && printf %s "$NEMOCLAW_MCPORTER_AUDIT_RECEIPT_SHA256" | grep -qxE '[0-9a-f]{64}' \
+            || { echo "ERROR: cached mcporter audit requires paired receipt, raw report, and receipt SHA-256" >&2; exit 1; }; \
+        printf '%s  %s\n' "$NEMOCLAW_MCPORTER_AUDIT_RECEIPT_SHA256" "$MCPORTER_RECEIPT" | sha256sum -c -; \
+        node --experimental-strip-types /scripts/lib/npm-audit-receipt.mts \
+            --receipt "$MCPORTER_RECEIPT" \
+            --package-json /usr/local/lib/nemoclaw/mcporter-runtime/package.json \
+            --package-lock /usr/local/lib/nemoclaw/mcporter-runtime/package-lock.json \
+            --raw-report "$MCPORTER_RAW_REPORT" --exceptions /scripts/npm-audit-exceptions.json \
+            --graph mcporter-runtime --npm-version "$(npm --version)" \
+            --registry https://registry.npmjs.org/ --threshold high; \
+        cp "$MCPORTER_RAW_REPORT" /tmp/mcporter-npm-audit.json; \
+        node --input-type=module -e 'import fs from "node:fs"; const receipt=JSON.parse(fs.readFileSync(process.argv[1], "utf8")); fs.writeFileSync(process.argv[2], JSON.stringify({status:receipt.acceptedAdvisoryIds.length ? "accepted-exceptions" : "clean", acceptedAdvisories:receipt.acceptedAdvisoryIds, exceptionPolicySha256:receipt.exceptionPolicySha256}));' "$MCPORTER_RECEIPT" /tmp/mcporter-npm-audit-policy.json; \
+      else \
+        node --experimental-strip-types /scripts/lib/reviewed-npm-audit.mts \
+            --directory /usr/local/lib/nemoclaw/mcporter-runtime \
+            --exceptions /scripts/npm-audit-exceptions.json --graph mcporter-runtime --threshold high \
+            --report /tmp/mcporter-npm-audit.json --result /tmp/mcporter-npm-audit-policy.json; \
+      fi \
     && MCPORTER_AUDIT_STATUS="$(node -p "require('/tmp/mcporter-npm-audit-policy.json').status")" \
     && MCPORTER_AUDIT_EXCEPTIONS="$(node -p "require('/tmp/mcporter-npm-audit-policy.json').acceptedAdvisories.join(',') || 'none'")" \
     && MCPORTER_AUDIT_POLICY_SHA256="$(node -p "require('/tmp/mcporter-npm-audit-policy.json').exceptionPolicySha256")" \

--- a/agents/openclaw/dependency-review.md
+++ b/agents/openclaw/dependency-review.md
@@ -41,7 +41,9 @@ The reviewed audit wrapper reports lower-severity production findings and blocks
   It installs the exact lock with lifecycle scripts disabled and legacy peer resolution, rejects any low-or-higher production advisory, and verifies registry signatures.
   It also exercises the reviewed archive through a copied writable cache while the trusted source remains read-only.
   Signature verification makes at most three attempts and retries only `npm error Failed to download`; all other failures stop immediately.
-  The shared report artifact stores the audit policy, provenance, and signature-attempt evidence.
+  The shared report artifact stores the audit policy, signature-attempt evidence, and whether each response came from a matching cache entry or a live registry request.
+  Its mcporter receipt and raw response cross into the image build; the other graph receipts remain CI evidence.
+  The archive graph also retains the generated manifest and lock bytes authenticated by its receipt.
 - Advisory command: `npm ci --ignore-scripts --omit=dev --legacy-peer-deps --prefix agents/openclaw/wechat-runtime && npm audit --omit=dev --audit-level=low --json --prefix agents/openclaw/wechat-runtime && npm audit signatures --prefix agents/openclaw/wechat-runtime`.
 - Advisory review: `2026-07-12`; result: `0` known vulnerabilities across the resolved production graph.
 - Regression tests: `test/install/wechat-locked-install.test.ts` keeps the manifest runtime-lock paths and installer verification dispatch synchronized; `test/install/verify-wechat-runtime-lock.test.ts` proves that the installed graph and OpenClaw peer range fail closed; `test/automation/releases/reviewed-npm-audit-workflow.test.ts` keeps the cache lifecycle, audit threshold, bounded signature retry, invalid-signature denial, and npm-pack boundary synchronized.

--- a/docs/security/advisory-early-warning.md
+++ b/docs/security/advisory-early-warning.md
@@ -95,7 +95,9 @@ The same #7338 sign-off gate applies to this work.
 
 Each reviewed npm audit report has a `*.provenance.json` sidecar.
 The sidecars include `coverage/reviewed-npm-audit/` artifacts and `npm-audit.provenance.json` for the WeChat locked runtime graph audit.
-Each sidecar records:
+A configured cache reuses a response only when the package and lock bytes, npm version, registry origin, command arguments, and parser identity match.
+The sidecar records whether the response came from the cache or a live registry request, plus its creation time, age, input digest, and response digest.
+Each sidecar also records:
 
 - Scanner identity, including `npm audit`, npm version, and Node.js version.
 - The configured registry with URL credentials removed.

--- a/scripts/audit-reviewed-npm-graph.mts
+++ b/scripts/audit-reviewed-npm-graph.mts
@@ -9,6 +9,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { remediateReviewedOpenClawPluginArchive } from "./lib/openclaw-npm-remediation.mts";
+import { canonicalAuditReceipt, createAuditReceipt } from "./lib/npm-audit-receipt.mts";
 import {
   packReviewedNpmArchive,
   verifyInstalledNpmLock,
@@ -134,6 +135,32 @@ function trustedRepositoryPath(relativePath: string, label: string): string {
 
 function targetRepositoryPath(relativePath: string, label: string): string {
   return resolvePathWithinRoot(TARGET_REPO_ROOT, relativePath, label);
+}
+
+function graphCacheFile(graphId: string): string | undefined {
+  const configuredDirectory = process.env.NEMOCLAW_REVIEWED_NPM_AUDIT_CACHE_DIR;
+  if (!configuredDirectory) return undefined;
+  if (!path.isAbsolute(configuredDirectory)) {
+    throw new Error("reviewed npm audit cache directory must be absolute");
+  }
+  if (!/^[a-z0-9][a-z0-9._-]*$/.test(graphId)) {
+    throw new Error(`npm audit cache graph ID is unsafe: ${graphId}`);
+  }
+  const directory = path.resolve(configuredDirectory);
+  let current = path.parse(directory).root;
+  for (const component of path.relative(current, directory).split(path.sep)) {
+    if (!component) continue;
+    current = path.join(current, component);
+    const stat = fs.lstatSync(current, { throwIfNoEntry: false });
+    if (!stat) throw new Error("reviewed npm audit cache directory must exist");
+    if (stat.isSymbolicLink()) {
+      throw new Error("reviewed npm audit cache directory must not contain symbolic links");
+    }
+  }
+  if (!fs.statSync(directory).isDirectory()) {
+    throw new Error("reviewed npm audit cache directory must be a directory");
+  }
+  return path.join(directory, `${graphId}.json`);
 }
 
 function run(command: string, args: readonly string[], cwd: string) {
@@ -671,6 +698,7 @@ function auditLockedGraph(
 ) {
   const directory = materializeLockedGraph(graph, tempRoot, config.registryOrigin);
   const result = runReviewedNpmAudit({
+    cacheFile: graphCacheFile(graph.id),
     directory,
     exceptionFile,
     graph: graph.id,
@@ -750,6 +778,7 @@ export function auditMaterializedSourceGraph(
   }> = {},
 ): AuditPolicyResult {
   const result = (dependencies.runAudit ?? runReviewedNpmAudit)({
+    cacheFile: graphCacheFile(SOURCE_GRAPH.id),
     directory: options.directory,
     exceptionFile: options.exceptionFile,
     graph: SOURCE_GRAPH.id,
@@ -769,6 +798,56 @@ export function auditMaterializedSourceGraph(
     ((directory) => run("npm", ["audit", "signatures", "--omit=dev"], directory))
   )(options.directory);
   return result;
+}
+
+export function emitAuditReceipt(
+  options: Readonly<{
+    artifactDirectory: string;
+    graphId: string;
+    npmVersion: string;
+    packageJsonFile: string;
+    packageLockFile: string;
+    rawReportFile: string;
+    registryOrigin: string;
+    result: AuditPolicyResult;
+    threshold: Severity;
+  }>,
+): string {
+  if (
+    options.result.status === "blocked" ||
+    options.result.unacceptedBlockingAdvisories.length > 0
+  ) {
+    throw new Error(`cannot emit receipt for blocked graph ${options.graphId}`);
+  }
+  const provenanceFile = options.rawReportFile.replace(/\.json$/, ".provenance.json");
+  const provenance = readJsonObject(provenanceFile, `${options.graphId} audit provenance`);
+  const cache = provenance.cache as Record<string, unknown> | undefined;
+  const run = provenance.run as Record<string, unknown> | undefined;
+  const createdAt = cache?.createdAt ?? run?.startedAt;
+  if (typeof createdAt !== "string") {
+    throw new Error(`${options.graphId} audit provenance lacks evidence creation time`);
+  }
+  const receipt = createAuditReceipt({
+    acceptedAdvisoryIds: options.result.acceptedAdvisories,
+    createdAt: new Date(createdAt),
+    blockingAdvisoryIds: options.result.unacceptedBlockingAdvisories.map(
+      ({ advisory }) => advisory,
+    ),
+    exceptionPolicySha256: options.result.exceptionPolicySha256,
+    graphId: options.graphId,
+    npmVersion: options.npmVersion,
+    packageJson: fs.readFileSync(options.packageJsonFile),
+    packageLock: fs.readFileSync(options.packageLockFile),
+    rawResponse: fs.readFileSync(options.rawReportFile),
+    registryOrigin: options.registryOrigin,
+    severityThreshold: options.threshold,
+  });
+  const receiptFile = path.join(options.artifactDirectory, `${options.graphId}.receipt.json`);
+  const transportRawFile = path.join(options.artifactDirectory, `${options.graphId}.raw.json`);
+  fs.copyFileSync(options.rawReportFile, transportRawFile);
+  fs.chmodSync(transportRawFile, 0o600);
+  fs.writeFileSync(receiptFile, canonicalAuditReceipt(receipt), { mode: 0o600 });
+  return receiptFile;
 }
 
 export function assertReviewedAuditReportsPass(
@@ -810,48 +889,97 @@ function main(): void {
   const npmVersion = run("npm", ["--version"], TRUSTED_REPO_ROOT).stdout.trim();
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-reviewed-npm-audit-"));
   try {
-    const reports = [
-      {
-        label: SOURCE_GRAPH.label,
-        result: auditSourceGraph(config, tempRoot, exceptionFile, artifactDirectory, npmVersion),
-      },
-      {
+    const sourceResult = auditSourceGraph(
+      config,
+      tempRoot,
+      exceptionFile,
+      artifactDirectory,
+      npmVersion,
+    );
+    const archiveDirectory = materializeArchiveGraph(
+      config.archivePackages,
+      tempRoot,
+      config.archiveTarVersion,
+    );
+    const archiveResult = runReviewedNpmAudit({
+      cacheFile: graphCacheFile(config.archiveGraphId),
+      directory: archiveDirectory,
+      exceptionFile,
+      graph: config.archiveGraphId,
+      provenance: {
         label: "reviewed archive graph",
-        result: runReviewedNpmAudit({
-          directory: materializeArchiveGraph(
-            config.archivePackages,
-            tempRoot,
-            config.archiveTarVersion,
-          ),
-          exceptionFile,
-          graph: config.archiveGraphId,
-          provenance: {
-            label: "reviewed archive graph",
-            nodeVersion: process.version,
-            npmVersion,
-            packageSpecs: config.archivePackages.map((reviewed) => reviewed.packageSpec),
-          },
-          reportFile: path.join(artifactDirectory, "reviewed-archive-graph.json"),
-          resultFile: path.join(artifactDirectory, "reviewed-archive-graph-policy.json"),
-          threshold: config.severityThreshold,
-          throwOnBlock: false,
-        }),
+        nodeVersion: process.version,
+        npmVersion,
+        packageSpecs: config.archivePackages.map((reviewed) => reviewed.packageSpec),
       },
+      reportFile: path.join(artifactDirectory, "reviewed-archive-graph.json"),
+      resultFile: path.join(artifactDirectory, "reviewed-archive-graph-policy.json"),
+      threshold: config.severityThreshold,
+      throwOnBlock: false,
+    });
+    const lockedResults = config.lockedGraphs.map((graph, index) =>
+      auditLockedGraph(
+        graph,
+        index,
+        config,
+        tempRoot,
+        exceptionFile,
+        artifactDirectory,
+        npmVersion,
+      ),
+    );
+    const reports = [
+      { label: SOURCE_GRAPH.label, result: sourceResult },
+      { label: "reviewed archive graph", result: archiveResult },
       ...config.lockedGraphs.map((graph, index) => ({
         label: graph.label,
         threshold: graph.severityThreshold ?? config.severityThreshold,
-        result: auditLockedGraph(
-          graph,
-          index,
-          config,
-          tempRoot,
-          exceptionFile,
-          artifactDirectory,
-          npmVersion,
-        ),
+        result: lockedResults[index]!,
       })),
     ];
     assertReviewedAuditReportsPass(reports, config.severityThreshold);
+
+    emitAuditReceipt({
+      artifactDirectory,
+      graphId: SOURCE_GRAPH.id,
+      npmVersion,
+      packageJsonFile: targetRepositoryPath("package.json", "NemoClaw CLI package manifest"),
+      packageLockFile: targetRepositoryPath("package-lock.json", "NemoClaw CLI lockfile"),
+      rawReportFile: path.join(artifactDirectory, "source-graph.json"),
+      registryOrigin: config.registryOrigin,
+      result: sourceResult,
+      threshold: config.severityThreshold,
+    });
+    emitAuditReceipt({
+      artifactDirectory,
+      graphId: config.archiveGraphId,
+      npmVersion,
+      packageJsonFile: path.join(archiveDirectory, "package.json"),
+      packageLockFile: path.join(archiveDirectory, "package-lock.json"),
+      rawReportFile: path.join(artifactDirectory, "reviewed-archive-graph.json"),
+      registryOrigin: config.registryOrigin,
+      result: archiveResult,
+      threshold: config.severityThreshold,
+    });
+    config.lockedGraphs.forEach((graph, index) => {
+      emitAuditReceipt({
+        artifactDirectory,
+        graphId: graph.id,
+        npmVersion,
+        packageJsonFile: targetRepositoryPath(
+          path.join(graph.directory, "package.json"),
+          `${graph.label} package manifest`,
+        ),
+        packageLockFile: targetRepositoryPath(
+          path.join(graph.directory, "package-lock.json"),
+          `${graph.label} lockfile`,
+        ),
+        rawReportFile: path.join(artifactDirectory, `locked-graph-${index + 1}.json`),
+        registryOrigin: config.registryOrigin,
+        result: lockedResults[index]!,
+        threshold: graph.severityThreshold ?? config.severityThreshold,
+      });
+    });
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }

--- a/scripts/audit-reviewed-npm-graph.mts
+++ b/scripts/audit-reviewed-npm-graph.mts
@@ -807,6 +807,7 @@ export function emitAuditReceipt(
     npmVersion: string;
     packageJsonFile: string;
     packageLockFile: string;
+    preserveInputs?: boolean;
     rawReportFile: string;
     registryOrigin: string;
     result: AuditPolicyResult;
@@ -846,6 +847,16 @@ export function emitAuditReceipt(
   const transportRawFile = path.join(options.artifactDirectory, `${options.graphId}.raw.json`);
   fs.copyFileSync(options.rawReportFile, transportRawFile);
   fs.chmodSync(transportRawFile, 0o600);
+  if (options.preserveInputs) {
+    for (const [source, suffix] of [
+      [options.packageJsonFile, "package.json"],
+      [options.packageLockFile, "package-lock.json"],
+    ] as const) {
+      const destination = path.join(options.artifactDirectory, `${options.graphId}.${suffix}`);
+      fs.copyFileSync(source, destination);
+      fs.chmodSync(destination, 0o600);
+    }
+  }
   fs.writeFileSync(receiptFile, canonicalAuditReceipt(receipt), { mode: 0o600 });
   return receiptFile;
 }
@@ -956,6 +967,7 @@ function main(): void {
       npmVersion,
       packageJsonFile: path.join(archiveDirectory, "package.json"),
       packageLockFile: path.join(archiveDirectory, "package-lock.json"),
+      preserveInputs: true,
       rawReportFile: path.join(artifactDirectory, "reviewed-archive-graph.json"),
       registryOrigin: config.registryOrigin,
       result: archiveResult,

--- a/scripts/lib/npm-audit-receipt.mts
+++ b/scripts/lib/npm-audit-receipt.mts
@@ -6,11 +6,15 @@ import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import {
+  evaluateAuditPolicy,
+  parseAuditExceptionRegistry,
+  parseAuditReport,
+} from "./reviewed-npm-audit.mts";
 
 export const AUDIT_ARGV = ["audit", "--omit=dev", "--json"] as const;
 export const RECEIPT_LIFETIME_MS = 12 * 60 * 60 * 1000 - 1;
 export const MAX_FUTURE_SKEW_MS = 5 * 60 * 1000;
-const SHA256 = /^[0-9a-f]{64}$/;
 const SEVERITIES = new Set(["info", "low", "moderate", "high", "critical"]);
 const RECEIPT_KEYS = [
   "acceptedAdvisoryIds",
@@ -218,18 +222,43 @@ function cli(args: readonly string[]): void {
     "--registry",
     "--threshold",
   ];
-  exactKeys(Object.fromEntries(values), required, "verifier arguments");
+  const allowed = [...required, "--result"];
+  exactKeys(
+    Object.fromEntries([...values].filter(([key]) => key !== "--result")),
+    required,
+    "verifier arguments",
+  );
+  if ([...values.keys()].some((key) => !allowed.includes(key)))
+    throw new Error("verifier arguments has unexpected or missing keys");
+  const packageJson = fs.readFileSync(values.get("--package-json")!);
+  const packageLock = fs.readFileSync(values.get("--package-lock")!);
+  const rawResponse = fs.readFileSync(values.get("--raw-report")!);
+  const exceptionPolicy = fs.readFileSync(values.get("--exceptions")!);
   parseAndVerifyAuditReceipt(fs.readFileSync(values.get("--receipt")!, "utf8"), {
     graphId: values.get("--graph")!,
     npmVersion: values.get("--npm-version")!,
-    exceptionPolicy: fs.readFileSync(values.get("--exceptions")!),
+    exceptionPolicy,
     severityThreshold: values.get("--threshold")! as AuditReceipt["severityThreshold"],
-    packageJson: fs.readFileSync(values.get("--package-json")!),
-    packageLock: fs.readFileSync(values.get("--package-lock")!),
-    rawResponse: fs.readFileSync(values.get("--raw-report")!),
+    packageJson,
+    packageLock,
+    rawResponse,
     registryOrigin: values.get("--registry")!,
   });
-  console.log("reviewed npm audit receipt verified");
+  const policyResult = evaluateAuditPolicy({
+    directory: path.dirname(values.get("--package-json")!),
+    exceptionPolicy: parseAuditExceptionRegistry(exceptionPolicy.toString("utf8")),
+    exceptionPolicySha256: sha256(exceptionPolicy),
+    graph: values.get("--graph")!,
+    report: parseAuditReport({ status: 0, stderr: "", stdout: rawResponse.toString("utf8") }),
+    threshold: values.get("--threshold")! as AuditReceipt["severityThreshold"],
+  });
+  if (policyResult.unacceptedBlockingAdvisories.length > 0)
+    throw new Error(
+      `${values.get("--graph")}: cached raw audit report fails current exception policy`,
+    );
+  if (values.has("--result"))
+    fs.writeFileSync(values.get("--result")!, `${JSON.stringify(policyResult, null, 2)}\n`);
+  console.log("reviewed npm audit receipt and current policy verified");
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {

--- a/scripts/lib/npm-audit-receipt.mts
+++ b/scripts/lib/npm-audit-receipt.mts
@@ -1,0 +1,242 @@
+#!/usr/bin/env -S node --experimental-strip-types
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+export const AUDIT_ARGV = ["audit", "--omit=dev", "--json"] as const;
+export const RECEIPT_LIFETIME_MS = 12 * 60 * 60 * 1000 - 1;
+export const MAX_FUTURE_SKEW_MS = 5 * 60 * 1000;
+const SHA256 = /^[0-9a-f]{64}$/;
+const SEVERITIES = new Set(["info", "low", "moderate", "high", "critical"]);
+const RECEIPT_KEYS = [
+  "acceptedAdvisoryIds",
+  "argv",
+  "blockingAdvisoryIds",
+  "createdAt",
+  "exceptionPolicySha256",
+  "expiresAt",
+  "graphId",
+  "npmVersion",
+  "packageJsonSha256",
+  "packageLockSha256",
+  "rawResponseSha256",
+  "registryOrigin",
+  "result",
+  "schemaVersion",
+  "severityThreshold",
+];
+
+export type AuditReceipt = Readonly<{
+  acceptedAdvisoryIds: readonly string[];
+  argv: readonly string[];
+  blockingAdvisoryIds: readonly string[];
+  createdAt: string;
+  exceptionPolicySha256: string;
+  expiresAt: string;
+  graphId: string;
+  npmVersion: string;
+  packageJsonSha256: string;
+  packageLockSha256: string;
+  rawResponseSha256: string;
+  registryOrigin: string;
+  result: "pass";
+  schemaVersion: 1;
+  severityThreshold: "info" | "low" | "moderate" | "high" | "critical";
+}>;
+
+export function sha256(contents: string | Buffer): string {
+  return createHash("sha256").update(contents).digest("hex");
+}
+
+function exactKeys(
+  value: Record<string, unknown>,
+  expected: readonly string[],
+  label: string,
+): void {
+  const actual = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  if (actual.length !== wanted.length || actual.some((key, index) => key !== wanted[index])) {
+    throw new Error(`${label} has unexpected or missing keys`);
+  }
+}
+
+function stringArray(value: unknown, label: string): readonly string[] {
+  if (
+    !Array.isArray(value) ||
+    value.some((item) => typeof item !== "string") ||
+    new Set(value).size !== value.length ||
+    [...value].sort().some((item, index) => item !== value[index])
+  ) {
+    throw new Error(`${label} must be a sorted array of unique strings`);
+  }
+  return value;
+}
+
+function utcInstant(value: unknown, label: string): number {
+  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(value))
+    throw new Error(`${label} must be a canonical UTC timestamp`);
+  const time = Date.parse(value);
+  if (!Number.isFinite(time) || new Date(time).toISOString() !== value)
+    throw new Error(`${label} must be a valid UTC timestamp`);
+  return time;
+}
+
+export function createAuditReceipt(
+  options: Readonly<{
+    acceptedAdvisoryIds: readonly string[];
+    blockingAdvisoryIds: readonly string[];
+    createdAt?: Date;
+    exceptionPolicySha256: string;
+    graphId: string;
+    npmVersion: string;
+    packageJson: string | Buffer;
+    packageLock: string | Buffer;
+    rawResponse: string | Buffer;
+    registryOrigin: string;
+    severityThreshold: AuditReceipt["severityThreshold"];
+  }>,
+): AuditReceipt {
+  if (options.blockingAdvisoryIds.length > 0)
+    throw new Error("cannot issue a passing receipt with blocking advisories");
+  const created = options.createdAt ?? new Date();
+  return {
+    acceptedAdvisoryIds: [...new Set(options.acceptedAdvisoryIds)].sort(),
+    argv: [...AUDIT_ARGV],
+    blockingAdvisoryIds: [],
+    createdAt: created.toISOString(),
+    exceptionPolicySha256: options.exceptionPolicySha256,
+    expiresAt: new Date(created.getTime() + RECEIPT_LIFETIME_MS).toISOString(),
+    graphId: options.graphId,
+    npmVersion: options.npmVersion,
+    packageJsonSha256: sha256(options.packageJson),
+    packageLockSha256: sha256(options.packageLock),
+    rawResponseSha256: sha256(options.rawResponse),
+    registryOrigin: options.registryOrigin,
+    result: "pass",
+    schemaVersion: 1,
+    severityThreshold: options.severityThreshold,
+  };
+}
+
+export function parseAndVerifyAuditReceipt(
+  contents: string,
+  expected: Readonly<{
+    graphId: string;
+    npmVersion: string;
+    exceptionPolicy: string | Buffer;
+    severityThreshold: AuditReceipt["severityThreshold"];
+    packageJson: string | Buffer;
+    packageLock: string | Buffer;
+    rawResponse: string | Buffer;
+    registryOrigin: string;
+    now?: Date;
+  }>,
+): AuditReceipt {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(contents);
+  } catch {
+    throw new Error("receipt is not valid JSON");
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed))
+    throw new Error("receipt must be an object");
+  const value = parsed as Record<string, unknown>;
+  exactKeys(value, RECEIPT_KEYS, "receipt");
+  if (value.schemaVersion !== 1 || value.result !== "pass")
+    throw new Error("receipt is not a passing schema version 1 receipt");
+  if (
+    value.graphId !== expected.graphId ||
+    value.npmVersion !== expected.npmVersion ||
+    value.registryOrigin !== expected.registryOrigin
+  )
+    throw new Error("receipt identity does not match expected graph, npm, and registry");
+  if (
+    !Array.isArray(value.argv) ||
+    value.argv.length !== AUDIT_ARGV.length ||
+    value.argv.some((arg, index) => arg !== AUDIT_ARGV[index])
+  )
+    throw new Error("receipt npm audit arguments do not match");
+  const accepted = stringArray(value.acceptedAdvisoryIds, "acceptedAdvisoryIds");
+  const blocking = stringArray(value.blockingAdvisoryIds, "blockingAdvisoryIds");
+  if (blocking.length !== 0) throw new Error("passing receipt contains blocking advisories");
+  for (const [key, actual] of [
+    ["packageJsonSha256", sha256(expected.packageJson)],
+    ["packageLockSha256", sha256(expected.packageLock)],
+  ] as const) {
+    if (value[key] !== actual) throw new Error(`receipt ${key} does not match`);
+  }
+  if (value.exceptionPolicySha256 !== sha256(expected.exceptionPolicy))
+    throw new Error("receipt exceptionPolicySha256 does not match");
+  if (value.rawResponseSha256 !== sha256(expected.rawResponse))
+    throw new Error("receipt rawResponseSha256 does not match");
+  if (
+    value.severityThreshold !== expected.severityThreshold ||
+    !SEVERITIES.has(expected.severityThreshold)
+  )
+    throw new Error("receipt severityThreshold does not match");
+  const created = utcInstant(value.createdAt, "createdAt");
+  const expires = utcInstant(value.expiresAt, "expiresAt");
+  if (expires <= created || expires - created >= 12 * 60 * 60 * 1000)
+    throw new Error("receipt lifetime must be positive and less than 12 hours");
+  const now = (expected.now ?? new Date()).getTime();
+  if (created - now > MAX_FUTURE_SKEW_MS)
+    throw new Error("receipt creation time is too far in the future");
+  if (now >= expires) throw new Error("receipt is expired");
+  return {
+    ...(value as AuditReceipt),
+    acceptedAdvisoryIds: accepted,
+    blockingAdvisoryIds: blocking,
+  };
+}
+
+export function canonicalAuditReceipt(receipt: AuditReceipt): string {
+  return `${JSON.stringify(receipt, null, 2)}\n`;
+}
+
+function cli(args: readonly string[]): void {
+  const values = new Map<string, string>();
+  for (let index = 0; index < args.length; index += 2) {
+    const value = args[index + 1];
+    if (!args[index]?.startsWith("--") || value === undefined)
+      throw new Error(
+        "usage: npm-audit-receipt.mts --receipt FILE --package-json FILE --package-lock FILE --raw-report FILE --exceptions FILE --graph ID --npm-version VERSION --registry ORIGIN --threshold SEVERITY",
+      );
+    values.set(args[index], value);
+  }
+  const required = [
+    "--receipt",
+    "--package-json",
+    "--package-lock",
+    "--raw-report",
+    "--exceptions",
+    "--graph",
+    "--npm-version",
+    "--registry",
+    "--threshold",
+  ];
+  exactKeys(Object.fromEntries(values), required, "verifier arguments");
+  parseAndVerifyAuditReceipt(fs.readFileSync(values.get("--receipt")!, "utf8"), {
+    graphId: values.get("--graph")!,
+    npmVersion: values.get("--npm-version")!,
+    exceptionPolicy: fs.readFileSync(values.get("--exceptions")!),
+    severityThreshold: values.get("--threshold")! as AuditReceipt["severityThreshold"],
+    packageJson: fs.readFileSync(values.get("--package-json")!),
+    packageLock: fs.readFileSync(values.get("--package-lock")!),
+    rawResponse: fs.readFileSync(values.get("--raw-report")!),
+    registryOrigin: values.get("--registry")!,
+  });
+  console.log("reviewed npm audit receipt verified");
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  try {
+    cli(process.argv.slice(2));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/scripts/lib/reviewed-npm-audit.mts
+++ b/scripts/lib/reviewed-npm-audit.mts
@@ -604,14 +604,16 @@ export function readAuditCache(
   now = new Date(),
 ): Readonly<{ result: NpmAuditCommandResult; evidence: AuditCacheEvidence }> | null {
   try {
-    const metadata = fs.lstatSync(filename);
-    if (
-      !metadata.isFile() ||
-      metadata.isSymbolicLink() ||
-      metadata.size > NPM_AUDIT_CACHE_MAX_BYTES
-    )
-      return null;
-    const record = parseAuditCacheRecord(fs.readFileSync(filename, "utf-8"));
+    const descriptor = fs.openSync(filename, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+    let source: string;
+    try {
+      const metadata = fs.fstatSync(descriptor);
+      if (!metadata.isFile() || metadata.size > NPM_AUDIT_CACHE_MAX_BYTES) return null;
+      source = fs.readFileSync(descriptor, "utf-8");
+    } finally {
+      fs.closeSync(descriptor);
+    }
+    const record = parseAuditCacheRecord(source);
     const ageMs = now.valueOf() - Date.parse(record.createdAt);
     if (ageMs < -NPM_AUDIT_CACHE_FUTURE_SKEW_MS || ageMs >= NPM_AUDIT_CACHE_MAX_AGE_MS) return null;
     if (JSON.stringify(record.input) !== JSON.stringify(expectedInput)) return null;
@@ -866,7 +868,10 @@ export function runReviewedNpmAudit(
         registry,
       );
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      if (!(error instanceof Error) || error.message !== "npm audit cache requires a valid HTTP(S) registry") {
+        throw error;
+      }
+      // An invalid optional cache registry degrades to a live audit.
     }
   }
   const cached = cacheFile && cacheInput ? readAuditCache(cacheFile, cacheInput) : null;

--- a/scripts/lib/reviewed-npm-audit.mts
+++ b/scripts/lib/reviewed-npm-audit.mts
@@ -54,6 +54,14 @@ export type AuditEndpoints = Readonly<{
   note: string;
 }>;
 
+export type AuditCacheEvidence = Readonly<{
+  origin: "cache" | "live";
+  createdAt: string;
+  ageMs: number;
+  inputSha256: string;
+  responseSha256: string;
+}>;
+
 export type AuditProvenance = Readonly<{
   schemaVersion: 1;
   scanner: Readonly<{ name: "npm audit"; npmVersion: string; nodeVersion: string }>;
@@ -62,6 +70,7 @@ export type AuditProvenance = Readonly<{
   graph: Readonly<{ label: string; packageSpecs: readonly string[] }>;
   rawReportPath: string;
   advisoryIds: readonly string[];
+  cache?: AuditCacheEvidence;
   failure?: string;
 }>;
 
@@ -93,6 +102,12 @@ const MAX_EXCEPTION_LIFETIME_DAYS = 30;
 const GHSA_ID_IN_URL = /GHSA(?:-[23456789cfghjmpqrvwx]{4}){3}/gi;
 const NPM_AUDIT_ATTEMPT_TIMEOUT_MS = 45_000;
 const NPM_AUDIT_RETRY_DELAYS_MS = [1_000, 2_000] as const;
+export const NPM_AUDIT_ARGV = ["audit", "--omit=dev", "--json"] as const;
+export const NPM_AUDIT_CACHE_MAX_AGE_MS = 12 * 60 * 60 * 1000;
+export const NPM_AUDIT_CACHE_FUTURE_SKEW_MS = 5 * 60 * 1000;
+const NPM_AUDIT_CACHE_MAX_BYTES = 64 * 1024 * 1024;
+const NPM_AUDIT_CACHE_SCHEMA_VERSION = 1;
+const NPM_AUDIT_PARSER_IDENTITY = "reviewed-npm-audit-report-v1";
 
 type NpmAuditCommandResult = Readonly<{
   error?: Error;
@@ -423,6 +438,7 @@ export function extractAdvisoryIds(report: Record<string, unknown>): readonly st
 
 export function buildAuditProvenance(
   input: Readonly<{
+    cache?: AuditCacheEvidence;
     failure?: string;
     finishedAt: string;
     label: string;
@@ -443,12 +459,25 @@ export function buildAuditProvenance(
     graph: { label: input.label, packageSpecs: input.packageSpecs },
     rawReportPath: input.rawReportPath,
     advisoryIds: extractAdvisoryIds(input.report),
+    ...(input.cache === undefined ? {} : { cache: input.cache }),
     ...(input.failure === undefined ? {} : { failure: input.failure }),
   };
 }
 
 export function provenanceSidecarPath(reportPath: string): string {
   return `${reportPath.replace(/\.json$/, "")}.provenance.json`;
+}
+
+function npmVersion(directory: string): string {
+  const result = spawnSync("npm", ["--version"], {
+    cwd: directory,
+    encoding: "utf-8",
+    env: { ...process.env, NPM_CONFIG_UPDATE_NOTIFIER: "false" },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.error || result.status !== 0)
+    throw new Error("npm version could not be determined for audit cache identity");
+  return result.stdout.trim();
 }
 
 function configuredNpmRegistry(directory: string): string {
@@ -460,6 +489,182 @@ function configuredNpmRegistry(directory: string): string {
     stdio: ["ignore", "pipe", "pipe"],
   });
   return result.error || result.status !== 0 ? "" : result.stdout.trim();
+}
+
+type AuditCacheInput = Readonly<{
+  argv: readonly string[];
+  npmVersion: string;
+  packageJsonSha256: string;
+  packageLockSha256: string;
+  parserIdentity: string;
+  registryOrigin: string;
+}>;
+
+type AuditCacheRecord = Readonly<{
+  schemaVersion: 1;
+  createdAt: string;
+  input: AuditCacheInput;
+  result: Readonly<{ stdout: string; exitCode: number }>;
+}>;
+
+function sha256(value: string | Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function canonicalRegistryOrigin(registry: string): string | null {
+  try {
+    const parsed = new URL(registry.trim());
+    if (parsed.protocol !== "https:") return null;
+    return `${parsed.origin}/`;
+  } catch {
+    return null;
+  }
+}
+
+export function buildAuditCacheInput(
+  directory: string,
+  npmVersion: string,
+  registry: string,
+): AuditCacheInput {
+  const registryOrigin = canonicalRegistryOrigin(registry);
+  if (!registryOrigin) throw new Error("npm audit cache requires a valid HTTP(S) registry");
+  return {
+    argv: NPM_AUDIT_ARGV,
+    npmVersion,
+    packageJsonSha256: sha256(fs.readFileSync(path.join(directory, "package.json"))),
+    packageLockSha256: sha256(fs.readFileSync(path.join(directory, "package-lock.json"))),
+    parserIdentity: NPM_AUDIT_PARSER_IDENTITY,
+    registryOrigin,
+  };
+}
+
+function cacheInputSha256(input: AuditCacheInput): string {
+  return sha256(JSON.stringify(input));
+}
+
+function parseAuditCacheRecord(source: string): AuditCacheRecord {
+  const parsed = asRecord(JSON.parse(source), "npm audit cache record");
+  requireExactKeys(
+    parsed,
+    new Set(["createdAt", "input", "result", "schemaVersion"]),
+    "npm audit cache record",
+  );
+  if (parsed.schemaVersion !== NPM_AUDIT_CACHE_SCHEMA_VERSION)
+    throw new Error("npm audit cache schema is incompatible");
+  const input = asRecord(parsed.input, "npm audit cache input");
+  requireExactKeys(
+    input,
+    new Set([
+      "argv",
+      "npmVersion",
+      "packageJsonSha256",
+      "packageLockSha256",
+      "parserIdentity",
+      "registryOrigin",
+    ]),
+    "npm audit cache input",
+  );
+  const result = asRecord(parsed.result, "npm audit cache result");
+  requireExactKeys(result, new Set(["exitCode", "stdout"]), "npm audit cache result");
+  if (!Array.isArray(input.argv) || JSON.stringify(input.argv) !== JSON.stringify(NPM_AUDIT_ARGV))
+    throw new Error("npm audit cache input.argv is invalid");
+  for (const key of [
+    "npmVersion",
+    "packageJsonSha256",
+    "packageLockSha256",
+    "parserIdentity",
+    "registryOrigin",
+  ] as const)
+    nonEmptyString(input[key], `npm audit cache input.${key}`);
+  if (
+    typeof result.stdout !== "string" ||
+    Buffer.byteLength(result.stdout) > NPM_AUDIT_CACHE_MAX_BYTES ||
+    (result.exitCode !== 0 && result.exitCode !== 1)
+  )
+    throw new Error("npm audit cache result is invalid");
+  for (const key of ["packageJsonSha256", "packageLockSha256"] as const) {
+    if (!/^[a-f0-9]{64}$/u.test(String(input[key])))
+      throw new Error(`npm audit cache input.${key} is invalid`);
+  }
+  if (
+    input.parserIdentity !== NPM_AUDIT_PARSER_IDENTITY ||
+    canonicalRegistryOrigin(String(input.registryOrigin)) !== input.registryOrigin
+  )
+    throw new Error("npm audit cache identity is invalid");
+  const createdAt = nonEmptyString(parsed.createdAt, "npm audit cache createdAt");
+  const createdTime = Date.parse(createdAt);
+  if (Number.isNaN(createdTime) || new Date(createdTime).toISOString() !== createdAt)
+    throw new Error("npm audit cache createdAt must be canonical UTC");
+  return parsed as unknown as AuditCacheRecord;
+}
+
+export function readAuditCache(
+  filename: string,
+  expectedInput: AuditCacheInput,
+  now = new Date(),
+): Readonly<{ result: NpmAuditCommandResult; evidence: AuditCacheEvidence }> | null {
+  try {
+    const metadata = fs.lstatSync(filename);
+    if (
+      !metadata.isFile() ||
+      metadata.isSymbolicLink() ||
+      metadata.size > NPM_AUDIT_CACHE_MAX_BYTES
+    )
+      return null;
+    const record = parseAuditCacheRecord(fs.readFileSync(filename, "utf-8"));
+    const ageMs = now.valueOf() - Date.parse(record.createdAt);
+    if (ageMs < -NPM_AUDIT_CACHE_FUTURE_SKEW_MS || ageMs >= NPM_AUDIT_CACHE_MAX_AGE_MS) return null;
+    if (JSON.stringify(record.input) !== JSON.stringify(expectedInput)) return null;
+    return {
+      result: {
+        status: record.result.exitCode,
+        stderr: "",
+        stdout: record.result.stdout,
+      },
+      evidence: {
+        origin: "cache",
+        createdAt: record.createdAt,
+        ageMs: Math.max(0, ageMs),
+        inputSha256: cacheInputSha256(expectedInput),
+        responseSha256: sha256(record.result.stdout),
+      },
+    };
+  } catch {
+    return null;
+  }
+}
+
+function writeAuditCache(
+  filename: string,
+  input: AuditCacheInput,
+  result: NpmAuditCommandResult,
+  createdAt: string,
+): void {
+  if (!Number.isSafeInteger(result.status)) return;
+  const record: AuditCacheRecord = {
+    schemaVersion: 1,
+    createdAt,
+    input,
+    result: { stdout: result.stdout, exitCode: result.status as number },
+  };
+  fs.mkdirSync(path.dirname(filename), { recursive: true });
+  const temporary = `${filename}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    const descriptor = fs.openSync(
+      temporary,
+      fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_NOFOLLOW,
+      0o600,
+    );
+    try {
+      fs.writeFileSync(descriptor, `${JSON.stringify(record, null, 2)}\n`);
+      fs.fsyncSync(descriptor);
+    } finally {
+      fs.closeSync(descriptor);
+    }
+    fs.renameSync(temporary, filename);
+  } finally {
+    fs.rmSync(temporary, { force: true });
+  }
 }
 
 function advisoryId(value: Readonly<Record<string, unknown>>): string {
@@ -634,6 +839,7 @@ export function evaluateAuditPolicy(
 
 export function runReviewedNpmAudit(
   options: Readonly<{
+    cacheFile?: string;
     directory: string;
     exceptionFile: string;
     graph: string;
@@ -649,23 +855,54 @@ export function runReviewedNpmAudit(
   }
   const exceptionRegistry = readAuditExceptionRegistry(options.exceptionFile);
   const startedAt = new Date().toISOString();
-  const audit = runNpmAuditWithRetry({
-    run: () =>
-      spawnSync("npm", ["audit", "--omit=dev", "--json"], {
-        cwd: options.directory,
-        encoding: "utf-8",
-        env: { ...process.env, NPM_CONFIG_UPDATE_NOTIFIER: "false" },
-        maxBuffer: 64 * 1024 * 1024,
-        stdio: ["ignore", "pipe", "pipe"],
-        timeout: NPM_AUDIT_ATTEMPT_TIMEOUT_MS,
-      }),
-  });
+  const cacheFile = options.cacheFile ?? process.env.NEMOCLAW_NPM_AUDIT_CACHE_FILE;
+  const registry = process.env.NPM_CONFIG_REGISTRY ?? configuredNpmRegistry(options.directory);
+  let cacheInput: AuditCacheInput | undefined;
+  if (cacheFile) {
+    try {
+      cacheInput = buildAuditCacheInput(
+        options.directory,
+        options.provenance?.npmVersion ?? npmVersion(options.directory),
+        registry,
+      );
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+  }
+  const cached = cacheFile && cacheInput ? readAuditCache(cacheFile, cacheInput) : null;
+  const audit = cached
+    ? runNpmAuditWithRetry({ run: () => cached.result, wait: () => {}, warn: () => {} })
+    : runNpmAuditWithRetry({
+        run: () =>
+          spawnSync("npm", NPM_AUDIT_ARGV, {
+            cwd: options.directory,
+            encoding: "utf-8",
+            env: { ...process.env, NPM_CONFIG_UPDATE_NOTIFIER: "false" },
+            maxBuffer: 64 * 1024 * 1024,
+            stdio: ["ignore", "pipe", "pipe"],
+            timeout: NPM_AUDIT_ATTEMPT_TIMEOUT_MS,
+          }),
+      });
   const finishedAt = new Date().toISOString();
+  if (!cached && cacheFile && cacheInput && audit.report)
+    writeAuditCache(cacheFile, cacheInput, audit.result, startedAt);
+  const cacheEvidence =
+    cached?.evidence ??
+    (cacheInput
+      ? {
+          origin: "live" as const,
+          createdAt: startedAt,
+          ageMs: 0,
+          inputSha256: cacheInputSha256(cacheInput),
+          responseSha256: sha256(audit.result.stdout),
+        }
+      : undefined);
   const auditFailure = audit.failure;
   const report = audit.report ?? {};
   if (options.reportFile) fs.writeFileSync(options.reportFile, audit.result.stdout);
   if (options.provenance && options.reportFile) {
     const provenance = buildAuditProvenance({
+      cache: cacheEvidence,
       failure: auditFailure?.message,
       finishedAt,
       label: options.provenance.label,
@@ -673,7 +910,7 @@ export function runReviewedNpmAudit(
       npmVersion: options.provenance.npmVersion,
       packageSpecs: options.provenance.packageSpecs,
       rawReportPath: path.basename(options.reportFile),
-      registry: configuredNpmRegistry(options.directory),
+      registry,
       report,
       startedAt,
     });
@@ -706,6 +943,7 @@ export function runReviewedNpmAudit(
 }
 
 function parseCliArgs(args: readonly string[]): {
+  cacheFile?: string;
   directory: string;
   exceptionFile: string;
   graph: string;
@@ -723,6 +961,7 @@ function parseCliArgs(args: readonly string[]): {
     values.set(key, value);
   }
   const allowed = new Set([
+    "--cache",
     "--directory",
     "--exceptions",
     "--graph",
@@ -745,6 +984,7 @@ function parseCliArgs(args: readonly string[]): {
   if (!SEVERITIES.includes(threshold as Severity))
     throw new Error("reviewed npm audit threshold is invalid");
   return {
+    ...(values.has("--cache") ? { cacheFile: values.get("--cache") } : {}),
     directory,
     exceptionFile,
     graph,

--- a/src/lib/sandbox/build-context.ts
+++ b/src/lib/sandbox/build-context.ts
@@ -450,6 +450,10 @@ function stageOptimizedSandboxBuildContext(
     path.join(stagedScriptsDir, "lib", "reviewed-npm-audit.mts"),
   );
   fs.copyFileSync(
+    path.join(rootDir, "scripts", "lib", "npm-audit-receipt.mts"),
+    path.join(stagedScriptsDir, "lib", "npm-audit-receipt.mts"),
+  );
+  fs.copyFileSync(
     path.join(rootDir, "scripts", "lib", "openclaw-npm-remediation.mts"),
     path.join(stagedScriptsDir, "lib", "openclaw-npm-remediation.mts"),
   );

--- a/test/automation/releases/npm-audit-receipt.test.ts
+++ b/test/automation/releases/npm-audit-receipt.test.ts
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  canonicalAuditReceipt,
+  createAuditReceipt,
+  parseAndVerifyAuditReceipt,
+  sha256,
+} from "../../../scripts/lib/npm-audit-receipt.mts";
+
+const NOW = new Date("2026-09-04T00:00:00.000Z");
+const inputs = {
+  graphId: "mcporter-runtime",
+  npmVersion: "10.9.4",
+  exceptionPolicy: "exceptions",
+  severityThreshold: "high",
+  packageJson: "package",
+  packageLock: "lock",
+  rawResponse: "raw",
+  registryOrigin: "https://registry.npmjs.org/",
+  now: NOW,
+} as const;
+function receipt(createdAt = NOW) {
+  return createAuditReceipt({
+    acceptedAdvisoryIds: ["GHSA-b", "GHSA-a"],
+    blockingAdvisoryIds: [],
+    createdAt,
+    exceptionPolicySha256: sha256(inputs.exceptionPolicy),
+    graphId: inputs.graphId,
+    npmVersion: inputs.npmVersion,
+    packageJson: inputs.packageJson,
+    packageLock: inputs.packageLock,
+    rawResponse: "raw",
+    registryOrigin: inputs.registryOrigin,
+    severityThreshold: "high",
+  });
+}
+
+describe("reviewed npm audit receipt", () => {
+  it("canonically binds all receipt inputs and verifies a fresh passing result", () => {
+    const parsed = parseAndVerifyAuditReceipt(canonicalAuditReceipt(receipt()), inputs);
+    expect(parsed.acceptedAdvisoryIds).toEqual(["GHSA-a", "GHSA-b"]);
+    expect(parsed.argv).toEqual(["audit", "--omit=dev", "--json"]);
+    expect(new Date(parsed.expiresAt).getTime() - NOW.getTime()).toBeLessThan(12 * 60 * 60 * 1000);
+  });
+
+  it.each([
+    [
+      "extra key",
+      (value: any) => {
+        value.extra = true;
+      },
+    ],
+    [
+      "changed command",
+      (value: any) => {
+        value.argv = ["audit", "--json"];
+      },
+    ],
+    [
+      "blocking result",
+      (value: any) => {
+        value.blockingAdvisoryIds = ["GHSA-x"];
+      },
+    ],
+    [
+      "long lifetime",
+      (value: any) => {
+        value.expiresAt = new Date(NOW.getTime() + 12 * 60 * 60 * 1000).toISOString();
+      },
+    ],
+    [
+      "weaker threshold",
+      (value: any) => {
+        value.severityThreshold = "critical";
+      },
+    ],
+    [
+      "different exception policy",
+      (value: any) => {
+        value.exceptionPolicySha256 = "a".repeat(64);
+      },
+    ],
+  ])("fails closed for %s", (_label, mutate) => {
+    const value: any = receipt();
+    mutate(value);
+    expect(() => parseAndVerifyAuditReceipt(JSON.stringify(value), inputs)).toThrow();
+  });
+
+  it("rejects expiry, excessive future skew, and graph bytes that differ", () => {
+    expect(() =>
+      parseAndVerifyAuditReceipt(
+        canonicalAuditReceipt(receipt(new Date(NOW.getTime() - 12 * 60 * 60 * 1000))),
+        inputs,
+      ),
+    ).toThrow(/expired/);
+    expect(() =>
+      parseAndVerifyAuditReceipt(
+        canonicalAuditReceipt(receipt(new Date(NOW.getTime() + 5 * 60 * 1000 + 1))),
+        inputs,
+      ),
+    ).toThrow(/future/);
+    expect(() =>
+      parseAndVerifyAuditReceipt(canonicalAuditReceipt(receipt()), {
+        ...inputs,
+        packageLock: "changed",
+      }),
+    ).toThrow(/packageLockSha256/);
+  });
+
+  it("provides a local CLI verifier suitable for a BuildKit secret mount", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "receipt-cli-"));
+    try {
+      fs.writeFileSync(path.join(root, "package.json"), inputs.packageJson);
+      fs.writeFileSync(path.join(root, "package-lock.json"), inputs.packageLock);
+      fs.writeFileSync(path.join(root, "exceptions.json"), inputs.exceptionPolicy);
+      fs.writeFileSync(path.join(root, "raw.json"), inputs.rawResponse);
+      fs.writeFileSync(path.join(root, "receipt.json"), canonicalAuditReceipt(receipt(new Date())));
+      const result = spawnSync(
+        process.execPath,
+        [
+          "--experimental-strip-types",
+          path.join(import.meta.dirname, "../../../scripts/lib/npm-audit-receipt.mts"),
+          "--receipt",
+          path.join(root, "receipt.json"),
+          "--package-json",
+          path.join(root, "package.json"),
+          "--package-lock",
+          path.join(root, "package-lock.json"),
+          "--raw-report",
+          path.join(root, "raw.json"),
+          "--exceptions",
+          path.join(root, "exceptions.json"),
+          "--graph",
+          inputs.graphId,
+          "--npm-version",
+          inputs.npmVersion,
+          "--registry",
+          inputs.registryOrigin,
+          "--threshold",
+          inputs.severityThreshold,
+        ],
+        { encoding: "utf8" },
+      );
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain("receipt verified");
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/automation/releases/npm-audit-receipt.test.ts
+++ b/test/automation/releases/npm-audit-receipt.test.ts
@@ -17,11 +17,12 @@ const NOW = new Date("2026-09-04T00:00:00.000Z");
 const inputs = {
   graphId: "mcporter-runtime",
   npmVersion: "10.9.4",
-  exceptionPolicy: "exceptions",
+  exceptionPolicy: '{"schemaVersion":1,"exceptions":[]}\n',
   severityThreshold: "high",
   packageJson: "package",
   packageLock: "lock",
-  rawResponse: "raw",
+  rawResponse:
+    '{"vulnerabilities":{},"metadata":{"vulnerabilities":{"info":0,"low":0,"moderate":0,"high":0,"critical":0}}}',
   registryOrigin: "https://registry.npmjs.org/",
   now: NOW,
 } as const;
@@ -35,7 +36,8 @@ function receipt(createdAt = NOW) {
     npmVersion: inputs.npmVersion,
     packageJson: inputs.packageJson,
     packageLock: inputs.packageLock,
-    rawResponse: "raw",
+    rawResponse:
+      '{"vulnerabilities":{},"metadata":{"vulnerabilities":{"info":0,"low":0,"moderate":0,"high":0,"critical":0}}}',
     registryOrigin: inputs.registryOrigin,
     severityThreshold: "high",
   });
@@ -148,7 +150,7 @@ describe("reviewed npm audit receipt", () => {
         { encoding: "utf8" },
       );
       expect(result.status, result.stderr).toBe(0);
-      expect(result.stdout).toContain("receipt verified");
+      expect(result.stdout).toContain("current policy verified");
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
     }

--- a/test/automation/releases/reviewed-npm-audit-workflow.test.ts
+++ b/test/automation/releases/reviewed-npm-audit-workflow.test.ts
@@ -66,10 +66,17 @@ function runConsolidatedAuditFixture(
   const artifactDirectory = path.join(targetRoot, "artifacts", "reviewed-npm-audit");
   try {
     fs.mkdirSync(path.join(trustedRoot, "ci"), { recursive: true });
-    fs.mkdirSync(path.join(targetRoot, "agents", "openclaw", "wechat-runtime"), { recursive: true });
+    fs.mkdirSync(path.join(targetRoot, "agents", "openclaw", "wechat-runtime"), {
+      recursive: true,
+    });
     fs.mkdirSync(bin);
-    fs.cpSync(path.join(REPO_ROOT, "scripts"), path.join(trustedRoot, "scripts"), { recursive: true });
-    fs.writeFileSync(path.join(trustedRoot, "ci", "npm-audit-exceptions.json"), '{"schemaVersion":1,"exceptions":[]}\n');
+    fs.cpSync(path.join(REPO_ROOT, "scripts"), path.join(trustedRoot, "scripts"), {
+      recursive: true,
+    });
+    fs.writeFileSync(
+      path.join(trustedRoot, "ci", "npm-audit-exceptions.json"),
+      '{"schemaVersion":1,"exceptions":[]}\n',
+    );
     const runtimeLock = fs.readFileSync(
       path.join(REPO_ROOT, "agents/openclaw/wechat-runtime/package-lock.json"),
     );
@@ -82,19 +89,22 @@ function runConsolidatedAuditFixture(
         archiveTarVersion: "7.5.21",
         artifactDirectory: "artifacts/reviewed-npm-audit",
         exceptionFile: "ci/npm-audit-exceptions.json",
-        lockedGraphs: [{
-          directory: "agents/openclaw/wechat-runtime",
-          id: "wechat-runtime",
-          inputValidation: "wechat-runtime",
-          installMode: "legacy-peer-deps",
-          integrity,
-          label: "WeChat fixture",
-          lockSha256: createHash("sha256").update(runtimeLock).digest("hex"),
-          packageSpec: "@tencent-weixin/openclaw-weixin@2.4.3",
-          severityThreshold: "low",
-          signatureAudit: "retry-download-failures",
-          tarballUrl: "https://registry.npmjs.org/@tencent-weixin/openclaw-weixin/-/openclaw-weixin-2.4.3.tgz",
-        }],
+        lockedGraphs: [
+          {
+            directory: "agents/openclaw/wechat-runtime",
+            id: "wechat-runtime",
+            inputValidation: "wechat-runtime",
+            installMode: "legacy-peer-deps",
+            integrity,
+            label: "WeChat fixture",
+            lockSha256: createHash("sha256").update(runtimeLock).digest("hex"),
+            packageSpec: "@tencent-weixin/openclaw-weixin@2.4.3",
+            severityThreshold: "low",
+            signatureAudit: "retry-download-failures",
+            tarballUrl:
+              "https://registry.npmjs.org/@tencent-weixin/openclaw-weixin/-/openclaw-weixin-2.4.3.tgz",
+          },
+        ],
         nodeVersion: process.version.slice(1),
         registryOrigin: "https://registry.npmjs.org/",
         schemaVersion: 2,
@@ -133,13 +143,20 @@ if (args[0] === "--version") { console.log("10.9.4"); process.exit(0); }
 if (args[0] === "config") { console.log("https://registry.npmjs.org/"); process.exit(0); }
 if (args[0] === "audit" && args[1] === "signatures") process.exit(0);
 if (args[0] === "audit") { process.stdout.write(process.env.NEMOCLAW_TEST_AUDIT_OUTPUT); process.exit(Number(process.env.NEMOCLAW_TEST_AUDIT_STATUS)); }
+(args[0] === "install" || args[0] === "ci") && !fs.existsSync("package-lock.json") && (() => {
+  const manifest = JSON.parse(fs.readFileSync("package.json", "utf8"));
+  fs.writeFileSync("package-lock.json", JSON.stringify({ ...manifest, lockfileVersion: 3, packages: { "": manifest } }));
+})();
 process.exit(0);
 `,
       { mode: 0o755 },
     );
     const result = spawnSync(
       process.execPath,
-      ["--experimental-strip-types", path.join(trustedRoot, "scripts/audit-reviewed-npm-graph.mts")],
+      [
+        "--experimental-strip-types",
+        path.join(trustedRoot, "scripts/audit-reviewed-npm-graph.mts"),
+      ],
       {
         cwd: trustedRoot,
         encoding: "utf-8",
@@ -269,7 +286,7 @@ describe("trusted reviewed npm audit workflow (#5896)", () => {
     const fixture = runConsolidatedAuditFixture(() => {}, output, status);
 
     expect(fixture.result.status).not.toBe(0);
-    expect(fixture.provenance).toMatchObject({
+    expect(fixture.provenance, fixture.result.stderr.toString()).toMatchObject({
       failure: expect.stringMatching(expectedFailure),
       rawReportPath: "source-graph.json",
     });

--- a/test/automation/releases/reviewed-npm-audit-workflow.test.ts
+++ b/test/automation/releases/reviewed-npm-audit-workflow.test.ts
@@ -11,6 +11,7 @@ import { describe, expect, it } from "vitest";
 import {
   assertReviewedAuditReportsPass,
   auditMaterializedSourceGraph,
+  emitAuditReceipt,
   materializeSourceGraph,
   normalizeOpenClawSignatureAlias,
   parseAuditConfig,
@@ -143,10 +144,14 @@ if (args[0] === "--version") { console.log("10.9.4"); process.exit(0); }
 if (args[0] === "config") { console.log("https://registry.npmjs.org/"); process.exit(0); }
 if (args[0] === "audit" && args[1] === "signatures") process.exit(0);
 if (args[0] === "audit") { process.stdout.write(process.env.NEMOCLAW_TEST_AUDIT_OUTPUT); process.exit(Number(process.env.NEMOCLAW_TEST_AUDIT_STATUS)); }
-(args[0] === "install" || args[0] === "ci") && !fs.existsSync("package-lock.json") && (() => {
+if (args[0] === "ci" && !fs.existsSync("package-lock.json")) {
+  console.error("npm ci requires an existing package-lock.json");
+  process.exit(1);
+}
+if (args[0] === "install" && !fs.existsSync("package-lock.json")) {
   const manifest = JSON.parse(fs.readFileSync("package.json", "utf8"));
   fs.writeFileSync("package-lock.json", JSON.stringify({ ...manifest, lockfileVersion: 3, packages: { "": manifest } }));
-})();
+}
 process.exit(0);
 `,
       { mode: 0o755 },
@@ -290,6 +295,52 @@ describe("trusted reviewed npm audit workflow (#5896)", () => {
       failure: expect.stringMatching(expectedFailure),
       rawReportPath: "source-graph.json",
     });
+  });
+
+  it("retains the temporary graph inputs that its receipt authenticates", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "npm-audit-receipt-inputs-"));
+    const packageJsonFile = path.join(root, "package.json");
+    const packageLockFile = path.join(root, "package-lock.json");
+    const rawReportFile = path.join(root, "report.json");
+    const packageJson = Buffer.from("temporary manifest\n");
+    const packageLock = Buffer.from("temporary lock\n");
+    try {
+      fs.writeFileSync(packageJsonFile, packageJson);
+      fs.writeFileSync(packageLockFile, packageLock);
+      fs.writeFileSync(rawReportFile, "{}\n");
+      fs.writeFileSync(
+        path.join(root, "report.provenance.json"),
+        JSON.stringify({ run: { startedAt: "2026-01-01T00:00:00.000Z" } }),
+      );
+      emitAuditReceipt({
+        artifactDirectory: root,
+        graphId: "temporary-graph",
+        npmVersion: "10.9.4",
+        packageJsonFile,
+        packageLockFile,
+        preserveInputs: true,
+        rawReportFile,
+        registryOrigin: "https://registry.npmjs.org/",
+        result: {
+          acceptedAdvisories: [],
+          blockingThreshold: "high",
+          exceptionPolicySha256: "a".repeat(64),
+          graph: "temporary-graph",
+          reported: { info: 0, low: 0, moderate: 0, high: 0, critical: 0 },
+          schemaVersion: 1,
+          status: "clean",
+          unacceptedBlockingAdvisories: [],
+        },
+        threshold: "high",
+      });
+
+      expect(fs.readFileSync(path.join(root, "temporary-graph.package.json"))).toEqual(packageJson);
+      expect(fs.readFileSync(path.join(root, "temporary-graph.package-lock.json"))).toEqual(
+        packageLock,
+      );
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it("keeps the WeChat archive and reviewed locked graph distinct", () => {

--- a/test/automation/releases/reviewed-npm-audit.test.ts
+++ b/test/automation/releases/reviewed-npm-audit.test.ts
@@ -7,7 +7,11 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   type AuditExceptionRegistry,
+  NPM_AUDIT_ARGV,
+  NPM_AUDIT_CACHE_FUTURE_SKEW_MS,
+  NPM_AUDIT_CACHE_MAX_AGE_MS,
   assertExceptionGraphs,
+  buildAuditCacheInput,
   buildAuditProvenance,
   deriveAuditEndpoints,
   evaluateAuditPolicy,
@@ -16,6 +20,7 @@ import {
   parseAuditExceptionRegistry,
   parseAuditReport,
   provenanceSidecarPath,
+  readAuditCache,
   readAuditExceptionRegistry,
   runNpmAuditWithRetry,
   runReviewedNpmAudit,
@@ -447,6 +452,112 @@ describe("reviewed npm audit gate", () => {
   });
 });
 
+describe("reviewed npm audit raw cache", () => {
+  function fixture() {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-audit-cache-"));
+    fs.writeFileSync(path.join(directory, "package.json"), '{"name":"fixture"}\n');
+    fs.writeFileSync(path.join(directory, "package-lock.json"), '{"lockfileVersion":3}\n');
+    return directory;
+  }
+
+  it("replays an exact fresh raw result and reports cache evidence (#11028)", () => {
+    const directory = fixture();
+    try {
+      const input = buildAuditCacheInput(
+        directory,
+        "10.9.7",
+        "https://user:secret@registry.npmjs.org/private/path?token=query#fragment",
+      );
+      const filename = path.join(directory, "cache.json");
+      const stdout = JSON.stringify({
+        metadata: { vulnerabilities: { info: 0, low: 0, moderate: 0, high: 0, critical: 0 } },
+      });
+      fs.writeFileSync(
+        filename,
+        JSON.stringify({
+          schemaVersion: 1,
+          createdAt: "2026-07-21T11:00:00.000Z",
+          input,
+          result: { stdout, exitCode: 0 },
+        }),
+      );
+      const hit = readAuditCache(filename, input, NOW);
+      expect(hit?.result.stdout).toBe(stdout);
+      expect(hit?.evidence).toMatchObject({ origin: "cache", ageMs: 3_600_000 });
+      expect(input.argv).toEqual(NPM_AUDIT_ARGV);
+      expect(input.registryOrigin).toBe("https://registry.npmjs.org/");
+      expect(JSON.stringify(input)).not.toContain("secret");
+      expect(JSON.stringify(input)).not.toContain("private");
+      expect(JSON.stringify(input)).not.toContain("query");
+      expect(hit?.evidence.inputSha256).toMatch(/^[a-f0-9]{64}$/);
+      expect(hit?.evidence.responseSha256).toMatch(/^[a-f0-9]{64}$/);
+    } finally {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    ["stale", -NPM_AUDIT_CACHE_MAX_AGE_MS],
+    ["too far in the future", NPM_AUDIT_CACHE_FUTURE_SKEW_MS + 1],
+  ])("rejects a %s record", (_label, createdOffset) => {
+    const directory = fixture();
+    try {
+      const input = buildAuditCacheInput(directory, "10.9.7", "https://registry.npmjs.org/");
+      const filename = path.join(directory, "cache.json");
+      fs.writeFileSync(
+        filename,
+        JSON.stringify({
+          schemaVersion: 1,
+          createdAt: new Date(NOW.valueOf() + createdOffset).toISOString(),
+          input,
+          result: { stdout: "{}", exitCode: 0 },
+        }),
+      );
+      expect(readAuditCache(filename, input, NOW)).toBeNull();
+    } finally {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects malformed, extra-field, and input-mismatched records", () => {
+    const directory = fixture();
+    try {
+      const input = buildAuditCacheInput(directory, "10.9.7", "https://registry.npmjs.org/");
+      const filename = path.join(directory, "cache.json");
+      fs.writeFileSync(filename, "not json");
+      expect(readAuditCache(filename, input, NOW)).toBeNull();
+      fs.writeFileSync(
+        filename,
+        JSON.stringify({
+          schemaVersion: 1,
+          createdAt: NOW.toISOString(),
+          input,
+          result: { stdout: "{}", exitCode: 0 },
+          poison: process.env,
+        }),
+      );
+      expect(readAuditCache(filename, input, NOW)).toBeNull();
+      const changed = { ...input, npmVersion: "11.0.0" };
+      fs.writeFileSync(
+        filename,
+        JSON.stringify({
+          schemaVersion: 1,
+          createdAt: NOW.toISOString(),
+          input,
+          result: { stdout: "{}", exitCode: 0 },
+        }),
+      );
+      expect(readAuditCache(filename, changed, NOW)).toBeNull();
+      fs.writeFileSync(path.join(directory, "package.json"), '{"name":"changed"}\n');
+      expect(buildAuditCacheInput(directory, "10.9.7", "https://registry.npmjs.org/")).not.toEqual(
+        input,
+      );
+    } finally {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("reviewed npm audit provenance", () => {
   const detectionReport = {
     metadata: {
@@ -489,17 +600,17 @@ describe("reviewed npm audit provenance", () => {
     expect(extractAdvisoryIds(report as Record<string, unknown>)).toEqual([]);
   });
 
-  it.each([
-    "https://registry.npmjs.org/",
-    "https://registry.npmjs.org",
-  ])("derives the bulk advisory endpoint npm audit uses from %s", (registry) => {
-    const endpoints = deriveAuditEndpoints(registry);
-    expect(endpoints).toEqual({
-      configuredRegistry: "https://registry.npmjs.org/",
-      bulkAdvisoryEndpoint: "https://registry.npmjs.org/-/npm/v1/security/advisories/bulk",
-      note: expect.stringMatching(/bulk advisory endpoint.*no advisory data/s),
-    });
-  });
+  it.each(["https://registry.npmjs.org/", "https://registry.npmjs.org"])(
+    "derives the bulk advisory endpoint npm audit uses from %s",
+    (registry) => {
+      const endpoints = deriveAuditEndpoints(registry);
+      expect(endpoints).toEqual({
+        configuredRegistry: "https://registry.npmjs.org/",
+        bulkAdvisoryEndpoint: "https://registry.npmjs.org/-/npm/v1/security/advisories/bulk",
+        note: expect.stringMatching(/bulk advisory endpoint.*no advisory data/s),
+      });
+    },
+  );
 
   it("redacts registry URL credentials from retained provenance", () => {
     expect(deriveAuditEndpoints("https://audit-user:audit-token@registry.npmjs.org/")).toEqual({
@@ -561,16 +672,16 @@ describe("reviewed npm audit provenance", () => {
     expect(provenance.advisoryIds).toEqual([]);
   });
 
-  it.each([
-    "",
-    "   ",
-  ])("records an unknown registry explicitly instead of deriving a nonsense endpoint (%j)", (registry) => {
-    expect(deriveAuditEndpoints(registry)).toEqual({
-      configuredRegistry: null,
-      bulkAdvisoryEndpoint: null,
-      note: expect.stringMatching(/registry could not be safely recorded/),
-    });
-  });
+  it.each(["", "   "])(
+    "records an unknown registry explicitly instead of deriving a nonsense endpoint (%j)",
+    (registry) => {
+      expect(deriveAuditEndpoints(registry)).toEqual({
+        configuredRegistry: null,
+        bulkAdvisoryEndpoint: null,
+        note: expect.stringMatching(/registry could not be safely recorded/),
+      });
+    },
+  );
 
   it("writes the failure sidecar before rethrowing when npm audit hard-fails", () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-audit-provenance-"));

--- a/test/helpers/fetch-guard-patch-harness.ts
+++ b/test/helpers/fetch-guard-patch-harness.ts
@@ -31,11 +31,11 @@ export function dockerRunCommandBetween(startMarker: string, endMarker: string):
     .slice(runIndex, end)
     .trim()
     .replace(/^RUN\s+/, "")
-    .replace(/^(?:--[a-z-]+=[^\s]+\s+)+/u, "")
     .split("\n")
     .filter((line) => !line.trimStart().startsWith("#"))
     .join("\n")
     .replace(/\\\n/g, " ")
+    .replace(/^(?:--[a-z-]+=[^\s]+\s+)+/u, "")
     .replace(/\\\s*$/, "")
     .replaceAll(
       "/usr/local/lib/nemoclaw/extract-semver",

--- a/test/inference/managed/managed-image-publication-workflow.test.ts
+++ b/test/inference/managed/managed-image-publication-workflow.test.ts
@@ -1104,6 +1104,14 @@ fi
     expect(contract.run).not.toContain("aliases:");
   });
 
+  it("binds non-PR OpenClaw publication to same-run reviewed audit evidence", () => {
+    const workflow = readWorkflow("managed-images.yaml"), publisher = managedPublisher(workflow), action = readAction("publish-managed-image-digest"), source = JSON.stringify(workflow);
+    expect(workflow.jobs?.["reviewed-npm-audit"]?.if).toBe("github.event_name != 'pull_request'");
+    expect(publisher.needs).toEqual(["publication-identity", "reviewed-npm-audit"]);
+    expect(["Download same-run reviewed npm audit evidence", "Prepare same-run mcporter audit evidence", "mcporter-runtime.receipt.json", "mcporter-runtime.raw.json", "nemoclaw-mcporter-audit-receipt", "nemoclaw-mcporter-audit-raw-report", "NEMOCLAW_MCPORTER_AUDIT_RECEIPT_SHA256"].filter((marker) => !source.includes(marker))).toEqual([]);
+    expect(source).not.toContain("NEMOCLAW_MCPORTER_AUDIT_RAW_REPORT_SHA256");
+    const actionSource = JSON.stringify(action); expect([actionSource.includes('"secret-files":{"description"'), actionSource.includes('"secret-files":"${{ inputs.secret-files }}"')]).toEqual([true, true]);
+  });
   it("holds every alias behind the exact six-candidate aggregate barrier (#7744)", () => {
     const workflow = readWorkflow("managed-images.yaml");
     const identity = workflow.jobs?.["publication-identity"];
@@ -1125,7 +1133,7 @@ fi
     );
 
     expect(identity?.outputs).toEqual({ cohort: "${{ steps.identity.outputs.cohort }}" });
-    expect(publisher.needs).toBe("publication-identity");
+    expect(publisher.needs).toEqual(["publication-identity", "reviewed-npm-audit"]);
     expect(publisher.outputs).toBeUndefined();
     expect(publisher.steps?.map((candidate) => candidate.name)).not.toContain(
       "Export validated managed image candidate output",

--- a/test/inference/managed/managed-image-publication-workflow.test.ts
+++ b/test/inference/managed/managed-image-publication-workflow.test.ts
@@ -136,12 +136,8 @@ describe("complete managed-image publication workflow", () => {
     const prAudit = step(required(readWorkflow("pr.yaml").jobs?.["reviewed-npm-audit"], "missing PR audit"), "Audit reviewed production npm graphs");
     const mainAudit = step(required(readWorkflow("main.yaml").jobs?.["reviewed-npm-audit"], "missing main audit"), "Audit reviewed production npm graphs");
     const managedAudit = step(managedPrReviewedAudit(readWorkflow("managed-images.yaml")), "Audit exact PR production npm graphs");
-    expect(prAudit.with).toMatchObject({
-      "cache-directory": "${{ runner.temp }}/reviewed-npm-audit-cache",
-    });
-    expect(managedAudit.with).toMatchObject({
-      "cache-directory": "${{ runner.temp }}/reviewed-npm-audit-cache",
-    });
+    expect(prAudit.with?.["cache-directory"]).toBeUndefined();
+    expect(managedAudit.with?.["cache-directory"]).toBeUndefined();
     expect(prAudit.with?.["trusted-cache-write"]).toBeUndefined();
     expect(managedAudit.with?.["trusted-cache-write"]).toBeUndefined();
     expect(mainAudit.with).toMatchObject({
@@ -445,7 +441,6 @@ describe("complete managed-image publication workflow", () => {
     expect(step(reviewedAudit, "Audit exact PR production npm graphs")).toMatchObject({
       uses: "./.trusted-reviewed-npm-audit/.github/actions/ci-reviewed-npm-audit",
       with: {
-        "cache-directory": "${{ runner.temp }}/reviewed-npm-audit-cache",
         "report-dir": "artifacts/reviewed-npm-audit",
         "target-root": "${{ github.workspace }}/candidate",
       },

--- a/test/inference/managed/managed-image-publication-workflow.test.ts
+++ b/test/inference/managed/managed-image-publication-workflow.test.ts
@@ -85,6 +85,70 @@ function managedPrOpenClawMcpDiscovery(workflow: Workflow): Job {
 }
 
 describe("complete managed-image publication workflow", () => {
+  it("restricts reviewed npm audit cache publication to trusted callers (#11028)", () => {
+    const action = readAction("ci-reviewed-npm-audit") as ReturnType<typeof readAction> & {
+      inputs: Record<string, { default?: string; required?: boolean }>;
+    };
+    const actionSteps = action.runs?.steps ?? [];
+    const restores = actionSteps.filter((candidate) =>
+      candidate.uses?.startsWith("actions/cache/restore@"),
+    );
+    expect(action.inputs).toMatchObject({
+      "cache-directory": { required: true },
+      "trusted-cache-write": { default: "false", required: false },
+    });
+    expect(restores).toHaveLength(2);
+    expect(restores.map(({ uses }) => uses)).toEqual([
+      "actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809",
+      "actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809",
+    ]);
+    expect(restores.map(({ with: inputs }) => inputs)).toEqual([
+      {
+        key: "reviewed-npm-audit-v1-${{ runner.os }}-${{ steps.cache-buckets.outputs.input-digest }}-${{ steps.cache-buckets.outputs.current }}",
+        path: "${{ inputs.cache-directory }}",
+      },
+      {
+        key: "reviewed-npm-audit-v1-${{ runner.os }}-${{ steps.cache-buckets.outputs.input-digest }}-${{ steps.cache-buckets.outputs.previous }}",
+        path: "${{ inputs.cache-directory }}",
+      },
+    ]);
+    const save = step(
+      { steps: actionSteps },
+      "Save current reviewed npm audit cache bucket",
+      "reviewed npm audit action",
+    );
+    expect(save).toMatchObject({
+      if: "inputs.trusted-cache-write == 'true' && steps.cache-current.outputs.cache-hit != 'true'",
+      uses: "actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809",
+      with: restores[0]?.with,
+    });
+    expect(
+      step(
+        { steps: actionSteps },
+        "Materialize and audit reviewed npm graphs",
+        "reviewed npm audit action",
+      ).env,
+    ).toMatchObject({
+      NEMOCLAW_REVIEWED_NPM_AUDIT_CACHE_DIR: "${{ inputs.cache-directory }}",
+      NPM_CONFIG_USERCONFIG: "/dev/null",
+    });
+
+    const prAudit = step(required(readWorkflow("pr.yaml").jobs?.["reviewed-npm-audit"], "missing PR audit"), "Audit reviewed production npm graphs");
+    const mainAudit = step(required(readWorkflow("main.yaml").jobs?.["reviewed-npm-audit"], "missing main audit"), "Audit reviewed production npm graphs");
+    const managedAudit = step(managedPrReviewedAudit(readWorkflow("managed-images.yaml")), "Audit exact PR production npm graphs");
+    expect(prAudit.with).toMatchObject({
+      "cache-directory": "${{ runner.temp }}/reviewed-npm-audit-cache",
+    });
+    expect(managedAudit.with).toMatchObject({
+      "cache-directory": "${{ runner.temp }}/reviewed-npm-audit-cache",
+    });
+    expect(prAudit.with?.["trusted-cache-write"]).toBeUndefined();
+    expect(managedAudit.with?.["trusted-cache-write"]).toBeUndefined();
+    expect(mainAudit.with).toMatchObject({
+      "cache-directory": "${{ runner.temp }}/reviewed-npm-audit-cache",
+      "trusted-cache-write": "true",
+    });
+  });
   it("rejects managed package paths redirected outside node_modules", () => {
     const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-managed-plugin-"));
     try {
@@ -153,8 +217,10 @@ describe("complete managed-image publication workflow", () => {
     expect(step(reviewedAudit, "Audit reviewed production npm graphs")).toMatchObject({
       uses: "./.github/actions/ci-reviewed-npm-audit",
       with: {
+        "cache-directory": "${{ runner.temp }}/reviewed-npm-audit-cache",
         "report-dir": "artifacts/reviewed-npm-audit",
         "target-root": "${{ github.workspace }}",
+        "trusted-cache-write": "${{ github.repository == 'NVIDIA/NemoClaw' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}",
       },
     });
   });
@@ -379,6 +445,7 @@ describe("complete managed-image publication workflow", () => {
     expect(step(reviewedAudit, "Audit exact PR production npm graphs")).toMatchObject({
       uses: "./.trusted-reviewed-npm-audit/.github/actions/ci-reviewed-npm-audit",
       with: {
+        "cache-directory": "${{ runner.temp }}/reviewed-npm-audit-cache",
         "report-dir": "artifacts/reviewed-npm-audit",
         "target-root": "${{ github.workspace }}/candidate",
       },

--- a/test/security/mcporter-supply-chain.test.ts
+++ b/test/security/mcporter-supply-chain.test.ts
@@ -181,7 +181,7 @@ describe("mcporter image supply-chain controls", () => {
     );
     expect(
       flattenedContents.includes(
-        "COPY scripts/lib/reviewed-npm-archive.mts scripts/lib/bundled-npm-package.mts scripts/lib/reviewed-npm-audit.mts scripts/lib/openclaw-npm-remediation.mts /scripts/lib/",
+        "COPY scripts/lib/reviewed-npm-archive.mts scripts/lib/bundled-npm-package.mts scripts/lib/reviewed-npm-audit.mts scripts/lib/npm-audit-receipt.mts scripts/lib/openclaw-npm-remediation.mts /scripts/lib/",
       ) ||
         contents.includes(
           "COPY scripts/lib/reviewed-npm-audit.mts /scripts/lib/reviewed-npm-audit.mts",
@@ -189,6 +189,25 @@ describe("mcporter image supply-chain controls", () => {
     ).toBe(true);
     expect(flattenedContents).toContain(
       "node --experimental-strip-types /scripts/lib/reviewed-npm-audit.mts --directory /usr/local/lib/nemoclaw/mcporter-runtime --exceptions /scripts/npm-audit-exceptions.json --graph mcporter-runtime --threshold high",
+    );
+    expect(contents).toContain("ARG NEMOCLAW_MCPORTER_AUDIT_RECEIPT_SHA256=");
+    expect(contents).toContain(
+      "--mount=type=secret,id=nemoclaw-mcporter-audit-receipt,required=false",
+    );
+    expect(contents).toContain(
+      "--mount=type=secret,id=nemoclaw-mcporter-audit-raw-report,required=false",
+    );
+    expect(flattenedContents).toContain(
+      "node --experimental-strip-types /scripts/lib/npm-audit-receipt.mts --receipt",
+    );
+    expect(flattenedContents).toContain(
+      "--package-json /usr/local/lib/nemoclaw/mcporter-runtime/package.json --package-lock /usr/local/lib/nemoclaw/mcporter-runtime/package-lock.json --raw-report",
+    );
+    expect(flattenedContents).toContain(
+      "--exceptions /scripts/npm-audit-exceptions.json --graph mcporter-runtime --npm-version",
+    );
+    expect(flattenedContents).toContain(
+      "--registry https://registry.npmjs.org/ --threshold high",
     );
     expect(contents).not.toContain(`${runtimePrefix} audit --omit=dev --audit-level=low`);
     expect(contents).not.toContain(`${runtimePrefix} audit signatures`);

--- a/test/security/mcporter-supply-chain.test.ts
+++ b/test/security/mcporter-supply-chain.test.ts
@@ -181,7 +181,7 @@ describe("mcporter image supply-chain controls", () => {
     );
     expect(
       flattenedContents.includes(
-        "COPY scripts/lib/reviewed-npm-archive.mts scripts/lib/bundled-npm-package.mts scripts/lib/reviewed-npm-audit.mts scripts/lib/npm-audit-receipt.mts scripts/lib/openclaw-npm-remediation.mts /scripts/lib/",
+        "COPY scripts/lib/reviewed-npm-archive.mts scripts/lib/bundled-npm-package.mts scripts/lib/reviewed-npm-audit.mts scripts/lib/openclaw-npm-remediation.mts /scripts/lib/",
       ) ||
         contents.includes(
           "COPY scripts/lib/reviewed-npm-audit.mts /scripts/lib/reviewed-npm-audit.mts",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

Fresh exact-input npm audit evidence is reused across trusted CI and image builds, reducing repeated dependence on registry advisory availability while preserving fail-closed policy evaluation.

## Reason

Reviewed npm graphs and Docker builds repeatedly queried the same advisory service, so a transient outage could fail multiple otherwise identical builds. Issue #11028 accepted bounded evidence reuse with strict identity, freshness, and trust boundaries.

### Related issues

Fixes #11028

## Changes

- Cache raw npm audit command results for less than 12 hours using exact graph, npm, registry, argv, parser, manifest, and lock identities; reject malformed, stale, future, symlinked, or mismatched entries and reapply current policy on replay.
- Emit canonical passing receipts with paired raw reports only after aggregate policy success, then validate graph bytes, exception policy, threshold, freshness, and raw-response hashes before reuse.
- Restore exact cache buckets in reviewed CI, restrict shared writes to trusted canonical workflows, and pass same-run mcporter evidence into supported OpenClaw image publication paths while retaining bounded live fail-closed fallback elsewhere.
- Cover cache poisoning, freshness, provenance, receipt verification, workflow trust, Docker fallback, and repository growth contracts.

## Verification

- Contributor validation: Signed commit hooks passed; `npm run validate:pr` passed at ef6c902561.
- Tests: Focused validation passed: 171 tests across receipt, cache, workflow, Docker supply-chain, managed-image, and growth suites. `npm run checks:repository` passed.
- Broad check: `npm run test:changed` reached 2364 passing tests and had two unrelated current-main CLI failures; focused owning suites and the required PR validation passed.
- Local review: `npm run review:local` was attempted with the 1Password inference credential and stopped during gateway setup because the installed gateway does not support `gateway info`; no findings were produced.
- Secrets review: The diff contains no secrets, API keys, or credentials.
<!-- nemoclaw-docs-review:start -->
- Documentation review: `docs-updated`
- Documentation evidence: Updated cache provenance and dependency-review evidence-boundary documentation; npm run validate:pr passed.
- Documentation agent: documentation repair subagent
<!-- docs-review-head-sha: b7420a6fbe80c9a2832e5974040869f384b30adb -->
<!-- docs-review-agents-blob-sha: dd3528f6e332f7f09f4841555c2ed11cb2139fb9 -->
<!-- nemoclaw-docs-review:end -->
<!-- nemoclaw-targeted-validation:start -->
- Targeted validation: Trusted-action compatibility: managed workflow and growth suites passed (81 tests); npm run typecheck:cli and npm run validate:pr passed.
<!-- nemoclaw-targeted-validation:end -->
<!-- nemoclaw-broad-gate:start -->
- Broad gate: passed — npm run validate:pr passed
<!-- nemoclaw-broad-gate:end -->

## Review notes

- Sensitive-path review: Independent security review findings were addressed: absolute cache paths, raw-report binding, freshness extension, credential-bearing registry values, sparse checkout imports, and atomic writes. Concurrent misses remain best-effort as explicitly accepted in #11028.

---

Signed-off-by: Chris Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added secure caching for reviewed npm audit results in eligible trusted builds.
  - Added verifiable audit receipts covering package, lockfile, registry, and policy details.
  - OpenClaw image builds can reuse validated audit evidence while retaining live-audit fallback behavior.
  - Build provenance now records audit evidence and cache metadata where applicable.
  - Audit evidence is securely forwarded through supported image publication workflows.

- **Security**
  - Added checksum, integrity, expiry, and input validation for audit receipts and reports.
  - Improved fail-closed handling for invalid or mismatched cached audit data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->