### PR TITLE
fix(snapshot): normalize GPU restore authority

### DIFF
--- a/src/lib/actions/sandbox/rebuild-post-restore-phase.test.ts
+++ b/src/lib/actions/sandbox/rebuild-post-restore-phase.test.ts
@@ -759,7 +759,7 @@ describe("rebuild post-restore phase", () => {
     expect(args.bail).not.toHaveBeenCalled();
   });
 
-  it("prints every incomplete OpenClaw recovery report in a fixed order (#8283)", async () => {
+  it("prints every incomplete OpenClaw recovery report in a fixed order (#8283, #10758)", async () => {
     vi.mocked(
       rebuildConfigHash.refreshMutableOpenClawConfigHashAfterPostRestoreWrites,
     ).mockReturnValue(false);
@@ -796,6 +796,7 @@ describe("rebuild post-restore phase", () => {
     const offsets = ordered.map((fragment) => output.indexOf(fragment));
     expect(offsets.every((offset) => offset >= 0)).toBe(true);
     expect(offsets).toEqual([...offsets].sort((left, right) => left - right));
+    expect(output).toContain("backup available at: /tmp/alpha-backup");
     expect(args.bail).toHaveBeenCalledWith(
       "State restore remained incomplete after rebuilding 'alpha'.",
     );

--- a/src/lib/actions/sandbox/snapshot/provider-lifecycle.test.ts
+++ b/src/lib/actions/sandbox/snapshot/provider-lifecycle.test.ts
@@ -39,6 +39,10 @@ function provider(
     preflightProviderId?: string;
     runtimeProviderId?: string;
     restoreProviderId?: string;
+    canRepresentAcceleration?: (
+      source: RuntimeProviderRuntimeReceipt["acceleration"],
+      target: RuntimeProviderRuntimeReceipt["acceleration"],
+    ) => boolean;
   } = {},
 ): {
   readonly bundle: RuntimeProviderBundle;
@@ -86,6 +90,9 @@ function provider(
         capabilities: { backup: true, restore: true, managedProfileRestore: true },
         preflight,
         capture,
+        ...(options.canRepresentAcceleration
+          ? { canRepresentAcceleration: options.canRepresentAcceleration }
+          : {}),
         validateRestore,
         restore,
       },
@@ -315,40 +322,40 @@ describe("snapshot provider lifecycle", () => {
   it.each([
     { field: "lifecycle state", lifecycleState: "stopped", lifecycleGeneration: "generation-1" },
     { field: "lifecycle generation", lifecycleState: "running", lifecycleGeneration: "changed" },
-  ] as const)("rejects restore proof with changed $field", ({
-    lifecycleState,
-    lifecycleGeneration,
-  }) => {
-    const { bundle, restore } = provider();
-    const target = sandbox("target");
-    const prepared = prepareSandboxRuntimeRestore(
-      bundle,
-      target,
-      {
+  ] as const)(
+    "rejects restore proof with changed $field",
+    ({ lifecycleState, lifecycleGeneration }) => {
+      const { bundle, restore } = provider();
+      const target = sandbox("target");
+      const prepared = prepareSandboxRuntimeRestore(
+        bundle,
+        target,
+        {
+          schemaVersion: 1,
+          providerId: "mxc",
+          providerHandle: "opaque-source",
+          lifecycleState: "running",
+          lifecycleGeneration: "source-generation",
+          runtime: runtime(),
+        },
+        managedProfile,
+      );
+      restore.mockReturnValueOnce({
         schemaVersion: 1,
         providerId: "mxc",
-        providerHandle: "opaque-source",
-        lifecycleState: "running",
-        lifecycleGeneration: "source-generation",
+        sandboxName: "target",
+        providerHandle: "provider-owned-restore-handle",
+        lifecycleState,
+        lifecycleGeneration,
         runtime: runtime(),
-      },
-      managedProfile,
-    );
-    restore.mockReturnValueOnce({
-      schemaVersion: 1,
-      providerId: "mxc",
-      sandboxName: "target",
-      providerHandle: "provider-owned-restore-handle",
-      lifecycleState,
-      lifecycleGeneration,
-      runtime: runtime(),
-      managedProfile,
-    });
+        managedProfile,
+      });
 
-    expect(() => confirmSandboxRuntimeRestore(bundle, target, prepared)).toThrow(
-      /invalid managed restore proof/u,
-    );
-  });
+      expect(() => confirmSandboxRuntimeRestore(bundle, target, prepared)).toThrow(
+        /invalid managed restore proof/u,
+      );
+    },
+  );
 
   it("rejects restore proof that changes acceleration authority", () => {
     const { bundle } = provider();
@@ -372,6 +379,67 @@ describe("snapshot provider lifecycle", () => {
 
     expect(() => confirmSandboxRuntimeRestore(bundle, target, prepared)).toThrow(
       /invalid managed restore proof/u,
+    );
+  });
+
+  it("accepts a provider-verified canonical acceleration receipt for a legacy source", () => {
+    const legacyAcceleration = {
+      kind: "gpu" as const,
+      vendor: "nvidia",
+      devices: ["docker-device-id:nvidia.com/gpu=all"],
+    };
+    const canonicalAcceleration = {
+      kind: "gpu" as const,
+      vendor: "nvidia",
+      devices: ["nvidia.com/gpu=all"],
+    };
+    const canRepresentAcceleration = vi.fn(
+      (
+        source: RuntimeProviderRuntimeReceipt["acceleration"],
+        target: RuntimeProviderRuntimeReceipt["acceleration"],
+      ) => {
+        expect(Object.isFrozen(source)).toBe(true);
+        expect(Object.isFrozen(target)).toBe(true);
+        return (
+          source.kind === "gpu" &&
+          target.kind === "gpu" &&
+          source.devices[0] === "docker-device-id:nvidia.com/gpu=all" &&
+          target.devices[0] === "nvidia.com/gpu=all"
+        );
+      },
+    );
+    const { bundle, restore } = provider({ canRepresentAcceleration });
+    const target = sandbox("target");
+    const prepared = prepareSandboxRuntimeRestore(
+      bundle,
+      target,
+      {
+        schemaVersion: 1,
+        providerId: "mxc",
+        providerHandle: "opaque-source",
+        lifecycleState: "running",
+        lifecycleGeneration: "source-generation",
+        runtime: { ...runtime(), acceleration: legacyAcceleration },
+      },
+      managedProfile,
+    );
+    restore.mockReturnValueOnce({
+      schemaVersion: 1,
+      providerId: "mxc",
+      sandboxName: "target",
+      providerHandle: "opaque-restore",
+      lifecycleState: "running",
+      lifecycleGeneration: "generation-1",
+      runtime: { ...runtime(), acceleration: canonicalAcceleration },
+      managedProfile,
+    });
+
+    expect(confirmSandboxRuntimeRestore(bundle, target, prepared)).toMatchObject({
+      restoreReceipt: { runtime: { acceleration: canonicalAcceleration } },
+    });
+    expect(canRepresentAcceleration).toHaveBeenCalledWith(
+      legacyAcceleration,
+      canonicalAcceleration,
     );
   });
 

--- a/src/lib/actions/sandbox/snapshot/provider-lifecycle.ts
+++ b/src/lib/actions/sandbox/snapshot/provider-lifecycle.ts
@@ -92,6 +92,7 @@ function requireRuntimeReceipt(
 
 function requireRestoreReceipt(
   bundle: RuntimeProviderBundle,
+  surface: SupportedSnapshotSurface,
   sandbox: SandboxEntry,
   authority: RuntimeProviderManagedProfileRestoreAuthority,
   preflight: RuntimeProviderSnapshotPreflightReceipt,
@@ -106,8 +107,18 @@ function requireRestoreReceipt(
     receipt.managedProfile.agent !== authority.agent ||
     receipt.managedProfile.profileFingerprint !== authority.profileFingerprint ||
     receipt.lifecycleState !== preflight.lifecycleState ||
-    receipt.lifecycleGeneration !== preflight.lifecycleGeneration ||
-    !isDeepStrictEqual(receipt.runtime.acceleration, source.runtime.acceleration)
+    receipt.lifecycleGeneration !== preflight.lifecycleGeneration
+  ) {
+    throw new SandboxSnapshotProviderError(
+      `runtime provider '${bundle.identity.id}' returned invalid managed restore proof`,
+    );
+  }
+  const canRepresentAcceleration = surface.canRepresentAcceleration ?? isDeepStrictEqual;
+  if (
+    !canRepresentAcceleration(
+      cloneAndDeepFreeze(source.runtime.acceleration),
+      cloneAndDeepFreeze(receipt.runtime.acceleration),
+    )
   ) {
     throw new SandboxSnapshotProviderError(
       `runtime provider '${bundle.identity.id}' returned invalid managed restore proof`,
@@ -272,6 +283,7 @@ export function confirmSandboxRuntimeRestore(
   const providerTarget = cloneAndDeepFreeze(target);
   const restoreReceipt = requireRestoreReceipt(
     bundle,
+    surface,
     target,
     authority.managedProfile,
     authority.preflight,

--- a/src/lib/actions/sandbox/snapshot/restore-authority.test.ts
+++ b/src/lib/actions/sandbox/snapshot/restore-authority.test.ts
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
 import { describe, expect, it, vi } from "vitest";
 
@@ -146,55 +149,54 @@ function provider(agent: ShippedManagedImageAgent) {
 }
 
 describe("managed rebuild restore authority", () => {
-  it.each([
-    "openclaw",
-    "hermes",
-    "langchain-deepagents-code",
-  ] as const)("revalidates %s content and provider authority at the mutation edge", (agent) => {
-    const target = sandbox(agent);
-    const runtimeProvider = provider(agent);
-    const restore = vi.fn(
-      (_name: string, _path: string, options: RecreatedSandboxRestoreOptions): RestoreResult => {
-        options.validateBeforeMutation?.();
-        return {
-          success: true,
-          restoredDirs: ["workspace"],
-          failedDirs: [],
-          restoredFiles: [],
-          failedFiles: [],
-        };
-      },
-    );
+  it.each(["openclaw", "hermes", "langchain-deepagents-code"] as const)(
+    "revalidates %s content and provider authority at the mutation edge",
+    (agent) => {
+      const target = sandbox(agent);
+      const runtimeProvider = provider(agent);
+      const restore = vi.fn(
+        (_name: string, _path: string, options: RecreatedSandboxRestoreOptions): RestoreResult => {
+          options.validateBeforeMutation?.();
+          return {
+            success: true,
+            restoredDirs: ["workspace"],
+            failedDirs: [],
+            restoredFiles: [],
+            failedFiles: [],
+          };
+        },
+      );
 
-    const result = restoreRecreatedSandboxStateWithManagedAuthority(
-      "alpha",
-      manifest(agent),
-      { targetAgentType: agent },
-      {
-        getSandbox: () => target,
-        requireProvider: () => runtimeProvider.bundle,
-        captureContentAuthority: () => ({
-          schemaVersion: 1,
-          backupPath: "/tmp/alpha",
-          contentSha256: "c".repeat(64),
+      const result = restoreRecreatedSandboxStateWithManagedAuthority(
+        "alpha",
+        manifest(agent),
+        { targetAgentType: agent },
+        {
+          getSandbox: () => target,
+          requireProvider: () => runtimeProvider.bundle,
+          captureContentAuthority: () => ({
+            schemaVersion: 1,
+            backupPath: "/tmp/alpha",
+            contentSha256: "c".repeat(64),
+          }),
+          restore,
+        },
+      );
+
+      expect(result.success).toBe(true);
+      expect(restore).toHaveBeenCalledWith(
+        "alpha",
+        "/tmp/alpha",
+        expect.objectContaining({
+          authority: expect.objectContaining({ contentSha256: "c".repeat(64) }),
+          validateBeforeMutation: expect.any(Function),
         }),
-        restore,
-      },
-    );
-
-    expect(result.success).toBe(true);
-    expect(restore).toHaveBeenCalledWith(
-      "alpha",
-      "/tmp/alpha",
-      expect.objectContaining({
-        authority: expect.objectContaining({ contentSha256: "c".repeat(64) }),
-        validateBeforeMutation: expect.any(Function),
-      }),
-    );
-    expect(runtimeProvider.preflight).toHaveBeenCalledTimes(2);
-    expect(runtimeProvider.validateRestore).toHaveBeenCalledTimes(2);
-    expect(runtimeProvider.restore).toHaveBeenCalledOnce();
-  });
+      );
+      expect(runtimeProvider.preflight).toHaveBeenCalledTimes(2);
+      expect(runtimeProvider.validateRestore).toHaveBeenCalledTimes(2);
+      expect(runtimeProvider.restore).toHaveBeenCalledOnce();
+    },
+  );
 
   it("keeps legacy rebuild manifests on the state-only restore path", () => {
     const legacy = { ...manifest("openclaw"), workload: undefined, runtimeSnapshot: undefined };
@@ -243,5 +245,70 @@ describe("managed rebuild restore authority", () => {
       error: expect.stringContaining("missing provider runtime authority"),
     });
     expect(restore).not.toHaveBeenCalled();
+  });
+
+  it("retains an incompatible backup for a successful retry before file mutation (#10758)", () => {
+    const backupPath = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-acceleration-retry-"));
+    const retainedFile = path.join(backupPath, "retained-state");
+    fs.writeFileSync(retainedFile, "state");
+    try {
+      const target = sandbox("openclaw");
+      const runtimeProvider = provider("openclaw");
+      runtimeProvider.validateRestore.mockImplementation(() => {
+        throw new Error("target cannot represent the snapshot acceleration state");
+      });
+      const restore = vi.fn(
+        (_name: string, _path: string, options: RecreatedSandboxRestoreOptions): RestoreResult => {
+          options.validateBeforeMutation?.();
+          return {
+            success: true,
+            restoredDirs: ["workspace"],
+            failedDirs: [],
+            restoredFiles: [],
+            failedFiles: [],
+          };
+        },
+      );
+      const retainedManifest = { ...manifest("openclaw"), backupPath };
+      const dependencies = {
+        getSandbox: () => target,
+        requireProvider: () => runtimeProvider.bundle,
+        captureContentAuthority: () => ({
+          schemaVersion: 1 as const,
+          backupPath,
+          contentSha256: "c".repeat(64),
+        }),
+        restore,
+      };
+
+      expect(
+        restoreRecreatedSandboxStateWithManagedAuthority(
+          "alpha",
+          retainedManifest,
+          { targetAgentType: "openclaw" },
+          dependencies,
+        ),
+      ).toMatchObject({
+        success: false,
+        error: expect.stringContaining("cannot represent the snapshot acceleration state"),
+      });
+      expect(restore).not.toHaveBeenCalled();
+      expect(fs.readFileSync(retainedFile, "utf8")).toBe("state");
+
+      runtimeProvider.validateRestore.mockReset();
+      expect(
+        restoreRecreatedSandboxStateWithManagedAuthority(
+          "alpha",
+          retainedManifest,
+          { targetAgentType: "openclaw" },
+          dependencies,
+        ),
+      ).toMatchObject({ success: true, restoredDirs: ["workspace"] });
+      expect(restore).toHaveBeenCalledOnce();
+      expect(runtimeProvider.restore).toHaveBeenCalledOnce();
+      expect(fs.readFileSync(retainedFile, "utf8")).toBe("state");
+    } finally {
+      fs.rmSync(backupPath, { recursive: true, force: true });
+    }
   });
 });

--- a/src/lib/onboard/runtime-provider/contract.ts
+++ b/src/lib/onboard/runtime-provider/contract.ts
@@ -643,6 +643,11 @@ export type RuntimeProviderSnapshotSurface =
         sandbox: SandboxEntry,
         preflight: RuntimeProviderSnapshotPreflightReceipt,
       ): RuntimeProviderRuntimeReceipt;
+      /** Compare provider-owned acceleration encodings without widening central authority. */
+      canRepresentAcceleration?(
+        source: RuntimeProviderRuntimeReceipt["acceleration"],
+        target: RuntimeProviderRuntimeReceipt["acceleration"],
+      ): boolean;
       validateRestore(
         sandbox: SandboxEntry,
         preflight: RuntimeProviderSnapshotPreflightReceipt,

--- a/src/lib/onboard/runtime-provider/podman-runtime-surfaces.ts
+++ b/src/lib/onboard/runtime-provider/podman-runtime-surfaces.ts
@@ -682,6 +682,9 @@ export function createPodmanRuntimeProviderSnapshotSurface(
       surface().preflight(...args),
     capture: (...args: Parameters<SupportedSnapshotSurface["capture"]>) =>
       surface().capture(...args),
+    canRepresentAcceleration: (
+      ...args: Parameters<NonNullable<SupportedSnapshotSurface["canRepresentAcceleration"]>>
+    ) => surface().canRepresentAcceleration?.(...args) ?? false,
     validateRestore: (...args: Parameters<SupportedSnapshotSurface["validateRestore"]>) =>
       surface().validateRestore(...args),
     restore: (...args: Parameters<SupportedSnapshotSurface["restore"]>) =>

--- a/src/lib/onboard/runtime-provider/snapshot.test.ts
+++ b/src/lib/onboard/runtime-provider/snapshot.test.ts
@@ -654,10 +654,177 @@ describe("Docker provider snapshot evidence", () => {
         acceleration: {
           kind: "gpu",
           vendor: "nvidia",
-          devices: ["docker-device-id:GPU-live-0", "docker-nvidia-visible-device:GPU-live-0"],
+          devices: ["nvidia.com/gpu=GPU-live-0"],
         },
       },
     });
+  });
+
+  it("restores all-GPU authority across CDI and Docker capability forms (#10758)", () => {
+    const target = sandbox({ openshellDriver: "docker" });
+    const sourceSurface = requireSupportedSurface(
+      createDockerRuntimeProviderSnapshotSurface("docker", {
+        captureHostCommand: dockerRestoreCapture(),
+        queryRuntimeSnapshot: () =>
+          dockerSnapshot({
+            deviceRequests: [
+              {
+                Driver: "cdi",
+                Count: 0,
+                DeviceIDs: ["nvidia.com/gpu=all"],
+                Capabilities: null,
+                Options: null,
+              },
+            ],
+            nativeGpuAttachmentState: "present",
+          }),
+      }),
+    );
+    const sourcePreflight = sourceSurface.preflight("backup", target);
+    const source = snapshotSource(sourcePreflight, sourceSurface.capture(target, sourcePreflight));
+    const restoreManagedProfile = dockerRestoreCapture();
+    const targetSurface = requireSupportedSurface(
+      createDockerRuntimeProviderSnapshotSurface("docker", {
+        captureHostCommand: restoreManagedProfile,
+        queryRuntimeSnapshot: () =>
+          dockerSnapshot({
+            deviceRequests: [
+              {
+                Driver: "",
+                Count: -1,
+                DeviceIDs: null,
+                Capabilities: [["gpu"]],
+                Options: null,
+              },
+            ],
+            nativeGpuAttachmentState: "present",
+          }),
+      }),
+    );
+    const targetPreflight = targetSurface.preflight("restore", target);
+
+    expect(source.runtime.acceleration).toEqual({
+      kind: "gpu",
+      vendor: "nvidia",
+      devices: ["nvidia.com/gpu=all"],
+    });
+    expect(targetSurface.restore(target, targetPreflight, source, managedProfile)).toMatchObject({
+      runtime: { acceleration: source.runtime.acceleration },
+    });
+    expect(restoreManagedProfile).toHaveBeenCalledWith(
+      "docker",
+      expect.arrayContaining(["exec", "--user", "root"]),
+      15_000,
+    );
+  });
+
+  it("restores a retained legacy all-GPU snapshot through canonical target authority (#10758)", () => {
+    const target = sandbox({ openshellDriver: "docker" });
+    const legacyObservation = observation("docker", {
+      runtime: {
+        schemaVersion: 1,
+        providerId: "docker",
+        runtime: { kind: "docker-container", handle: "c".repeat(64) },
+        acceleration: {
+          kind: "gpu",
+          vendor: "nvidia",
+          devices: ["docker-device-id:nvidia.com/gpu=all"],
+        },
+      },
+    });
+    const legacySurface = requireSupportedSurface(
+      createRuntimeProviderSnapshotSurface(
+        "docker",
+        surfaceDriver(() => legacyObservation),
+      ),
+    );
+    const sourcePreflight = legacySurface.preflight("backup", target);
+    const source = snapshotSource(sourcePreflight, legacySurface.capture(target, sourcePreflight));
+    const targetSurface = requireSupportedSurface(
+      createDockerRuntimeProviderSnapshotSurface("docker", {
+        captureHostCommand: dockerRestoreCapture(),
+        queryRuntimeSnapshot: () =>
+          dockerSnapshot({
+            deviceRequests: [
+              {
+                Driver: "",
+                Count: -1,
+                DeviceIDs: null,
+                Capabilities: [["gpu"]],
+                Options: null,
+              },
+            ],
+            nativeGpuAttachmentState: "present",
+          }),
+      }),
+    );
+    const targetPreflight = targetSurface.preflight("restore", target);
+
+    expect(source.runtime.acceleration).toMatchObject({
+      devices: ["docker-device-id:nvidia.com/gpu=all"],
+    });
+    expect(targetSurface.restore(target, targetPreflight, source, managedProfile)).toMatchObject({
+      runtime: {
+        acceleration: {
+          kind: "gpu",
+          vendor: "nvidia",
+          devices: ["nvidia.com/gpu=all"],
+        },
+      },
+    });
+  });
+
+  it("rejects an all-GPU target for an exact-device snapshot before restore (#10758)", () => {
+    const target = sandbox({ openshellDriver: "docker" });
+    const sourceSurface = requireSupportedSurface(
+      createDockerRuntimeProviderSnapshotSurface("docker", {
+        captureHostCommand: dockerRestoreCapture(),
+        queryRuntimeSnapshot: () =>
+          dockerSnapshot({
+            deviceRequests: [
+              {
+                Driver: "cdi",
+                Count: 0,
+                DeviceIDs: ["nvidia.com/gpu=0"],
+                Capabilities: null,
+                Options: null,
+              },
+            ],
+            nativeGpuAttachmentState: "present",
+          }),
+      }),
+    );
+    const sourcePreflight = sourceSurface.preflight("backup", target);
+    const source = snapshotSource(sourcePreflight, sourceSurface.capture(target, sourcePreflight));
+    const restoreManagedProfile = dockerRestoreCapture();
+    const targetSurface = requireSupportedSurface(
+      createDockerRuntimeProviderSnapshotSurface("docker", {
+        captureHostCommand: restoreManagedProfile,
+        queryRuntimeSnapshot: () =>
+          dockerSnapshot({
+            deviceRequests: [
+              {
+                Driver: "",
+                Count: -1,
+                DeviceIDs: null,
+                Capabilities: [["gpu"]],
+                Options: null,
+              },
+            ],
+            nativeGpuAttachmentState: "present",
+          }),
+      }),
+    );
+    const targetPreflight = targetSurface.preflight("restore", target);
+
+    expect(() => targetSurface.restore(target, targetPreflight, source, managedProfile)).toThrow(
+      /cannot represent the snapshot acceleration state/u,
+    );
+    expect(restoreManagedProfile).not.toHaveBeenCalledWith(
+      "docker",
+      expect.arrayContaining(["exec"]),
+      expect.any(Number),
+    );
   });
 
   it.each(
@@ -681,6 +848,18 @@ describe("Docker provider snapshot evidence", () => {
           ],
           nativeGpuAttachmentState: "present",
           runtime: "nvidia",
+        }),
+        dockerSnapshot({
+          deviceRequests: [
+            {
+              Driver: "cdi",
+              Count: 0,
+              DeviceIDs: ["nvidia.com/gpu="],
+              Capabilities: null,
+              Options: null,
+            },
+          ],
+          nativeGpuAttachmentState: "present",
         }),
         dockerSnapshot({ nativeGpuAttachmentState: "unknown", runtime: "custom-runtime" }),
       ],
@@ -712,7 +891,7 @@ describe("Docker provider snapshot evidence", () => {
         },
       );
       expect(allDevices.runtime.acceleration).toMatchObject({
-        devices: ["docker-device-request:nvidia:count=-1", "docker-nvidia-visible-devices:all"],
+        devices: ["nvidia.com/gpu=all"],
       });
 
       expect(() =>
@@ -744,8 +923,31 @@ describe("Docker provider snapshot evidence", () => {
     expect(observed.runtime.acceleration).toEqual({
       kind: "gpu",
       vendor: "nvidia",
-      devices: ["docker-nvidia-visible-device:0", "docker-nvidia-visible-device:GPU-live-1"],
+      devices: ["nvidia.com/gpu=0", "nvidia.com/gpu=GPU-live-1"],
     });
+  });
+
+  it("rejects conflicting Docker GPU selectors instead of widening access", () => {
+    expect(() =>
+      observeDockerRuntimeSnapshot(sandbox({ openshellDriver: "docker" }), "docker", {
+        captureHostCommand: dockerLifecycleCapture(),
+        queryRuntimeSnapshot: () =>
+          dockerSnapshot({
+            deviceRequests: [
+              {
+                Driver: "nvidia",
+                Count: 0,
+                DeviceIDs: ["GPU-live-0"],
+                Capabilities: [["gpu"]],
+                Options: null,
+              },
+            ],
+            nativeGpuAttachmentState: "present",
+            runtime: "nvidia",
+            nvidiaVisibleDevices: "all",
+          }),
+      }),
+    ).toThrow(/conflicting live device selectors/u);
   });
 
   it.each(["openclaw", "hermes", "langchain-deepagents-code"] as const)(

--- a/src/lib/onboard/runtime-provider/snapshot.ts
+++ b/src/lib/onboard/runtime-provider/snapshot.ts
@@ -66,6 +66,10 @@ export type RuntimeProviderManagedProfileRestorer = (
 export interface RuntimeProviderSnapshotDriver {
   readonly observe: RuntimeProviderSnapshotObserver;
   readonly restoreManagedProfile: RuntimeProviderManagedProfileRestorer;
+  readonly canRepresentAcceleration?: (
+    source: RuntimeProviderRuntimeReceipt["acceleration"],
+    target: RuntimeProviderRuntimeReceipt["acceleration"],
+  ) => boolean;
 }
 
 export interface OpenShellRuntimeSnapshotDependencies {
@@ -236,6 +240,81 @@ function dockerRequestUsesGpu(
   );
 }
 
+function canonicalNvidiaGpuSelector(device: string): string {
+  const value = device.trim();
+  const cdiPrefix = /^nvidia[.]com\/gpu=/iu;
+  const identifier = cdiPrefix.test(value) ? value.replace(cdiPrefix, "") : value;
+  if (!identifier || CONTROL_CHARACTERS.test(identifier)) {
+    throw new RuntimeProviderSnapshotError(
+      "Docker GPU attachment does not expose exact live device selectors",
+    );
+  }
+  return identifier.toLowerCase() === "all" ? "nvidia.com/gpu=all" : `nvidia.com/gpu=${identifier}`;
+}
+
+function canonicalDockerGpuSelection(devices: readonly string[]): readonly string[] {
+  const selectors = [...new Set(devices.map(canonicalNvidiaGpuSelector))].sort();
+  if (selectors.includes("nvidia.com/gpu=all") && selectors.length !== 1) {
+    throw new RuntimeProviderSnapshotError(
+      "Docker GPU attachment exposes conflicting live device selectors",
+    );
+  }
+  return selectors;
+}
+
+function canonicalDockerAcceleration(
+  acceleration: RuntimeProviderRuntimeReceipt["acceleration"],
+): RuntimeProviderRuntimeReceipt["acceleration"] | null {
+  if (acceleration.kind === "none") return acceleration;
+  if (acceleration.vendor.toLowerCase() !== "nvidia") return null;
+  const gpuSelectors: string[] = [];
+  const pathSelectors: string[] = [];
+  for (const selector of acceleration.devices) {
+    if (selector.startsWith("docker-device-path:")) {
+      pathSelectors.push(selector);
+      continue;
+    }
+    if (selector === "docker-nvidia-visible-devices:all") {
+      gpuSelectors.push("all");
+      continue;
+    }
+    if (/^docker-device-request:[^:]+:count=-1$/u.test(selector)) {
+      gpuSelectors.push("all");
+      continue;
+    }
+    const legacyDevice = selector.match(/^docker-(?:device-id|nvidia-visible-device):(.+)$/u)?.[1];
+    if (legacyDevice) {
+      gpuSelectors.push(legacyDevice);
+      continue;
+    }
+    if (/^nvidia[.]com\/gpu=/iu.test(selector)) {
+      gpuSelectors.push(selector);
+      continue;
+    }
+    return null;
+  }
+  try {
+    const devices = [
+      ...canonicalDockerGpuSelection(gpuSelectors),
+      ...new Set(pathSelectors),
+    ].sort();
+    return devices.length > 0 ? { kind: "gpu", vendor: "nvidia", devices } : null;
+  } catch {
+    return null;
+  }
+}
+
+function dockerCanRepresentAcceleration(
+  source: RuntimeProviderRuntimeReceipt["acceleration"],
+  target: RuntimeProviderRuntimeReceipt["acceleration"],
+): boolean {
+  const canonicalSource = canonicalDockerAcceleration(source);
+  const canonicalTarget = canonicalDockerAcceleration(target);
+  return Boolean(
+    canonicalSource && canonicalTarget && isDeepStrictEqual(canonicalSource, canonicalTarget),
+  );
+}
+
 function dockerGpuSelectors(
   snapshot: Extract<OpenShellDockerSandboxRuntimeSnapshotQuery, { ok: true }>,
 ): RuntimeProviderRuntimeReceipt["acceleration"] {
@@ -244,35 +323,41 @@ function dockerGpuSelectors(
     throw new RuntimeProviderSnapshotError("Docker returned ambiguous live acceleration evidence");
   }
 
-  const selectors: string[] = [];
+  const selections: string[][] = [];
   if (snapshot.runtime.trim().toLowerCase() === "nvidia") {
     const visibleDevices = snapshot.nvidiaVisibleDevices;
     if (visibleDevices === "all") {
-      selectors.push("docker-nvidia-visible-devices:all");
+      selections.push(["all"]);
     } else if (visibleDevices && !["none", "void"].includes(visibleDevices)) {
-      for (const device of visibleDevices.split(",")) {
-        selectors.push(`docker-nvidia-visible-device:${device}`);
-      }
+      selections.push(visibleDevices.split(","));
     }
   }
+  const requestedDevices: string[] = [];
   for (const request of snapshot.deviceRequests ?? []) {
     if (!dockerRequestUsesGpu(request)) continue;
     if (request.DeviceIDs && request.DeviceIDs.length > 0) {
-      for (const device of request.DeviceIDs) {
-        selectors.push(`docker-device-id:${device}`);
-      }
+      requestedDevices.push(...request.DeviceIDs);
       continue;
     }
     if (request.Count === -1) {
       // Count=-1 is Docker's explicit live all-device selector. Never infer
       // this value from a durable "GPU enabled" flag.
-      selectors.push(`docker-device-request:${request.Driver || "default"}:count=-1`);
+      requestedDevices.push("all");
       continue;
     }
     throw new RuntimeProviderSnapshotError(
       "Docker GPU attachment does not expose exact live device selectors",
     );
   }
+  if (requestedDevices.length > 0) selections.push(requestedDevices);
+  const canonicalSelections = selections.map(canonicalDockerGpuSelection);
+  const selectedDevices = canonicalSelections[0] ?? [];
+  if (canonicalSelections.some((selection) => !isDeepStrictEqual(selection, selectedDevices))) {
+    throw new RuntimeProviderSnapshotError(
+      "Docker GPU attachment exposes conflicting live device selectors",
+    );
+  }
+  const selectors = [...selectedDevices];
   for (const mapping of snapshot.devices ?? []) {
     const rendered =
       `docker-device-path:${mapping.PathOnHost}=>${mapping.PathInContainer}` +
@@ -611,7 +696,8 @@ function validateRestoreRequest(
   }
   const observed = observeAndNormalize(driver.observe, sandbox, providerId);
   assertUnchanged(providerId, expected, observed);
-  if (!isDeepStrictEqual(source.runtime.acceleration, observed.runtime.acceleration)) {
+  const canRepresentAcceleration = driver.canRepresentAcceleration ?? isDeepStrictEqual;
+  if (!canRepresentAcceleration(source.runtime.acceleration, observed.runtime.acceleration)) {
     throw new RuntimeProviderSnapshotError(
       `sandbox '${sandbox.name}' cannot represent the snapshot acceleration state`,
     );
@@ -650,6 +736,9 @@ export function createRuntimeProviderSnapshotSurface(
       const observed = observeAndNormalize(driver.observe, sandbox, providerId);
       assertUnchanged(providerId, expected, observed);
       return observed.runtime;
+    },
+    canRepresentAcceleration(source, target) {
+      return (driver.canRepresentAcceleration ?? isDeepStrictEqual)(source, target);
     },
     validateRestore(sandbox, preflight, source, managedProfile) {
       validateRestoreRequest(providerId, driver, sandbox, preflight, source, managedProfile);
@@ -709,6 +798,7 @@ export function createDockerRuntimeProviderSnapshotSurface(
   };
   return createRuntimeProviderSnapshotSurface(providerId, {
     observe: (sandbox, id) => observeDockerRuntimeSnapshot(sandbox, id, resolved),
+    canRepresentAcceleration: dockerCanRepresentAcceleration,
     restoreManagedProfile: (sandbox, authority, runtime) =>
       verifyDockerManagedProfileRestore(sandbox, authority, runtime, resolved),
   });


### PR DESCRIPTION
## Outcome

Rebuild restore now treats equivalent NVIDIA all-GPU Docker attachments as the same acceleration authority across CDI and Docker capability encodings. Exact-device differences, unknown encodings, and conflicting live evidence still fail closed before filesystem mutation.

## Reason

On DGX Station GB300, the source and recreated sandbox can expose the same all-GPU authority through different Docker API forms. The snapshot previously persisted those transport-specific strings and compared them byte-for-byte, so a compatible replacement reached Ready and then failed restore validation.

### Related issues

Fixes #10758

## Changes

- Canonicalize explicit live NVIDIA GPU evidence from CDI device IDs, Docker `--gpus all` requests, and `NVIDIA_VISIBLE_DEVICES` for the Docker snapshot consumer. Direct string comparison is insufficient because Docker can encode the same authority in different fields; the provider snapshot tests cover CDI-to-capability restore and conflicting evidence.
- Add a bounded Docker-owned comparison for retained legacy snapshot encodings. Central restore orchestration passes detached, frozen acceleration evidence to that provider hook; unknown encodings, vendor changes, exact-device changes, and all-versus-exact mismatches remain incompatible. Provider lifecycle and Docker snapshot tests protect both the compatibility and fail-closed paths.
- Verify that an acceleration rejection happens before file mutation, preserves the backup, exposes the existing backup path and rebuild recovery command, and succeeds on a later retry with unchanged retained state.

## Verification

- `npx vitest run --project cli src/lib/onboard/runtime-provider/snapshot.test.ts src/lib/onboard/openshell-docker-sandbox-containers.test.ts src/lib/actions/sandbox/snapshot/backup-authority.test.ts src/lib/actions/sandbox/snapshot/restore-authority.test.ts src/lib/actions/sandbox/snapshot/provider-lifecycle.test.ts src/lib/actions/sandbox/rebuild-restore-phase.test.ts src/lib/actions/sandbox/rebuild-post-restore-phase.test.ts` — 154 tests passed.
- `npx vitest run --project integration test/state/snapshot-managed-restore-authority.test.ts` — 4 tests passed.
- `npm run typecheck:cli` — passed.
- `npm run build:cli` — passed.
- `npm run checks:repository` — passed.
- `npm run validate:pr` — passed against canonical base `7533f279edeb9cd6d71117e8e65c364ef15cacab`.
- `npm run test:changed` — broad local diagnostic did not pass: 6,613 tests passed, 17 skipped, and 47 failed. The failures were outside the issue-owned test files and included local timeouts, host-specific Podman/user-state errors, and stale mock expectations; the focused and integration restore suites above passed.
- Reviewed the complete diff and confirmed that it contains no secrets, API keys, or credentials.

## Review notes

No live DGX Station hardware validation was run or claimed. The regression evidence uses deterministic provider fixtures for the CDI all-GPU and Docker capability forms described by the issue.

---

Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>
