### PR TITLE
fix(hermes): reject unmanaged profile gateways

### DIFF
--- a/agents/hermes/hermes-wrapper.py
+++ b/agents/hermes/hermes-wrapper.py
@@ -768,9 +768,38 @@ def _report_cli_adapter_error(exc: _CliAdapterError) -> int:
     return 2
 
 
+_GATEWAY_LAUNCH_COMMANDS = frozenset({"install", "restart", "run", "start"})
+
+
+def _requests_named_profile_gateway_launch(argv: list[str]) -> bool:
+    """Detect upstream profile forms before a gateway launch command."""
+    if len(argv) >= 4 and argv[0] in ("-p", "--profile"):
+        return (
+            bool(argv[1])
+            and argv[2] == "gateway"
+            and argv[3] in _GATEWAY_LAUNCH_COMMANDS
+        )
+    if len(argv) >= 3 and argv[0].startswith("--profile="):
+        return (
+            bool(argv[0].partition("=")[2])
+            and argv[1] == "gateway"
+            and argv[2] in _GATEWAY_LAUNCH_COMMANDS
+        )
+    return False
+
+
 def main(argv: list[str]) -> int:
     real_hermes = _resolve_real_hermes()
     guard_path = _resolve_guard()
+    if _requests_named_profile_gateway_launch(argv):
+        print(
+            "[COMPATIBILITY] Refusing named-profile Hermes gateway: NemoClaw "
+            "manages only the default-profile gateway. Use a separate NemoClaw "
+            "sandbox for another supervised gateway; named-profile gateway "
+            "processes have no managed restart, crash quarantine, or protected log.",
+            file=sys.stderr,
+        )
+        return 2
     if argv[:1] == ["dashboard"] and not _load_dashboard_api_server_key():
         return 1
     if argv[:2] == ["config", "show"]:

--- a/docs/manage-sandboxes/gateway-lifecycle-control.mdx
+++ b/docs/manage-sandboxes/gateway-lifecycle-control.mdx
@@ -57,6 +57,19 @@ The authorization records host intent for that exit; it does not claim that the 
 After the in-sandbox processes are healthy, the host repairs only the host-side OpenShell forwards.
 </AgentOnly>
 
+<AgentOnly variant="hermes">
+## Use Only the Default Hermes Gateway
+
+NemoClaw manages one Hermes gateway in each sandbox and launches it with the default Hermes profile.
+The managed lifecycle does not include a gateway that uses `-p` or `--profile`.
+The Hermes wrapper rejects named-profile `gateway run`, `gateway start`, `gateway restart`, and `gateway install` commands because their processes would have no managed health checks, restart, crash quarantine, or teardown.
+
+Create another NemoClaw Hermes sandbox when you need another managed gateway.
+Do not bypass the wrapper and launch the upstream binary in the background.
+NemoClaw protects the default gateway log at `/tmp/gateway.log` with mode `0600`, but it does not create or protect logs for an unmanaged process.
+Do not redirect gateway output to a shared or world-readable file.
+</AgentOnly>
+
 ## Fail Closed on Unsupported Topologies
 
 The host selects the matching controller automatically for `recover` and `gateway restart`.

--- a/test/agents/hermes/hermes-gateway-wrapper.test.ts
+++ b/test/agents/hermes/hermes-gateway-wrapper.test.ts
@@ -105,6 +105,51 @@ describe.skipIf(!canRun)("agents/hermes/hermes-wrapper.py", () => {
     expect(run.realArgs).toBe("gateway run");
   });
 
+  it.each([
+    ["short option", ["-p", "research", "gateway", "run"]],
+    ["long option", ["--profile", "operations", "gateway", "run"]],
+    ["equals option", ["--profile=research", "gateway", "run"]],
+  ])("refuses a named-profile gateway through the %s form (#10776)", (_form, args) => {
+    const run = runWrapper(args, {});
+
+    expect(run.status).toBe(2);
+    expect(run.stderr).toContain("Refusing named-profile Hermes gateway");
+    expect(run.stderr).toContain("separate NemoClaw sandbox");
+    expect(run.realInvoked).toBe(false);
+  });
+
+  it.each(["install", "restart", "start"])(
+    "refuses the named-profile gateway %s launch path (#10776)",
+    (command) => {
+      const run = runWrapper(["--profile", "operations", "gateway", command], {});
+
+      expect(run.status).toBe(2);
+      expect(run.stderr).toContain("Refusing named-profile Hermes gateway");
+      expect(run.realInvoked).toBe(false);
+    },
+  );
+
+  it.each(["../outside", "profile with spaces", "$(touch /tmp/profile-owned)", "gateway\nrun"])(
+    "refuses a named gateway without rendering the hostile profile name %s (#10776)",
+    (profile) => {
+      const run = runWrapper(["--profile", profile, "gateway", "run"], {});
+
+      expect(run.status).toBe(2);
+      expect(run.stderr).toContain("Refusing named-profile Hermes gateway");
+      expect(run.stderr).not.toContain(profile);
+      expect(run.realInvoked).toBe(false);
+    },
+  );
+
+  it("preserves named-profile non-gateway commands", () => {
+    const run = runWrapper(["--profile", "research", "chat", "hello"], {});
+
+    expect(run.status).toBe(0);
+    expect(run.stderr).toBe("");
+    expect(run.realInvoked).toBe(true);
+    expect(run.realArgs).toBe("--profile research chat hello");
+  });
+
   it("scrubs package-manager and Python startup inputs before a root-separated gateway exec", () => {
     const run = runWrapper(
       ["gateway", "run"],


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

NemoClaw now rejects named-profile Hermes gateway launch commands before they start an unmanaged process. The default-profile gateway and named-profile non-gateway commands retain their existing behavior.

## Reason

A named-profile gateway bypasses NemoClaw's single managed gateway lifecycle. It receives no managed PID identity, health checks, crash respawn, quarantine, teardown, or protected log, so a crash can silently stop profile cron work.

### Related issues

Fixes #10776

## Changes

- Reject named-profile `gateway run`, `gateway start`, `gateway restart`, and `gateway install` forms in the Hermes wrapper.
- Keep the profile name out of the refusal message and prevent the upstream binary from running for hostile profile values.
- Preserve default-profile gateway launch and named-profile non-gateway commands.
- Document the one-gateway contract, the separate-sandbox alternative, and the mode `0600` default log boundary.
- Protect the rejection boundary with Linux wrapper tests for all accepted profile forms, launch variants, hostile names, and allowed sibling behavior.

## Verification

- `npx vitest run --project integration test/agents/hermes/hermes-gateway-wrapper.test.ts` — passed on Linux ARM64: 1 file, 61 tests.
- `npm run typecheck:cli` — passed.
- `npm run docs` — passed with 0 Fern errors.
- `npm run checks:repository` — passed.
- `npm run validate:pr` — passed against current `origin/main`, including pre-commit, commitlint, and pre-push checks.
- The diff contains no secrets, API keys, or credentials.

## Review notes

This change closes an unmanaged process and log boundary. It does not add profile discovery, a second supervisor role, or another lifecycle authority. The wrapper rejects the process before launch, does not echo untrusted profile names, and leaves the existing managed default gateway unchanged.

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>
