### PR TITLE
fix(onboard): honor selected Hermes portable gateway

### DIFF
--- a/src/lib/actions/uninstall/hermes-portable-uninstall.ts
+++ b/src/lib/actions/uninstall/hermes-portable-uninstall.ts
@@ -420,6 +420,7 @@ function loadAuthority(
       directory: runtime.inferenceStateDir,
       transactionId: inference.receipt.publication.transactionId,
       targetSha256: inference.receipt.publication.targetSha256,
+      gatewayName: receipt.gatewayName,
       sandboxName,
       model: row.model!,
       credentialEnv: OLLAMA_LOCAL_CREDENTIAL_ENV,

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3061,6 +3061,7 @@ async function runOnboard(opts: OnboardOptions = {}): Promise<void> {
             resolveHostLocalInferenceStartupSelection:
               setupNimFlow.createHermesPortableOllamaInferenceResolver({
                 runtimeContext: lockedRuntime.portableRuntimeContext,
+                gatewayName: GATEWAY_NAME,
                 credentialEnv: OLLAMA_PROXY_CREDENTIAL_ENV,
                 getReservationSessionId: () => session?.sessionId,
                 runGatewayOpenshell: runCoreGatewayOpenshell,
@@ -3391,7 +3392,6 @@ async function runOnboard(opts: OnboardOptions = {}): Promise<void> {
   }
   preserveIncompleteSession = true;
 }
-
 module.exports = {
   buildOrphanedSandboxRollbackMessage,
   buildProviderArgs,

--- a/src/lib/onboard/experimental/hermes-portable-ollama-gateway-transaction.ts
+++ b/src/lib/onboard/experimental/hermes-portable-ollama-gateway-transaction.ts
@@ -257,7 +257,7 @@ type GatewayProviderJournalPhase =
 type GatewayProviderJournalIntent = Readonly<{
   transactionId: string;
   targetSha256: string;
-  gatewayName: "nemoclaw";
+  gatewayName: string;
   sandboxName: string;
   provider: "ollama-local";
   model: string;
@@ -519,6 +519,7 @@ function observeExactGatewayProvider(
 
 function exactGatewayMutation(
   runGatewayOpenshell: HermesPortableOllamaGatewayRunner,
+  expectedGatewayName: string,
   expectedModel: string,
   expectedSandboxName: string,
   expectedCredentialEnv: string,
@@ -617,7 +618,7 @@ function exactGatewayMutation(
   const prepareGatewayMutation: HostLocalInferenceStartupSelection["prepareGatewayMutation"] =
     async (input) => {
       if (
-        input.gatewayName !== "nemoclaw" ||
+        input.gatewayName !== expectedGatewayName ||
         input.sandboxName !== expectedSandboxName ||
         input.provider !== "ollama-local" ||
         input.model !== expectedModel ||
@@ -829,6 +830,7 @@ export function createHermesPortableOllamaGatewayTransaction(options: {
   readonly directory: string;
   readonly transactionId: string;
   readonly targetSha256: string;
+  readonly gatewayName: string;
   readonly sandboxName: string;
   readonly model: string;
   readonly credentialEnv: string;
@@ -858,7 +860,7 @@ export function createHermesPortableOllamaGatewayTransaction(options: {
     Object.freeze({
       transactionId,
       targetSha256: options.targetSha256,
-      gatewayName: "nemoclaw",
+      gatewayName: options.gatewayName,
       sandboxName: options.sandboxName,
       provider: "ollama-local",
       model: options.model,
@@ -886,6 +888,7 @@ export function createHermesPortableOllamaGatewayTransaction(options: {
   }
   const gatewayMutation = exactGatewayMutation(
     options.runGatewayOpenshell,
+    options.gatewayName,
     options.model,
     options.sandboxName,
     options.credentialEnv,
@@ -918,6 +921,7 @@ export interface HermesPortableOllamaPublishedReceiptAuthority {
 /** Bind the committed private receipt and journal without repeating the live provider observation. */
 export function prepareHermesPortableOllamaPublishedReceiptAuthority(options: {
   readonly directory: string;
+  readonly gatewayName: string;
   readonly sandboxName: string;
   readonly credentialEnv: string;
 }): HermesPortableOllamaPublishedReceiptAuthority {
@@ -952,7 +956,7 @@ export function prepareHermesPortableOllamaPublishedReceiptAuthority(options: {
     Object.freeze({
       transactionId,
       targetSha256: receipt.publication.targetSha256,
-      gatewayName: "nemoclaw" as const,
+      gatewayName: options.gatewayName,
       sandboxName: options.sandboxName,
       provider: "ollama-local" as const,
       model: receipt.inference.model,
@@ -982,6 +986,7 @@ export function prepareHermesPortableOllamaPublishedReceiptAuthority(options: {
 /** Re-prove an already committed Ollama publication without opening a mutation path. */
 export function prepareHermesPortableOllamaPublishedInferenceAuthority(options: {
   readonly directory: string;
+  readonly gatewayName: string;
   readonly sandboxName: string;
   readonly credentialEnv: string;
   readonly runGatewayOpenshell: HermesPortableOllamaGatewayRunner;
@@ -1016,7 +1021,7 @@ export function prepareHermesPortableOllamaPublishedInferenceAuthority(options: 
   const intent = Object.freeze({
     transactionId,
     targetSha256,
-    gatewayName: "nemoclaw" as const,
+    gatewayName: options.gatewayName,
     sandboxName: options.sandboxName,
     provider: "ollama-local" as const,
     model: receipt.inference.model,
@@ -1102,6 +1107,7 @@ export function prepareHermesPortableOllamaProviderRetirement(options: {
   readonly directory: string;
   readonly transactionId: string;
   readonly targetSha256: string;
+  readonly gatewayName: string;
   readonly sandboxName: string;
   readonly model: string;
   readonly credentialEnv: string;
@@ -1117,7 +1123,7 @@ export function prepareHermesPortableOllamaProviderRetirement(options: {
     Object.freeze({
       transactionId: options.transactionId,
       targetSha256: options.targetSha256,
-      gatewayName: "nemoclaw",
+      gatewayName: options.gatewayName,
       sandboxName: options.sandboxName,
       provider: "ollama-local",
       model: options.model,

--- a/src/lib/onboard/experimental/hermes-portable-ollama-inference.test.ts
+++ b/src/lib/onboard/experimental/hermes-portable-ollama-inference.test.ts
@@ -165,7 +165,7 @@ function executableAuthorityDeps(): PodmanExecutableAuthorityDeps {
   };
 }
 
-function createRuntimeFixture(pullFailure?: PullFailure) {
+function createRuntimeFixture(pullFailure?: PullFailure, gatewayName = "nemoclaw") {
   const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-portable-inference-"));
   temporaryDirectories.push(homeDir);
   const runtime = runtimeAuthority(homeDir);
@@ -211,6 +211,7 @@ function createRuntimeFixture(pullFailure?: PullFailure) {
     : capture;
   const resolverOptions = {
     runtimeContext: { authority: runtime, environmentScope },
+    gatewayName,
     credentialEnv: "NEMOCLAW_OLLAMA_PROXY_TOKEN",
     getReservationSessionId: () => "portable-session",
     runGatewayOpenshell,
@@ -294,6 +295,7 @@ function gatewayJournal(fixture: ReturnType<typeof createRuntimeFixture>) {
   return JSON.parse(fs.readFileSync(gatewayJournalPath(fixture), "utf8")) as {
     phase: string;
     intent: {
+      gatewayName: string;
       providerCredentialEnv: string;
       transactionId: string;
       targetSha256: string;
@@ -340,6 +342,7 @@ describe("Hermes Portable Ollama inference activation", () => {
 
     const authority = prepareHermesPortableOllamaPublishedReceiptAuthority({
       directory: path.dirname(receiptPath),
+      gatewayName: journal.intent.gatewayName,
       sandboxName: journal.intent.sandboxName,
       credentialEnv: journal.intent.credentialEnv,
     });
@@ -364,6 +367,7 @@ describe("Hermes Portable Ollama inference activation", () => {
 
     const authority = prepareHermesPortableOllamaPublishedInferenceAuthority({
       directory: path.dirname(receiptPath),
+      gatewayName: journal.intent.gatewayName,
       sandboxName: journal.intent.sandboxName,
       credentialEnv: journal.intent.credentialEnv,
       runGatewayOpenshell: fixture.gatewayProvider.run,
@@ -537,6 +541,7 @@ describe("Hermes Portable Ollama inference activation", () => {
     vi.stubEnv("NEMOCLAW_EXPERIMENTAL_PROFILE", "portable");
     const resolverOptions = {
       runtimeContext: null,
+      gatewayName: "nemoclaw",
       credentialEnv: "NEMOCLAW_OLLAMA_PROXY_TOKEN",
       getReservationSessionId: () => null,
       runGatewayOpenshell: () => ({ status: 1, stdout: "", stderr: "" }),
@@ -682,6 +687,44 @@ describe("Hermes Portable Ollama inference activation", () => {
     await expect(published.prepareGatewayMutation(gatewayMutationInput)).rejects.toThrow(
       "gateway mutation authority changed",
     );
+  });
+
+  it("preserves the selected gateway through publication and retirement for a non-default port (#10778)", async () => {
+    const gatewayName = "nemoclaw-18080";
+    const fixture = createRuntimeFixture(undefined, gatewayName);
+    const selection = fixture.resolve()!;
+    const route = prepareManagedRoute(fixture, selection);
+    route.prepared.validateBeforeCommit();
+    const mutation = await selection.prepareGatewayMutation({
+      ...gatewayMutationInput,
+      gatewayName,
+    });
+    createExactGatewayProvider(mutation);
+    await mutation.commit();
+    route.prepared.commit();
+    const journal = gatewayJournal(fixture);
+
+    expect(journal.intent.gatewayName).toBe(gatewayName);
+    const published = prepareHermesPortableOllamaPublishedReceiptAuthority({
+      directory: path.dirname(gatewayJournalPath(fixture)),
+      gatewayName,
+      sandboxName: journal.intent.sandboxName,
+      credentialEnv: journal.intent.credentialEnv,
+    });
+    published.assertCurrent();
+    const retirement = prepareHermesPortableOllamaProviderRetirement({
+      directory: path.dirname(gatewayJournalPath(fixture)),
+      transactionId: journal.intent.transactionId,
+      targetSha256: journal.intent.targetSha256,
+      gatewayName,
+      sandboxName: journal.intent.sandboxName,
+      model: journal.intent.model,
+      credentialEnv: journal.intent.credentialEnv,
+      runGatewayOpenshell: fixture.gatewayProvider.run,
+    });
+    expect(retirement.present).toBe(true);
+    retirement.removeAndVerify();
+    retirement.verifyAbsent();
   });
 
   it("recovers a committed gateway transaction before checking rebound live authority (#9596)", async () => {

--- a/src/lib/onboard/experimental/hermes-portable-ollama-inference.ts
+++ b/src/lib/onboard/experimental/hermes-portable-ollama-inference.ts
@@ -99,6 +99,7 @@ const SAFE_CREDENTIAL_ENV = /^[A-Z_][A-Z0-9_]*$/u;
 
 export interface HermesPortableOllamaInferenceResolverOptions {
   readonly runtimeContext: PortableOnboardRuntimeContext | null;
+  readonly gatewayName: string;
   readonly credentialEnv: string;
   readonly getReservationSessionId: () => string | null | undefined;
   readonly runGatewayOpenshell: HermesPortableOllamaGatewayRunner;
@@ -874,6 +875,7 @@ export function inspectHermesPortableOllamaReadinessRuntime(
   const inferenceStateDir = hermesPortableInferenceStateDir(stateDir, input.sandboxName);
   const published = deps.preparePublishedReceiptAuthority({
     directory: inferenceStateDir,
+    gatewayName: input.operatingReceipt.gatewayName,
     sandboxName: input.sandboxName,
     credentialEnv: OLLAMA_LOCAL_CREDENTIAL_ENV,
   });
@@ -1057,6 +1059,7 @@ export function recoverHermesPortableOllamaInference(
       atOllamaRecoveryPhase("PRIVATE_PUBLICATION_AUTHORITY", () => {
         const current = deps.preparePublishedAuthority({
           directory: hermesPortableInferenceStateDir(stateDir, operating.receipt.sandboxName),
+          gatewayName: operating.receipt.gatewayName,
           sandboxName: input.sandboxName,
           credentialEnv: OLLAMA_LOCAL_CREDENTIAL_ENV,
           runGatewayOpenshell: input.runGatewayOpenshell,
@@ -1438,6 +1441,7 @@ export function createHermesPortableOllamaInferenceResolver(
       directory: stateDir,
       transactionId,
       targetSha256,
+      gatewayName: options.gatewayName,
       sandboxName: input.sandboxName,
       model,
       credentialEnv: options.credentialEnv,

--- a/test/helpers/hermes-portable-uninstall-fixture.ts
+++ b/test/helpers/hermes-portable-uninstall-fixture.ts
@@ -359,6 +359,7 @@ export async function createHermesPortableUninstallFixture(
   );
   const resolver = createHermesPortableOllamaInferenceResolver({
     runtimeContext: { authority: runtime, environmentScope },
+    gatewayName: "nemoclaw",
     credentialEnv: "NEMOCLAW_OLLAMA_PROXY_TOKEN",
     getReservationSessionId: () => "portable-session",
     runGatewayOpenshell: gatewayProvider.run,


### PR DESCRIPTION
## Outcome

Hermes Portable Ollama now uses the selected OpenShell gateway for provider activation, recovery, and uninstall. Non-default gateway ports no longer fall back to the hard-coded `nemoclaw` gateway.

## Reason

A non-default `NEMOCLAW_GATEWAY_PORT` selects a gateway such as `nemoclaw-18080`. The gateway transaction previously stored and validated `nemoclaw`, which caused authority checks and later lifecycle operations to use the wrong gateway.

### Related issues

Fixes #10778

## Changes

- Pass the selected gateway name into the Portable Ollama resolver.
- Store that gateway name in the provider transaction journal.
- Reuse the stored gateway authority during recovery and uninstall.
- Protect activation, publication, and retirement with a non-default-port regression test.

## Verification

- `npx vitest run --project cli src/lib/onboard/experimental/hermes-portable-ollama-inference.test.ts src/lib/onboard/experimental/hermes-portable-ollama-published-engine-recovery.test.ts src/lib/actions/uninstall/hermes-portable-uninstall.test.ts` — 3 files and 102 tests passed.
- `npm run typecheck:cli` — passed.
- `npm run checks:repository` — passed.
- `npm run validate:pr` — passed.
- Brev L4 test with gateway port 18080 — provider creation, route publication, durable journal commit, GPU inference, and route readback passed. A follow-up comment contains the full evidence.
- The diff contains no secrets, API keys, or credentials.

## Review notes

The Brev run validated commit `7201b2c654e7e7656687a488309d260df059ec73`. Full onboarding later encountered a separate published-resume lifecycle error after the custom-gateway transaction had committed.

---

Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>