### PR TITLE
ci(security): enable trusted npm audit reuse

### DIFF
--- a/.github/actions/ci-install-dependencies.sh
+++ b/.github/actions/ci-install-dependencies.sh
@@ -56,5 +56,5 @@ if [ "$package_mode" = "registry" ] && [ -n "${NODE_AUTH_TOKEN:-}" ]; then
   export NPM_CONFIG_USERCONFIG="$trusted_npmrc"
 fi
 
-npm ci --ignore-scripts --prefer-offline --cache "$npm_cache"
-npm --prefix nemoclaw ci --ignore-scripts --prefer-offline --cache "$npm_cache"
+npm ci --ignore-scripts --prefer-offline --no-audit --no-fund --cache "$npm_cache"
+npm --prefix nemoclaw ci --ignore-scripts --prefer-offline --no-audit --no-fund --cache "$npm_cache"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -160,7 +160,7 @@ jobs:
           cache: npm
 
       - name: Install test dependencies
-        run: npm ci --ignore-scripts
+        run: npm ci --ignore-scripts --no-audit --no-fund
 
       - name: Build generated harness inputs
         run: npm run build:policy-boundary && npm run catalog:compile

--- a/.github/workflows/managed-images.yaml
+++ b/.github/workflows/managed-images.yaml
@@ -122,6 +122,7 @@ jobs:
         with:
           target-root: ${{ github.workspace }}/candidate
           report-dir: artifacts/reviewed-npm-audit
+          cache-directory: ${{ runner.temp }}/reviewed-npm-audit-cache
 
   pr-staging-qa-deep-code:
     name: Staging QA base permission regression (Deep Agents Code)
@@ -765,7 +766,7 @@ jobs:
 
       - name: Install managed-image direct harness dependencies
         run: |
-          npm ci --ignore-scripts
+          npm ci --ignore-scripts --no-audit --no-fund
           npm run build:policy-boundary
 
       - name: Exercise managed startup root stdin and hold
@@ -965,7 +966,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          npm ci --ignore-scripts
+          npm ci --ignore-scripts --no-audit --no-fund
           mapfile -d '' contracts < <(
             find "$RUNNER_TEMP/managed-pr-contracts" -type f -name contract.json -print0
           )
@@ -1067,7 +1068,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          npm ci --ignore-scripts
+          npm ci --ignore-scripts --no-audit --no-fund
           mapfile -d '' contracts < <(
             find "$RUNNER_TEMP/managed-pr-contracts" -type f -name contract.json -print0
           )
@@ -1894,7 +1895,7 @@ jobs:
 
       - name: Install managed-image publication harness dependencies
         run: |
-          npm ci --ignore-scripts
+          npm ci --ignore-scripts --no-audit --no-fund
           npm run build:policy-boundary
 
       - name: Validate exact managed image before promotion

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -67,7 +67,7 @@ jobs:
           cache: npm
 
       - name: Install docs-only check dependencies
-        run: npm install --ignore-scripts
+        run: npm install --ignore-scripts --no-audit --no-fund
 
       - name: Install hadolint
         shell: bash
@@ -162,7 +162,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci --ignore-scripts
+        run: npm ci --ignore-scripts --no-audit --no-fund
 
       - name: Verify Hugging Face model references
         run: npm run catalog:verify-hugging-face
@@ -552,6 +552,7 @@ jobs:
         with:
           target-root: ${{ github.workspace }}
           report-dir: artifacts/reviewed-npm-audit
+          cache-directory: ${{ runner.temp }}/reviewed-npm-audit-cache
 
   cli-test-shards:
     needs: [changes, compile-artifacts, openshell-sdk-package]

--- a/test/automation/pull-requests/pr-workflow-contract.test.ts
+++ b/test/automation/pull-requests/pr-workflow-contract.test.ts
@@ -514,7 +514,7 @@ describe("pull request and main workflow contracts", () => {
     expect(stepUses(job)).toEqual([trustedCheckoutAction, trustedSetupNodeAction]);
     expect(requiredWorkflowStep(job, "Checkout").with?.["persist-credentials"]).toBe(false);
     expect(requiredWorkflowStep(job, "Install dependencies").run).toBe(
-      "npm ci --ignore-scripts",
+      "npm ci --ignore-scripts --no-audit --no-fund",
     );
     expect(requiredWorkflowStep(job, "Verify Hugging Face model references").run).toBe(
       "npm run catalog:verify-hugging-face",

--- a/test/inference/managed/managed-image-publication-workflow.test.ts
+++ b/test/inference/managed/managed-image-publication-workflow.test.ts
@@ -136,8 +136,8 @@ describe("complete managed-image publication workflow", () => {
     const prAudit = step(required(readWorkflow("pr.yaml").jobs?.["reviewed-npm-audit"], "missing PR audit"), "Audit reviewed production npm graphs");
     const mainAudit = step(required(readWorkflow("main.yaml").jobs?.["reviewed-npm-audit"], "missing main audit"), "Audit reviewed production npm graphs");
     const managedAudit = step(managedPrReviewedAudit(readWorkflow("managed-images.yaml")), "Audit exact PR production npm graphs");
-    expect(prAudit.with?.["cache-directory"]).toBeUndefined();
-    expect(managedAudit.with?.["cache-directory"]).toBeUndefined();
+    expect(prAudit.with?.["cache-directory"]).toBe("${{ runner.temp }}/reviewed-npm-audit-cache");
+    expect(managedAudit.with?.["cache-directory"]).toBe("${{ runner.temp }}/reviewed-npm-audit-cache");
     expect(prAudit.with?.["trusted-cache-write"]).toBeUndefined();
     expect(managedAudit.with?.["trusted-cache-write"]).toBeUndefined();
     expect(mainAudit.with).toMatchObject({
@@ -441,6 +441,7 @@ describe("complete managed-image publication workflow", () => {
     expect(step(reviewedAudit, "Audit exact PR production npm graphs")).toMatchObject({
       uses: "./.trusted-reviewed-npm-audit/.github/actions/ci-reviewed-npm-audit",
       with: {
+        "cache-directory": "${{ runner.temp }}/reviewed-npm-audit-cache",
         "report-dir": "artifacts/reviewed-npm-audit",
         "target-root": "${{ github.workspace }}/candidate",
       },
@@ -719,7 +720,7 @@ describe("complete managed-image publication workflow", () => {
       "${{ github.event.pull_request.head.sha }}",
     );
     expect(step(activation, "Assemble exact all-agent activation catalog").run).toMatch(
-      /npm ci --ignore-scripts[\s\S]*pr-managed-image-publication\.mts assemble[\s\S]*"\$CANDIDATE_SHA"[\s\S]*"\$\{contracts\[@\]\}"/u,
+      /npm ci --ignore-scripts --no-audit --no-fund[\s\S]*pr-managed-image-publication\.mts assemble[\s\S]*"\$CANDIDATE_SHA"[\s\S]*"\$\{contracts\[@\]\}"/u,
     );
     expect(step(activation, "Build exact candidate CLI").run).toContain("npm run build:cli");
     expect(step(activation, "Install OpenShell CLI").run).toContain("scripts/install-openshell.sh");
@@ -772,7 +773,7 @@ describe("complete managed-image publication workflow", () => {
     expect(step(discovery, "Bind E2E correlation identity").run).toContain("randomUUID()");
     const assemble = step(discovery, "Assemble exact all-agent MCP catalog").run ?? "";
     expect(assemble).toMatch(
-      /npm ci --ignore-scripts[\s\S]*pr-managed-image-publication\.mts assemble[\s\S]*"\$CANDIDATE_SHA"[\s\S]*"\$\{contracts\[@\]\}"/u,
+      /npm ci --ignore-scripts --no-audit --no-fund[\s\S]*pr-managed-image-publication\.mts assemble[\s\S]*"\$CANDIDATE_SHA"[\s\S]*"\$\{contracts\[@\]\}"/u,
     );
     const run = step(discovery, "Run exact OpenClaw managed-image MCP discovery").run ?? "";
     expect(run).toContain('[[ "$(git rev-parse --verify HEAD)" == "$CANDIDATE_SHA" ]]');
@@ -1016,6 +1017,7 @@ fi
     const validate = step(publisher, "Validate exact managed image before promotion");
     const evidence = step(publisher, "Capture exact managed image publication evidence");
     const dependencies = step(publisher, "Install managed-image publication harness dependencies");
+    expect(dependencies.run).toContain("npm ci --ignore-scripts --no-audit --no-fund");
     expect(releaseIdentity.id).toBe("release");
     expect(releaseIdentity.run).toContain("git describe --tags --match 'v*' \"$GITHUB_SHA\"");
     expect(releaseIdentity.run).toContain("managed image release identity does not match");

--- a/test/repository/ci-install-dependencies.test.ts
+++ b/test/repository/ci-install-dependencies.test.ts
@@ -66,8 +66,8 @@ describe("shared CI dependency installer", () => {
 
     expect(result.status, result.stderr).toBe(0);
     expect(readFileSync(fixture.trace, "utf8").trim().split("\n")).toEqual([
-      `ci --ignore-scripts --prefer-offline --cache ${join(fixture.root, "npm-cache")}`,
-      `--prefix nemoclaw ci --ignore-scripts --prefer-offline --cache ${join(fixture.root, "npm-cache")}`,
+      `ci --ignore-scripts --prefer-offline --no-audit --no-fund --cache ${join(fixture.root, "npm-cache")}`,
+      `--prefix nemoclaw ci --ignore-scripts --prefer-offline --no-audit --no-fund --cache ${join(fixture.root, "npm-cache")}`,
     ]);
   });
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

Trusted pull request audit jobs now restore reviewed npm audit evidence without triggering redundant install-time advisory requests in CI paths that already have explicit reviewed audit coverage.

## Reason

PR #11029 landed the cache-aware trusted action, so its PR callers can now pass cache-directory safely. Ordinary npm installs in the same reviewed CI paths should not make separate best-effort advisory calls.

### Related issues

Refs #11028

## Changes

- Enable cache-directory for the trusted PR and managed-image reviewed-audit action callers.
- Disable npm's implicit install-time audit and funding requests in shared CI dependency installation and reviewed main/PR/managed-image workflows.
- Update workflow and installer contracts to protect cache input compatibility and no-audit install arguments.

## Verification

- Contributor validation: Commit hooks and npm run validate:pr passed.
- Tests: Focused integration and E2E-support workflow tests: 130 passed. npm run typecheck:cli passed after npm run build:cli. npm run validate:pr passed.
- Broad gate: npm run validate:pr passed.
- Secrets review: The diff contains no secrets, API keys, or credentials

---

Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency installation to skip npm audit checks and funding notices.
  * Added a temporary cache location for reviewed npm audit jobs.
* **Tests**
  * Updated workflow validation to verify the revised dependency installation and audit-cache settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->