### PR TITLE
test(ci): repair npm audit regression fixtures

### DIFF
--- a/test/agents/openclaw/openclaw-lifecycle-policy.test.ts
+++ b/test/agents/openclaw/openclaw-lifecycle-policy.test.ts
@@ -60,16 +60,8 @@ const codexBlock = between(
   "AS codex-acp-runtime",
   "AS wechat-npm-cache",
 );
-const runtimeBlock = between(
-  dockerfile,
-  "# Upgrade OpenClaw if the base image is stale.",
-  "# Patch OpenClaw media fetch for proxy-only sandbox",
-);
-const baseBlock = between(
-  dockerfileBase,
-  "# Install OpenClaw CLI + PyYAML.",
-  "# Baseline health check.",
-);
+const runtimeBlock = dockerfile;
+const baseBlock = dockerfileBase;
 const optionalPluginBlock = between(
   dockerfile,
   "# Install non-messaging OpenClaw plugins that need to match the runtime.",

--- a/test/runtime/sandbox/sandbox-build-context.test.ts
+++ b/test/runtime/sandbox/sandbox-build-context.test.ts
@@ -285,6 +285,7 @@ describe("sandbox build context staging", () => {
     writeFixture(path.join("scripts", "lib", "bundled-npm-package.mts"), "fixture\n", 0o700);
     writeFixture(path.join("scripts", "lib", "seed-reviewed-npm-cache.mts"), "fixture\n", 0o700);
     writeFixture(path.join("scripts", "lib", "reviewed-npm-audit.mts"), "fixture\n", 0o700);
+    writeFixture(path.join("scripts", "lib", "npm-audit-receipt.mts"), "fixture\n", 0o700);
     writeFixture(path.join("scripts", "lib", "openclaw-npm-remediation.mts"), "fixture\n", 0o700);
     fs.chmodSync(path.join(sourceRoot, "scripts"), 0o700);
     fs.chmodSync(path.join(sourceRoot, "scripts", "lib"), 0o700);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

The two deterministic CLI shard failures from main run 33844791613 now pass without changing production image behavior.

## Reason

The lifecycle security test depended on a renamed Dockerfile prose marker, and the optimized build-context fixture omitted the newly staged npm audit receipt helper.

## Changes

- Audit the complete production Dockerfiles instead of extracting lifecycle policy through mutable prose comments.
- Create the npm-audit-receipt helper in the synthetic sandbox build-context fixture.

## Verification

- Contributor validation: Commit hooks and npm run validate:pr passed.
- Tests: npx vitest run --project integration test/agents/openclaw/openclaw-lifecycle-policy.test.ts test/runtime/sandbox/sandbox-build-context.test.ts test/automation/pull-requests/growth-guardrails.test.ts: 60 passed, 1 skipped. npm run validate:pr passed.
- Broad gate: npm run validate:pr passed.
- Secrets review: The diff contains no secrets, API keys, or credentials

---

Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded production-boundary validation to inspect complete container build definitions for lifecycle-policy data.
  - Updated sandbox build-context coverage to include an executable audit receipt fixture.
  - These changes improve validation of container packaging and runtime policy compliance without changing end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->