### PR TITLE
fix(ci): allow one long npm audit retry

### DIFF
--- a/scripts/lib/reviewed-npm-audit.mts
+++ b/scripts/lib/reviewed-npm-audit.mts
@@ -100,8 +100,8 @@ const GRAPH_ID = /^[a-z0-9]+(?:-[a-z0-9]+)*$/u;
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/u;
 const MAX_EXCEPTION_LIFETIME_DAYS = 30;
 const GHSA_ID_IN_URL = /GHSA(?:-[23456789cfghjmpqrvwx]{4}){3}/gi;
-export const NPM_AUDIT_ATTEMPT_TIMEOUT_MS = 180_000;
-const NPM_AUDIT_RETRY_DELAYS_MS = [1_000, 2_000] as const;
+export const NPM_AUDIT_ATTEMPT_TIMEOUT_MS = 600_000;
+const NPM_AUDIT_RETRY_DELAYS_MS = [1_000] as const;
 export const NPM_AUDIT_REGISTRY = "https://registry.yarnpkg.com";
 export const NPM_AUDIT_ARGV = [
   "audit",
@@ -111,6 +111,17 @@ export const NPM_AUDIT_ARGV = [
 ] as const;
 export const NPM_AUDIT_CACHE_MAX_AGE_MS = 12 * 60 * 60 * 1000;
 export const NPM_AUDIT_CACHE_FUTURE_SKEW_MS = 5 * 60 * 1000;
+
+export function npmAuditProcessOptions(directory: string) {
+  return {
+    cwd: directory,
+    encoding: "utf-8" as const,
+    env: { ...process.env, NPM_CONFIG_UPDATE_NOTIFIER: "false" },
+    maxBuffer: 64 * 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"] as ["ignore", "pipe", "pipe"],
+    timeout: NPM_AUDIT_ATTEMPT_TIMEOUT_MS,
+  };
+}
 const NPM_AUDIT_CACHE_MAX_BYTES = 64 * 1024 * 1024;
 const NPM_AUDIT_CACHE_SCHEMA_VERSION = 1;
 const NPM_AUDIT_PARSER_IDENTITY = "reviewed-npm-audit-report-v1";
@@ -877,14 +888,7 @@ export function runReviewedNpmAudit(
     ? runNpmAuditWithRetry({ run: () => cached.result, wait: () => {}, warn: () => {} })
     : runNpmAuditWithRetry({
         run: () =>
-          spawnSync("npm", NPM_AUDIT_ARGV, {
-            cwd: options.directory,
-            encoding: "utf-8",
-            env: { ...process.env, NPM_CONFIG_UPDATE_NOTIFIER: "false" },
-            maxBuffer: 64 * 1024 * 1024,
-            stdio: ["ignore", "pipe", "pipe"],
-            timeout: NPM_AUDIT_ATTEMPT_TIMEOUT_MS,
-          }),
+          spawnSync("npm", NPM_AUDIT_ARGV, npmAuditProcessOptions(options.directory)),
       });
   const finishedAt = new Date().toISOString();
   if (!cached && cacheFile && cacheInput && audit.report)

--- a/test/automation/releases/reviewed-npm-audit.test.ts
+++ b/test/automation/releases/reviewed-npm-audit.test.ts
@@ -19,6 +19,7 @@ import {
   exceedsAuditThreshold,
   extractAdvisoryIds,
   parseAuditExceptionRegistry,
+  npmAuditProcessOptions,
   parseAuditReport,
   provenanceSidecarPath,
   readAuditCache,
@@ -183,17 +184,8 @@ describe("reviewed npm audit gate", () => {
     };
     const sensitiveStderr =
       "request failed for https://audit-user:secret-token@registry.example/\n\u001b[31mstderr detail";
-    const sensitiveErrorBody = {
-      summary: "request failed for https://json-user:json-secret@registry.example/",
-      detail: "first line\n\u001b[31msecond line",
-    };
     const responses = [
       { status: 1, stderr: sensitiveStderr, stdout: "" },
-      {
-        status: 1,
-        stderr: "",
-        stdout: JSON.stringify({ error: sensitiveErrorBody }),
-      },
       { status: 0, stderr: "", stdout: JSON.stringify(completeReport) },
     ];
     const delays: number[] = [];
@@ -206,22 +198,19 @@ describe("reviewed npm audit gate", () => {
       warn: (message) => warnings.push(message),
     });
 
-    expect(attempt).toBe(3);
-    expect(delays).toEqual([1_000, 2_000]);
+    expect(attempt).toBe(2);
+    expect(delays).toEqual([1_000]);
     expect(warnings).toEqual([
-      "npm audit scan incomplete on attempt 1/3; retrying in 1000 ms (reason=empty-output)",
-      "npm audit scan incomplete on attempt 2/3; retrying in 2000 ms (reason=incomplete-report)",
+      "npm audit scan incomplete on attempt 1/2; retrying in 1000 ms (reason=empty-output)",
     ]);
     const warningOutput = warnings.join("\n");
     expect(warningOutput).not.toContain("audit-user");
     expect(warningOutput).not.toContain("secret-token");
-    expect(warningOutput).not.toContain("json-user");
-    expect(warningOutput).not.toContain("json-secret");
     expect(warningOutput).not.toContain("registry.example");
     expect(warningOutput).not.toContain("\u001b");
     expect(audit.failure).toBeUndefined();
     expect(audit.report).toEqual(completeReport);
-    expect(audit.result).toEqual(responses[2]);
+    expect(audit.result).toEqual(responses[1]);
   });
 
   it("does not retry a complete blocking vulnerability report", () => {
@@ -258,8 +247,12 @@ describe("reviewed npm audit gate", () => {
     });
   });
 
-  it("allows one slow advisory response to complete within a three-minute attempt", () => {
-    expect(NPM_AUDIT_ATTEMPT_TIMEOUT_MS).toBe(180_000);
+  it("gives each audit process ten minutes to complete", () => {
+    expect(NPM_AUDIT_ATTEMPT_TIMEOUT_MS).toBe(600_000);
+    expect(npmAuditProcessOptions("/tmp/audit-graph")).toMatchObject({
+      cwd: "/tmp/audit-graph",
+      timeout: 600_000,
+    });
   });
 
   it("retries a timed-out scanner process within the same budget", () => {
@@ -279,7 +272,7 @@ describe("reviewed npm audit gate", () => {
         },
       }),
     };
-    const responses = [timeoutResult, timeoutResult, completeResult];
+    const responses = [timeoutResult, completeResult];
     let attempts = 0;
 
     const audit = runNpmAuditWithRetry({
@@ -288,8 +281,8 @@ describe("reviewed npm audit gate", () => {
       warn: () => {},
     });
 
-    expect(attempts).toBe(3);
-    expect(delays).toEqual([1_000, 2_000]);
+    expect(attempts).toBe(2);
+    expect(delays).toEqual([1_000]);
     expect(audit.failure).toBeUndefined();
   });
 
@@ -342,11 +335,11 @@ describe("reviewed npm audit gate", () => {
       warn: () => {},
     });
 
-    expect(attempts).toBe(3);
-    expect(delays).toEqual([1_000, 2_000]);
+    expect(attempts).toBe(2);
+    expect(delays).toEqual([1_000]);
     expect(audit.report).toBeUndefined();
     expect(audit.failure?.message).toBe(
-      "npm audit scan remained incomplete after 3 attempts (reason=incomplete-report)",
+      "npm audit scan remained incomplete after 2 attempts (reason=incomplete-report)",
     );
     expect(audit.failure?.message).not.toContain("terminal-stderr-secret");
     expect(audit.failure?.message).not.toContain("terminal-summary-secret");
@@ -727,12 +720,12 @@ describe("reviewed npm audit provenance", () => {
           reportFile: reportPath,
           threshold: "high",
         }),
-      ).toThrow("npm audit scan remained incomplete after 3 attempts (reason=incomplete-report)");
+      ).toThrow("npm audit scan remained incomplete after 2 attempts (reason=incomplete-report)");
       const sidecar = JSON.parse(
         fs.readFileSync(path.join(tempRoot, "graph.provenance.json"), "utf-8"),
       ) as Record<string, unknown>;
       expect(sidecar.failure).toBe(
-        "npm audit scan remained incomplete after 3 attempts (reason=incomplete-report)",
+        "npm audit scan remained incomplete after 2 attempts (reason=incomplete-report)",
       );
       expect(sidecar.failure).not.toContain("ECONNREFUSED");
       expect(sidecar.failure).not.toContain("registry unreachable");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

Reviewed npm audits get enough uninterrupted time to finish on GitHub-hosted runners while retaining one bounded retry.

## Reason

Three separate three-minute attempts all timed out on Main. A terminal request completed in 75 to 90 seconds, but restarting slow requests discards their progress. Two ten-minute attempts keep roughly the requested 20-minute upper bound while favoring completion over repeated restarts.

## Changes

- Increase each npm audit process deadline from three minutes to ten minutes.
- Reduce the retry policy from three total attempts to two total attempts.
- Test the timeout at the spawned-process option boundary and update retry, exhaustion, and provenance expectations.

## Verification

- Tests: npx vitest run --project integration test/automation/releases/reviewed-npm-audit.test.ts — 41 passed.
- Contributor validation: npm run validate:pr passed against canonical main 969df32c1d6367cb7b3bd4ea958b6133743d8941.
- Local Advisor: attempted; unavailable because PR_REVIEW_ADVISOR_API_KEY is not configured.
- Secrets review: The diff contains no secrets, API keys, or credentials.

---

Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Dependency security audits now allow up to 10 minutes per attempt, improving reliability for slower audit runs.
  - Audit checks now retry once when needed, with clearer retry and failure reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->