### PR TITLE
fix(ci): fit jobs to npm audit budget

### DIFF
--- a/.github/workflows/base-image.yaml
+++ b/.github/workflows/base-image.yaml
@@ -109,7 +109,7 @@ jobs:
   reviewed-npm-audit:
     if: github.repository == 'NVIDIA/NemoClaw'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     permissions:
       contents: read
     steps:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -123,7 +123,7 @@ jobs:
 
   reviewed-npm-audit:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/managed-images.yaml
+++ b/.github/workflows/managed-images.yaml
@@ -77,7 +77,7 @@ jobs:
     name: PR reviewed npm audit
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     permissions:
       contents: read
     steps:
@@ -1572,7 +1572,7 @@ jobs:
     name: Reviewed npm audit for managed image publication
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     permissions:
       contents: read
     steps:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -523,7 +523,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/scripts/lib/reviewed-npm-audit.mts
+++ b/scripts/lib/reviewed-npm-audit.mts
@@ -101,7 +101,7 @@ const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/u;
 const MAX_EXCEPTION_LIFETIME_DAYS = 30;
 const GHSA_ID_IN_URL = /GHSA(?:-[23456789cfghjmpqrvwx]{4}){3}/gi;
 export const NPM_AUDIT_ATTEMPT_TIMEOUT_MS = 600_000;
-const NPM_AUDIT_RETRY_DELAYS_MS = [1_000] as const;
+export const NPM_AUDIT_RETRY_DELAYS_MS = [1_000] as const;
 export const NPM_AUDIT_REGISTRY = "https://registry.yarnpkg.com";
 export const NPM_AUDIT_ARGV = [
   "audit",

--- a/test/automation/releases/reviewed-npm-audit.test.ts
+++ b/test/automation/releases/reviewed-npm-audit.test.ts
@@ -11,6 +11,7 @@ import {
   NPM_AUDIT_ATTEMPT_TIMEOUT_MS,
   NPM_AUDIT_CACHE_FUTURE_SKEW_MS,
   NPM_AUDIT_CACHE_MAX_AGE_MS,
+  NPM_AUDIT_RETRY_DELAYS_MS,
   assertExceptionGraphs,
   buildAuditCacheInput,
   buildAuditProvenance,
@@ -28,6 +29,7 @@ import {
   runReviewedNpmAudit,
   vulnerabilityCounts,
 } from "../../../scripts/lib/reviewed-npm-audit.mts";
+import { reviewedNpmAuditWorkflowDeadlines } from "../../helpers/reviewed-npm-audit-workflow";
 
 const REPO_ROOT = path.join(import.meta.dirname, "../../..");
 const CONFIG = JSON.parse(
@@ -253,6 +255,22 @@ describe("reviewed npm audit gate", () => {
       cwd: "/tmp/audit-graph",
       timeout: 600_000,
     });
+  });
+
+  it("gives every audit workflow enough time for both attempts and evidence upload", () => {
+    const retryBudgetMs =
+      NPM_AUDIT_ATTEMPT_TIMEOUT_MS * (NPM_AUDIT_RETRY_DELAYS_MS.length + 1) +
+      NPM_AUDIT_RETRY_DELAYS_MS.reduce((total, delay) => total + delay, 0);
+    const minimumJobTimeoutMinutes = Math.ceil(retryBudgetMs / 60_000) + 4;
+    const callers = reviewedNpmAuditWorkflowDeadlines(
+      path.join(REPO_ROOT, ".github", "workflows"),
+    );
+
+    expect(callers).toHaveLength(5);
+    expect(callers.map(({ timeoutMinutes }) => timeoutMinutes)).toEqual([25, 25, 25, 25, 25]);
+    expect(Math.min(...callers.map(({ timeoutMinutes }) => timeoutMinutes))).toBeGreaterThanOrEqual(
+      minimumJobTimeoutMinutes,
+    );
   });
 
   it("retries a timed-out scanner process within the same budget", () => {

--- a/test/helpers/reviewed-npm-audit-workflow.ts
+++ b/test/helpers/reviewed-npm-audit-workflow.ts
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+import YAML from "yaml";
+
+type Workflow = {
+  jobs?: Record<string, { steps?: Array<{ uses?: string }>; "timeout-minutes"?: number }>;
+};
+
+export function reviewedNpmAuditWorkflowDeadlines(workflowDirectory: string) {
+  const callers: Array<{ job: string; timeoutMinutes: number; workflow: string }> = [];
+  const workflowFiles = fs.readdirSync(workflowDirectory).filter((file) => /\.ya?ml$/u.test(file));
+  for (const workflow of workflowFiles) {
+    const parsed = YAML.parse(
+      fs.readFileSync(path.join(workflowDirectory, workflow), "utf-8"),
+    ) as Workflow;
+    for (const [job, definition] of Object.entries(parsed.jobs ?? {})) {
+      if (definition.steps?.some((step) => step.uses?.includes("ci-reviewed-npm-audit"))) {
+        callers.push({ job, timeoutMinutes: definition["timeout-minutes"] ?? 0, workflow });
+      }
+    }
+  }
+  return callers;
+}


### PR DESCRIPTION
## Outcome

Every workflow that invokes the reviewed npm audit now permits the complete two-attempt audit policy to finish and publish evidence.

## Reason

PR #11059 increased the scanner policy to two ten-minute attempts, but the five caller jobs retained 15-minute job deadlines. A job could terminate midway through the retry before the action wrote its report and provenance.

## Changes

- Increase all five reviewed npm audit caller deadlines from 15 to 25 minutes.
- Export the retry schedule so the workflow contract derives the complete process budget.
- Add a workflow discovery helper and regression test covering all current action callers plus four minutes for setup and evidence publication.

## Verification

- Tests: npx vitest run --project integration test/automation/releases/reviewed-npm-audit.test.ts — 42 passed.
- Contributor validation: npm run validate:pr passed against canonical main 1c90d4fa04c6f388b2dd55b1922587cb9edc634e.
- Review: addresses the Delivery and workflow causality finding from PR #11059.
- Secrets review: The diff contains no secrets, API keys, or credentials.

## DCO Sign-Off

Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Extended npm audit workflow timeouts from 15 to 25 minutes, allowing additional time for retries and evidence uploads.

* **Tests**
  * Added coverage to verify that all relevant audit workflows use the updated 25-minute timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->