### PR TITLE
fix(ci): cover sequential npm audit budget

### DIFF
--- a/.github/workflows/base-image.yaml
+++ b/.github/workflows/base-image.yaml
@@ -109,7 +109,7 @@ jobs:
   reviewed-npm-audit:
     if: github.repository == 'NVIDIA/NemoClaw'
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 135
     permissions:
       contents: read
     steps:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -123,7 +123,7 @@ jobs:
 
   reviewed-npm-audit:
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 135
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/managed-images.yaml
+++ b/.github/workflows/managed-images.yaml
@@ -77,7 +77,7 @@ jobs:
     name: PR reviewed npm audit
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 135
     permissions:
       contents: read
     steps:
@@ -1572,7 +1572,7 @@ jobs:
     name: Reviewed npm audit for managed image publication
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 135
     permissions:
       contents: read
     steps:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -523,7 +523,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 135
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/ci/source-shape-test-budget.json
+++ b/ci/source-shape-test-budget.json
@@ -260,6 +260,11 @@
       "file": "test/runtime/policy/repro-5978-policy-denial-hint.test.ts",
       "test": "prints only once when the file is sourced twice in one login shell",
       "category": "compatibility"
+    },
+    {
+      "file": "test/automation/releases/reviewed-npm-audit.test.ts",
+      "test": "gives every audit workflow enough time for both attempts and evidence upload",
+      "category": "compatibility"
     }
   ]
 }

--- a/test/automation/releases/reviewed-npm-audit.test.ts
+++ b/test/automation/releases/reviewed-npm-audit.test.ts
@@ -35,6 +35,7 @@ const REPO_ROOT = path.join(import.meta.dirname, "../../..");
 const CONFIG = JSON.parse(
   fs.readFileSync(path.join(REPO_ROOT, "ci", "reviewed-npm-audit.json"), "utf-8"),
 ) as {
+  lockedGraphs: unknown[];
   severityThreshold: "info" | "low" | "moderate" | "high" | "critical";
 };
 const CHECKED_IN_POLICY = parseAuditExceptionRegistry(
@@ -257,17 +258,21 @@ describe("reviewed npm audit gate", () => {
     });
   });
 
+  // source-shape-contract: compatibility -- Every audit caller must preserve enough job time for all configured graphs to exhaust the reviewed retry policy and publish evidence
   it("gives every audit workflow enough time for both attempts and evidence upload", () => {
-    const retryBudgetMs =
+    const graphCount = CONFIG.lockedGraphs.length + 2;
+    const retryBudgetPerGraphMs =
       NPM_AUDIT_ATTEMPT_TIMEOUT_MS * (NPM_AUDIT_RETRY_DELAYS_MS.length + 1) +
       NPM_AUDIT_RETRY_DELAYS_MS.reduce((total, delay) => total + delay, 0);
-    const minimumJobTimeoutMinutes = Math.ceil(retryBudgetMs / 60_000) + 4;
+    const setupAndEvidenceAllowanceMinutes = 10;
+    const minimumJobTimeoutMinutes =
+      Math.ceil((retryBudgetPerGraphMs * graphCount) / 60_000) + setupAndEvidenceAllowanceMinutes;
     const callers = reviewedNpmAuditWorkflowDeadlines(
       path.join(REPO_ROOT, ".github", "workflows"),
     );
 
     expect(callers).toHaveLength(5);
-    expect(callers.map(({ timeoutMinutes }) => timeoutMinutes)).toEqual([25, 25, 25, 25, 25]);
+    expect(callers.map(({ timeoutMinutes }) => timeoutMinutes)).toEqual([135, 135, 135, 135, 135]);
     expect(Math.min(...callers.map(({ timeoutMinutes }) => timeoutMinutes))).toBeGreaterThanOrEqual(
       minimumJobTimeoutMinutes,
     );

--- a/test/inference/managed/managed-image-publication-workflow.test.ts
+++ b/test/inference/managed/managed-image-publication-workflow.test.ts
@@ -207,7 +207,7 @@ describe("complete managed-image publication workflow", () => {
       if: "github.repository == 'NVIDIA/NemoClaw'",
       permissions: { contents: "read" },
       "runs-on": "ubuntu-latest",
-      "timeout-minutes": 15,
+      "timeout-minutes": 135,
     });
     expect(step(reviewedAudit, "Checkout").with?.["persist-credentials"]).toBe(false);
     expect(step(reviewedAudit, "Audit reviewed production npm graphs")).toMatchObject({
@@ -410,7 +410,7 @@ describe("complete managed-image publication workflow", () => {
       if: "github.event_name == 'pull_request'",
       permissions: { contents: "read" },
       "runs-on": "ubuntu-latest",
-      "timeout-minutes": 15,
+      "timeout-minutes": 135,
     });
     const candidateCheckout = step(reviewedAudit, "Checkout commit under review");
     expect(candidateCheckout.with).toMatchObject({


### PR DESCRIPTION
## Outcome

Reviewed npm audit jobs can exhaust the retry policy for every sequential graph and still publish diagnostics.

## Reason

PR #11062 budgeted one graph, but the action audits six graphs sequentially. Its 25-minute deadline could still cancel the job without complete evidence.

## Changes

- Increase all five caller deadlines to 135 minutes.
- Derive the minimum deadline from the configured graph count, per-graph retry budget, and a ten-minute setup/evidence reserve.
- Update the existing managed-image workflow deadline contracts and register the compatibility assertion.

## Verification

- Focused integration tests: 78 passed.
- npm run validate:pr passed against canonical main d6e85434ed50255188044652f6f8992c7e052d72.
- Addresses the Delivery, Operability, and Architecture findings from PR #11062.
- The diff contains no secrets, API keys, or credentials.

## DCO Sign-Off

Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the npm audit workflow timeout to 135 minutes across supported automation workflows.
  * Updated validation and compatibility checks to reflect the longer audit duration.
* **Tests**
  * Adjusted workflow coverage to account for retries, locked graphs, and setup or evidence-upload time.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->