### PR TITLE
fix(ci): restore reviewed npm cache permissions

### DIFF
--- a/scripts/audit-reviewed-npm-graph.mts
+++ b/scripts/audit-reviewed-npm-graph.mts
@@ -673,25 +673,29 @@ function verifyWechatInstallCacheBoundary(
   });
   if (cache.error) throw cache.error;
   if (cache.status !== 0) throw new Error(`npm cache add failed: ${cache.stderr || cache.stdout}`);
-  fs.chmodSync(trustedCache, 0o555);
-  for (const entry of fs.readdirSync(trustedCache, { recursive: true })) {
-    fs.chmodSync(
-      path.join(trustedCache, entry.toString()),
-      fs.lstatSync(path.join(trustedCache, entry.toString())).isDirectory() ? 0o555 : 0o444,
-    );
+  try {
+    fs.chmodSync(trustedCache, 0o555);
+    for (const entry of fs.readdirSync(trustedCache, { recursive: true })) {
+      fs.chmodSync(
+        path.join(trustedCache, entry.toString()),
+        fs.lstatSync(path.join(trustedCache, entry.toString())).isDirectory() ? 0o555 : 0o444,
+      );
+    }
+    assertTreeReadOnly(trustedCache);
+    fs.cpSync(trustedCache, installCache, { recursive: true, force: true });
+    makeTreeOwnerWritable(installCache);
+    packReviewedNpmArchive({
+      env: { ...env, NPM_CONFIG_CACHE: installCache, NPM_CONFIG_OFFLINE: "true" },
+      expectedIntegrity: graph.integrity,
+      label: graph.label,
+      packageSpec: graph.packageSpec,
+      tarballUrl: graph.tarballUrl,
+      tempDirectory: packDirectory,
+    });
+    assertTreeReadOnly(trustedCache);
+  } finally {
+    makeTreeOwnerWritable(trustedCache);
   }
-  assertTreeReadOnly(trustedCache);
-  fs.cpSync(trustedCache, installCache, { recursive: true, force: true });
-  makeTreeOwnerWritable(installCache);
-  packReviewedNpmArchive({
-    env: { ...env, NPM_CONFIG_CACHE: installCache, NPM_CONFIG_OFFLINE: "true" },
-    expectedIntegrity: graph.integrity,
-    label: graph.label,
-    packageSpec: graph.packageSpec,
-    tarballUrl: graph.tarballUrl,
-    tempDirectory: packDirectory,
-  });
-  assertTreeReadOnly(trustedCache);
 }
 
 function auditLockedGraph(

--- a/test/automation/releases/reviewed-npm-audit-workflow.test.ts
+++ b/test/automation/releases/reviewed-npm-audit-workflow.test.ts
@@ -55,6 +55,7 @@ type ConsolidatedAuditFixture = Readonly<{
   lockedPackageLock: Buffer;
   provenance?: Record<string, unknown>;
   result: ReturnType<typeof spawnSync>;
+  trustedCacheModes?: { directory: number; entry: number };
 }>;
 
 function runConsolidatedAuditFixture(
@@ -64,11 +65,13 @@ function runConsolidatedAuditFixture(
     metadata: { vulnerabilities: { info: 0, low: 0, moderate: 0, high: 0, critical: 0 } },
   }),
   auditStatus = 0,
+  offlinePackStatus = 0,
 ): ConsolidatedAuditFixture {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-reviewed-audit-entry-"));
   const trustedRoot = path.join(root, "trusted");
   const targetRoot = path.join(root, "target");
   const bin = path.join(root, "bin");
+  const cacheModesFile = path.join(root, "cache-modes");
   const callsFile = path.join(root, "npm-calls");
   const artifactDirectory = path.join(targetRoot, "artifacts", "reviewed-npm-audit");
   try {
@@ -164,6 +167,15 @@ if (args[0] === "view") {
   process.exit(0);
 }
 if (args[0] === "pack") {
+  if (process.env.NPM_CONFIG_OFFLINE === "true") {
+    const trustedCache = process.env.NPM_CONFIG_CACHE.replace(/wechat-install-cache$/, "wechat-trusted-cache");
+    fs.writeFileSync(process.env.NEMOCLAW_TEST_CACHE_MODES_FILE, JSON.stringify({
+      directory: fs.statSync(trustedCache).mode & 0o777,
+      entry: fs.statSync(trustedCache + "/_cacache/fixture").mode & 0o777,
+    }));
+    const status = Number(process.env.NEMOCLAW_TEST_OFFLINE_PACK_STATUS);
+    if (status !== 0) { console.error("simulated offline pack failure"); process.exit(status); }
+  }
   const destination = args[args.indexOf("--pack-destination") + 1];
   const filename = "fixture.tgz";
   fs.writeFileSync(destination + "/" + filename, "fixture");
@@ -207,7 +219,7 @@ process.exit(0);
       process.execPath,
       [
         "--experimental-strip-types",
-        path.join(trustedRoot, "scripts/audit-reviewed-npm-graph.mts"),
+        fs.realpathSync(path.join(trustedRoot, "scripts/audit-reviewed-npm-graph.mts")),
       ],
       {
         cwd: trustedRoot,
@@ -218,7 +230,9 @@ process.exit(0);
           NEMOCLAW_REVIEWED_NPM_AUDIT_TARGET_ROOT: targetRoot,
           NEMOCLAW_TEST_AUDIT_OUTPUT: auditOutput,
           NEMOCLAW_TEST_AUDIT_STATUS: String(auditStatus),
+          NEMOCLAW_TEST_CACHE_MODES_FILE: cacheModesFile,
           NEMOCLAW_TEST_NPM_CALLS: callsFile,
+          NEMOCLAW_TEST_OFFLINE_PACK_STATUS: String(offlinePackStatus),
           NEMOCLAW_TEST_REVIEWED_INTEGRITY: integrity,
           NEMOCLAW_TEST_REVIEWED_TARBALL:
             "https://registry.npmjs.org/@tencent-weixin/openclaw-weixin/-/openclaw-weixin-2.4.3.tgz",
@@ -242,6 +256,12 @@ process.exit(0);
         ? (JSON.parse(fs.readFileSync(provenanceFile, "utf-8")) as Record<string, unknown>)
         : undefined,
       result,
+      trustedCacheModes: fs.existsSync(cacheModesFile)
+        ? (JSON.parse(fs.readFileSync(cacheModesFile, "utf-8")) as {
+            directory: number;
+            entry: number;
+          })
+        : undefined,
     };
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
@@ -319,6 +339,22 @@ describe("trusted reviewed npm audit workflow (#5896)", () => {
         calls.length > 0 &&
         calls.every((call) => call.includes("--registry=https://registry.yarnpkg.com")),
     );
+  });
+
+  it("restores the read-only trusted cache after offline packing fails", () => {
+    const fixture = runConsolidatedAuditFixture(() => {}, undefined, 0, 9);
+
+    expect({
+      status: fixture.result.status,
+      stderr: fixture.result.stderr.toString(),
+      trustedCacheModes: fixture.trustedCacheModes,
+      cleanupPermissionFailure: fixture.result.stderr.includes("EACCES"),
+    }).toEqual({
+      status: 1,
+      stderr: expect.stringContaining("simulated offline pack failure"),
+      trustedCacheModes: { directory: 0o555, entry: 0o444 },
+      cleanupPermissionFailure: false,
+    });
   });
 
   it("rejects a target-controlled npm registry override", () => {

--- a/test/automation/releases/reviewed-npm-audit-workflow.test.ts
+++ b/test/automation/releases/reviewed-npm-audit-workflow.test.ts
@@ -172,6 +172,11 @@ if (args[0] === "pack") {
 }
 if (args[0] === "audit" && args[1] === "signatures") process.exit(0);
 if (args[0] === "audit") { process.stdout.write(process.env.NEMOCLAW_TEST_AUDIT_OUTPUT); process.exit(Number(process.env.NEMOCLAW_TEST_AUDIT_STATUS)); }
+if (args[0] === "cache" && args[1] === "add") {
+  fs.mkdirSync(process.env.NPM_CONFIG_CACHE + "/_cacache", { recursive: true });
+  fs.writeFileSync(process.env.NPM_CONFIG_CACHE + "/_cacache/fixture", "cached");
+  process.exit(0);
+}
 if (args[0] === "ci" && !fs.existsSync("package-lock.json")) {
   console.error("npm ci requires an existing package-lock.json");
   process.exit(1);


### PR DESCRIPTION
## Outcome

The reviewed npm audit now removes its temporary WeChat cache after proving the trusted cache stayed read-only. Successful graph audits no longer leave the job red during cleanup.

## Reason

[Main run 33879304721](https://github.com/NVIDIA/NemoClaw/actions/runs/33879304721/job/101044044959) passed all six npm audit graphs, then failed when recursive cleanup tried to remove the read-only nested `_cacache` directory. The test fixture previously modeled an empty cache, so it did not exercise that cleanup failure.

## Changes

- restore owner-write permissions in a `finally` block after the trusted-cache boundary check
- make the reviewed-audit fixture create a nested npm cache entry so process cleanup is covered

## Verification

- pre-fix focused regression — failed during temporary cleanup with `ENOTEMPTY`
- `vitest run --project integration test/automation/releases/reviewed-npm-audit-workflow.test.ts` — 37 passed
- `npm run test:changed` — passed; 45 growth-guardrail tests passed and no affected CLI/plugin/E2E-support tests were selected
- `npm run checks:repository` — passed
- `npm --prefix nemoclaw run build` — passed
- `npm run build:cli` — passed
- `npm run validate:pr` — passed on `e57400686bef777ff6294675805fdc878ebb6476`
- secret review — the diff contains no secrets, API keys, or credentials

## Review notes

- The PR audit jobs execute `scripts/audit-reviewed-npm-graph.mts` from trusted base commit `6df1b1fa1eb8fc5d09c1f04dc0a8c89275b45ea4`, not from this PR. Both [CI / Pull Request](https://github.com/NVIDIA/NemoClaw/actions/runs/33881482868/job/101051030584) and [managed-image CI](https://github.com/NVIDIA/NemoClaw/actions/runs/33881482957/job/101050948696) passed all six audit graphs, then reproduced the base commit's `_cacache` cleanup failure. This bootstrap failure requires maintainer disposition because the check cannot execute its own fix before merge.
- No documentation changes are needed; this only corrects CI temporary-directory cleanup.

---
Signed-off-by: San Dang <sdang@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of package cache verification by restoring the trusted cache to writable permissions even when an intermediate operation fails.
  - Fixed failure handling for offline package archive creation so cleanup does not produce misleading permission errors.

- **Tests**
  - Expanded automated coverage for offline packaging failures and trusted-cache permission preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->