### PR TITLE
fix(readiness): resolve container engine for legacy-cluster gateway inspection

### DIFF
--- a/src/lib/readiness/gateway-production.test.ts
+++ b/src/lib/readiness/gateway-production.test.ts
@@ -39,6 +39,7 @@ import {
   gatewayPortConflictDetail,
   gatewayProcessIdentityMatchesTrustedBinary,
   gatewayProcessSamplesMatchTrustedBinary,
+  inspectLegacyCluster,
   parseDarwinLsofExecutable,
 } from "./gateway-production";
 
@@ -462,6 +463,64 @@ describe("managed gateway port readiness (#7411)", () => {
       ["gateway", "info"],
       expect.any(Object),
     );
+  });
+
+  it("inspects the legacy cluster container through the resolved runtime provider engine, not a hardcoded docker binary", () => {
+    const gatewayName = "nemoclaw-readiness-test";
+    const gatewayPort = 18_080;
+    const openshell = "/usr/local/bin/openshell";
+    const containerName = `openshell-cluster-${gatewayName}`;
+    const resultByInvocation = new Map([
+      [
+        [openshell, "status", "-g", gatewayName].join("\0"),
+        commandResult(`Gateway: ${gatewayName}\nStatus: Connected\n`, 0),
+      ],
+      [[openshell, "gateway", "info", "-g", gatewayName].join("\0"), commandResult("", 0)],
+      [
+        [openshell, "gateway", "info"].join("\0"),
+        commandResult(`Gateway endpoint: http://127.0.0.1:${gatewayPort}\n`, 0),
+      ],
+      [
+        ["podman", "inspect", "--format", "{{.State.Running}}", containerName].join("\0"),
+        commandResult("true", 0),
+      ],
+      [
+        [
+          "podman",
+          "inspect",
+          "--format",
+          "{{json .NetworkSettings.Ports}}",
+          containerName,
+        ].join("\0"),
+        commandResult(JSON.stringify({ "8080/tcp": [{ HostPort: String(gatewayPort) }] }), 0),
+      ],
+      [
+        ["podman", "inspect", "--format", "{{.Config.Image}}", containerName].join("\0"),
+        commandResult("ghcr.io/nvidia/openshell/gateway:latest", 0),
+      ],
+    ]);
+    subprocess.spawnSync.mockImplementation((command: string, args: readonly string[] = []) => {
+      return resultByInvocation.get([command, ...args].join("\0")) ?? commandResult();
+    });
+
+    const result = inspectLegacyCluster(gatewayName, gatewayPort, openshell, {}, "podman");
+
+    expect(result).toEqual({ active: true, imageRef: "ghcr.io/nvidia/openshell/gateway:latest" });
+    expect(subprocess.spawnSync.mock.calls.some(([command]) => command === "podman")).toBe(true);
+    expect(subprocess.spawnSync.mock.calls.some(([command]) => command === "docker")).toBe(false);
+  });
+
+  it("skips legacy-cluster container inspection when no runtime provider engine can be resolved", () => {
+    const result = inspectLegacyCluster(
+      "nemoclaw-readiness-test",
+      18_080,
+      "/usr/local/bin/openshell",
+      {},
+      null,
+    );
+
+    expect(result).toEqual({ active: false, imageRef: null });
+    expect(subprocess.spawnSync).not.toHaveBeenCalled();
   });
 
   it("collects production port evidence without attempting sudo", async () => {

--- a/src/lib/readiness/gateway-production.test.ts
+++ b/src/lib/readiness/gateway-production.test.ts
@@ -523,6 +523,117 @@ describe("managed gateway port readiness (#7411)", () => {
     expect(subprocess.spawnSync).not.toHaveBeenCalled();
   });
 
+  it("threads an injected engine into legacy-cluster inspection reached through the public entrypoint", async () => {
+    vi.stubEnv("NEMOCLAW_OPENSHELL_BIN", "/bin/sh");
+    const gatewayName = "nemoclaw-readiness-test";
+    const openshell = "/bin/sh";
+    const containerName = `openshell-cluster-${gatewayName}`;
+    const foreignListener = net.createServer();
+    await new Promise<void>((resolve, reject) => {
+      foreignListener.once("error", reject);
+      foreignListener.listen(0, "127.0.0.1", resolve);
+    });
+    const gatewayPort = (foreignListener.address() as AddressInfo).port;
+    const resultByInvocation = new Map([
+      [
+        [openshell, "status", "-g", gatewayName].join("\0"),
+        commandResult(`Gateway: ${gatewayName}\nStatus: Connected\n`, 0),
+      ],
+      [[openshell, "gateway", "info", "-g", gatewayName].join("\0"), commandResult("", 0)],
+      [
+        [openshell, "gateway", "info"].join("\0"),
+        commandResult(`Gateway endpoint: http://127.0.0.1:${gatewayPort}\n`, 0),
+      ],
+      [
+        ["podman", "inspect", "--format", "{{.State.Running}}", containerName].join("\0"),
+        commandResult("true", 0),
+      ],
+      [
+        [
+          "podman",
+          "inspect",
+          "--format",
+          "{{json .NetworkSettings.Ports}}",
+          containerName,
+        ].join("\0"),
+        commandResult(JSON.stringify({ "8080/tcp": [{ HostPort: String(gatewayPort) }] }), 0),
+      ],
+      [
+        ["podman", "inspect", "--format", "{{.Config.Image}}", containerName].join("\0"),
+        commandResult("ghcr.io/nvidia/openshell/gateway:latest", 0),
+      ],
+    ]);
+    subprocess.spawnSync.mockImplementation((command: string, args: readonly string[] = []) => {
+      return resultByInvocation.get([command, ...args].join("\0")) ?? commandResult();
+    });
+
+    try {
+      const deps = createProductionGatewayReadinessDependencies({
+        gatewayName: () => gatewayName,
+        gatewayPort: () => gatewayPort,
+        containerEngineId: () => "podman",
+      });
+
+      await deps.observeManagedGateway(managedOwner(gatewayPort));
+
+      expect(subprocess.spawnSync.mock.calls.some(([command]) => command === "podman")).toBe(true);
+      expect(subprocess.spawnSync.mock.calls.some(([command]) => command === "docker")).toBe(
+        false,
+      );
+    } finally {
+      await new Promise<void>((resolve) => foreignListener.close(() => resolve()));
+    }
+  });
+
+  it("honors an explicit null engine override instead of falling back to the resolved default", async () => {
+    vi.stubEnv("NEMOCLAW_OPENSHELL_BIN", "/bin/sh");
+    vi.stubEnv("NEMOCLAW_GATEWAY_RUNTIME", "docker");
+    const gatewayName = "nemoclaw-readiness-test";
+    const openshell = "/bin/sh";
+    const foreignListener = net.createServer();
+    await new Promise<void>((resolve, reject) => {
+      foreignListener.once("error", reject);
+      foreignListener.listen(0, "127.0.0.1", resolve);
+    });
+    const gatewayPort = (foreignListener.address() as AddressInfo).port;
+    const resultByInvocation = new Map([
+      [
+        [openshell, "status", "-g", gatewayName].join("\0"),
+        commandResult(`Gateway: ${gatewayName}\nStatus: Connected\n`, 0),
+      ],
+      [[openshell, "gateway", "info", "-g", gatewayName].join("\0"), commandResult("", 0)],
+      [
+        [openshell, "gateway", "info"].join("\0"),
+        commandResult(`Gateway endpoint: http://127.0.0.1:${gatewayPort}\n`, 0),
+      ],
+    ]);
+    subprocess.spawnSync.mockImplementation((command: string, args: readonly string[] = []) => {
+      return resultByInvocation.get([command, ...args].join("\0")) ?? commandResult();
+    });
+
+    try {
+      const deps = createProductionGatewayReadinessDependencies({
+        gatewayName: () => gatewayName,
+        gatewayPort: () => gatewayPort,
+        containerEngineId: () => null,
+      });
+
+      await deps.observeManagedGateway(managedOwner(gatewayPort));
+
+      // Before the fix, `options.containerEngineId?.() ?? resolveGatewayInspectionEngineId()`
+      // treated an explicit `null` return as "not provided" and fell back to the
+      // resolved default ("docker" here), silently overriding the caller's opt-out.
+      expect(subprocess.spawnSync.mock.calls.some(([command]) => command === "docker")).toBe(
+        false,
+      );
+      expect(subprocess.spawnSync.mock.calls.some(([command]) => command === "podman")).toBe(
+        false,
+      );
+    } finally {
+      await new Promise<void>((resolve) => foreignListener.close(() => resolve()));
+    }
+  });
+
   it("collects production port evidence without attempting sudo", async () => {
     vi.stubEnv("GITHUB_TOKEN", "github-secret");
     vi.stubEnv("OPENSHELL_GATEWAY_AUTH_TOKEN", "gateway-secret");

--- a/src/lib/readiness/gateway-production.ts
+++ b/src/lib/readiness/gateway-production.ts
@@ -49,6 +49,10 @@ import { ownedHostGatewayTarget } from "../onboard/gateway-process-target-identi
 import { resolveOpenshell } from "../onboard/openshell-cli";
 import { checkPortAvailable } from "../onboard/preflight";
 import { resolveGatewayStateDirForPort } from "../onboard/gateway/state-dir";
+import {
+  resolveCurrentRuntimeProviderBundle,
+  runtimeProviderContainerEngineIdentity,
+} from "../onboard/runtime-provider/access";
 import type {
   GatewayPortConflictState,
   GatewayReadinessDependencies,
@@ -59,6 +63,7 @@ import { buildSystemReadinessProbeEnv, type ReadinessProbeEnvironmentControls } 
 export interface ProductionGatewayReadinessOptions {
   gatewayName?: () => string;
   gatewayPort?: () => number;
+  containerEngineId?: () => string | null;
   resolveOwner?: GatewayReadinessDependencies["resolveOwner"];
   probeAttachment?: GatewayReadinessDependencies["probeAttachment"];
   isLegacyClusterBound?: () => boolean;
@@ -66,6 +71,17 @@ export interface ProductionGatewayReadinessOptions {
     source: GatewayVersionSource,
     hostProcessPid: number | null,
   ) => GatewayVersionCompatibility;
+}
+
+/**
+ * Resolve the container engine binary bound to the active runtime provider's
+ * `gateway-inspection` operation ("docker" or "podman"). Returns null when the
+ * active provider does not register that operation, so callers can skip
+ * engine-specific inspection instead of guessing a binary.
+ */
+function resolveGatewayInspectionEngineId(): string | null {
+  const bundle = resolveCurrentRuntimeProviderBundle();
+  return runtimeProviderContainerEngineIdentity(bundle, "gateway-inspection")?.engineId ?? null;
 }
 
 interface ReadonlyCaptureResult {
@@ -340,13 +356,14 @@ function observeReuseState(
   };
 }
 
-function inspectLegacyCluster(
+export function inspectLegacyCluster(
   gatewayName: string,
   gatewayPort: number,
   openshell: string | null,
   env: NodeJS.ProcessEnv,
+  containerEngineId: string | null,
 ): { active: boolean; imageRef: string | null } {
-  if (!openshell) return { active: false, imageRef: null };
+  if (!openshell || !containerEngineId) return { active: false, imageRef: null };
   const status = captureReadonly([openshell, "status", "-g", gatewayName], env);
   const named = captureReadonly([openshell, "gateway", "info", "-g", gatewayName], env);
   const active = captureReadonly([openshell, "gateway", "info"], env);
@@ -368,11 +385,11 @@ function inspectLegacyCluster(
 
   const containerName = getGatewayClusterContainerName(gatewayName);
   const running = captureReadonly(
-    ["docker", "inspect", "--format", "{{.State.Running}}", containerName],
+    [containerEngineId, "inspect", "--format", "{{.State.Running}}", containerName],
     env,
   );
   const ports = captureReadonly(
-    ["docker", "inspect", "--format", "{{json .NetworkSettings.Ports}}", containerName],
+    [containerEngineId, "inspect", "--format", "{{json .NetworkSettings.Ports}}", containerName],
     env,
   );
   if (
@@ -399,7 +416,7 @@ function inspectLegacyCluster(
   }
 
   const image = captureReadonly(
-    ["docker", "inspect", "--format", "{{.Config.Image}}", containerName],
+    [containerEngineId, "inspect", "--format", "{{.Config.Image}}", containerName],
     env,
   );
   return {
@@ -577,6 +594,7 @@ export function createProductionGatewayReadinessDependencies(
 ): GatewayReadinessDependencies {
   const gatewayPort = options.gatewayPort?.() ?? getConfiguredGatewayPort();
   const gatewayName = options.gatewayName?.() ?? resolveDockerDriverGatewayName(gatewayPort);
+  const containerEngineId = options.containerEngineId?.() ?? resolveGatewayInspectionEngineId();
   const probeEnv = buildGatewayReadinessProbeEnv(process.env, {
     gatewayName,
     localTlsDir: resolveManagedGatewayProbeTlsDir(gatewayPort, process.env),
@@ -765,6 +783,7 @@ export function createProductionGatewayReadinessDependencies(
             gatewayPort,
             openshellBin,
             probeEnv,
+            containerEngineId,
           );
           legacyClusterBound = legacyCluster.active;
           legacyClusterImageRef = legacyCluster.imageRef;

--- a/src/lib/readiness/gateway-production.ts
+++ b/src/lib/readiness/gateway-production.ts
@@ -594,7 +594,9 @@ export function createProductionGatewayReadinessDependencies(
 ): GatewayReadinessDependencies {
   const gatewayPort = options.gatewayPort?.() ?? getConfiguredGatewayPort();
   const gatewayName = options.gatewayName?.() ?? resolveDockerDriverGatewayName(gatewayPort);
-  const containerEngineId = options.containerEngineId?.() ?? resolveGatewayInspectionEngineId();
+  const containerEngineId = options.containerEngineId
+    ? options.containerEngineId()
+    : resolveGatewayInspectionEngineId();
   const probeEnv = buildGatewayReadinessProbeEnv(process.env, {
     gatewayName,
     localTlsDir: resolveManagedGatewayProbeTlsDir(gatewayPort, process.env),


### PR DESCRIPTION
## Outcome

Before: `observeManagedGateway()`'s legacy-cluster check hardcoded `"docker"` for its three container-inspect calls, regardless of the active runtime provider. On a Podman-selected host with no Docker installed, every call failed with `ENOENT`, surfacing as an opaque `gateway.reuse.ready`/`gateway.version.compatible`/`gateway.port.uncontested` readiness failure. After: the container engine bound to the active provider's `gateway-inspection` operation is resolved and used instead, so the check runs against `podman` when Podman is selected.

## Reason

This is the root cause behind #10984: native Podman onboarding (activated by #9923) fails at the gateway readiness step because this specific check never became runtime-aware. The registry needed to fix it already exists — PR #9923 built `runtime-provider/registry.ts`'s `gateway-inspection` operation and registered it for both `docker.ts` and `podman.ts` — `gateway-production.ts` just wasn't using it for these three calls.

### Related issues

Fixes #10984

## Changes

- `src/lib/readiness/gateway-production.ts`: added `resolveGatewayInspectionEngineId()`, which resolves the current runtime provider bundle and asks it for the `gateway-inspection` engine identity (`"docker"` or `"podman"`). `inspectLegacyCluster()` now takes this resolved engine id and uses it for its three `inspect` calls instead of the literal `"docker"`. Fails closed (skips the check entirely) when no engine or `openshell` binary can be resolved, rather than guessing a binary. Added `containerEngineId` as an injectable option on `createProductionGatewayReadinessDependencies`, matching the existing `isLegacyClusterBound`/`gatewayName` injection pattern. Exported `inspectLegacyCluster` for direct unit testing, matching this file's existing convention (`classifyManagedGatewayPortConflict`, `gatewayProcessIdentityMatchesTrustedBinary`, etc. are already exported the same way).
- `src/lib/readiness/gateway-production.test.ts`: two new tests — one proving a Podman-selected engine reaches an active legacy-cluster result via `podman inspect` (not `docker`), one proving a null engine id skips inspection entirely with zero subprocess calls.

## Verification

- `npx vitest run src/lib/readiness/gateway-production.test.ts src/lib/readiness/gateway.test.ts` — 68 passed (66 existing + 2 new)
- `npm run typecheck:cli` — clean
- `npm run test:changed` — 161 passed, no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved production gateway readiness checks for environments using Podman or other configured container runtimes.
  * Legacy cluster inspection now uses the active container engine to verify container state, port bindings, and image details.
  * Skips legacy inspection when no container runtime is configured, avoiding incorrect Docker-based checks.
  * Explicitly disabling container-engine inspection now prevents fallback checks through other runtimes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->