### PR TITLE
fix(ci): bind audit receipt to reviewed npm

### DIFF
--- a/.github/actions/ci-reviewed-npm-audit/action.yaml
+++ b/.github/actions/ci-reviewed-npm-audit/action.yaml
@@ -30,15 +30,21 @@ runs:
     - name: Resolve reviewed npm audit cache buckets
       id: cache-buckets
       shell: bash
+      env:
+        NEMOCLAW_REVIEWED_NPM_AUDIT_TARGET_ROOT: ${{ inputs.target-root }}
       run: |
         set -euo pipefail
         current_bucket="$(( $(date -u +%s) / 43200 ))"
         previous_bucket="$(( current_bucket - 1 ))"
-        node --input-type=module - '${{ inputs.target-root }}' "$GITHUB_ACTION_PATH/../../../ci/reviewed-npm-audit.json" <<'NODE'
+        node --input-type=module - "$GITHUB_ACTION_PATH/../../../ci/reviewed-npm-audit.json" <<'NODE'
         import { createHash } from "node:crypto";
         import { appendFileSync, readFileSync } from "node:fs";
         import { join } from "node:path";
-        const [targetRoot, configFile] = process.argv.slice(2);
+        const targetRoot = process.env.NEMOCLAW_REVIEWED_NPM_AUDIT_TARGET_ROOT;
+        const [configFile] = process.argv.slice(2);
+        if (!targetRoot) {
+          throw new Error("reviewed npm audit target root is required");
+        }
         const configSource = readFileSync(configFile, "utf8");
         const config = JSON.parse(configSource);
         if (!/^(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)$/.test(config.npmVersion) || /[\r\n]/.test(config.npmVersion)) {

--- a/.github/actions/ci-reviewed-npm-audit/action.yaml
+++ b/.github/actions/ci-reviewed-npm-audit/action.yaml
@@ -31,6 +31,7 @@ runs:
       id: cache-buckets
       shell: bash
       env:
+        NEMOCLAW_REVIEWED_NPM_AUDIT_CACHE_DIRECTORY: ${{ inputs.cache-directory }}
         NEMOCLAW_REVIEWED_NPM_AUDIT_TARGET_ROOT: ${{ inputs.target-root }}
       run: |
         set -euo pipefail
@@ -70,7 +71,7 @@ runs:
         );
         NODE
         printf 'current=%s\nprevious=%s\n' "$current_bucket" "$previous_bucket" >> "$GITHUB_OUTPUT"
-        mkdir -p "${{ inputs.cache-directory }}"
+        mkdir -p "$NEMOCLAW_REVIEWED_NPM_AUDIT_CACHE_DIRECTORY"
 
     - name: Restore current reviewed npm audit cache bucket
       id: cache-current

--- a/.github/actions/ci-reviewed-npm-audit/action.yaml
+++ b/.github/actions/ci-reviewed-npm-audit/action.yaml
@@ -34,17 +34,23 @@ runs:
         set -euo pipefail
         current_bucket="$(( $(date -u +%s) / 43200 ))"
         previous_bucket="$(( current_bucket - 1 ))"
-        input_digest="$(node --input-type=module - '${{ inputs.target-root }}' "$GITHUB_ACTION_PATH/../../../ci/reviewed-npm-audit.json" <<'NODE'
+        node --input-type=module - '${{ inputs.target-root }}' "$GITHUB_ACTION_PATH/../../../ci/reviewed-npm-audit.json" <<'NODE'
         import { createHash } from "node:crypto";
-        import { readFileSync } from "node:fs";
+        import { appendFileSync, readFileSync } from "node:fs";
         import { join } from "node:path";
         const [targetRoot, configFile] = process.argv.slice(2);
         const configSource = readFileSync(configFile, "utf8");
         const config = JSON.parse(configSource);
+        if (!/^(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)$/.test(config.npmVersion) || /[\r\n]/.test(config.npmVersion)) {
+          throw new Error("reviewed npm audit configuration has an invalid npmVersion");
+        }
+        if (!/^sha512-[A-Za-z0-9+/]+={0,2}$/.test(config.npmIntegrity) || /[\r\n]/.test(config.npmIntegrity)) {
+          throw new Error("reviewed npm audit configuration has an invalid npmIntegrity");
+        }
         const directories = ["", ...config.lockedGraphs.map((graph) => graph.directory)].sort();
         const hash = createHash("sha256");
         hash.update(configSource);
-        hash.update(JSON.stringify({ argv: ["audit", "--registry=https://registry.yarnpkg.com", "--omit=dev", "--json"], npmVersion: "10.9.4", registry: "https://registry.yarnpkg.com/", schemaVersion: 1 }));
+        hash.update(JSON.stringify({ argv: ["audit", "--registry=https://registry.yarnpkg.com", "--omit=dev", "--json"], npmVersion: config.npmVersion, registry: "https://registry.yarnpkg.com/", schemaVersion: 1 }));
         for (const directory of directories) {
           for (const file of ["package.json", "package-lock.json"]) {
             const relative = join(directory, file);
@@ -52,10 +58,12 @@ runs:
             hash.update(readFileSync(join(targetRoot, relative)));
           }
         }
-        process.stdout.write(hash.digest("hex"));
+        appendFileSync(
+          process.env.GITHUB_OUTPUT,
+          `input-digest=${hash.digest("hex")}\nnpm-version=${config.npmVersion}\nnpm-integrity=${config.npmIntegrity}\n`,
+        );
         NODE
-        )"
-        printf 'current=%s\nprevious=%s\ninput-digest=%s\n' "$current_bucket" "$previous_bucket" "$input_digest" >> "$GITHUB_OUTPUT"
+        printf 'current=%s\nprevious=%s\n' "$current_bucket" "$previous_bucket" >> "$GITHUB_OUTPUT"
         mkdir -p "${{ inputs.cache-directory }}"
 
     - name: Restore current reviewed npm audit cache bucket
@@ -75,9 +83,8 @@ runs:
     - name: Download and verify production npm
       shell: bash
       env:
-        NEMOCLAW_REVIEWED_NPM_VERSION: "10.9.4"
-        NEMOCLAW_REVIEWED_NPM_INTEGRITY: >-
-          sha512-OnUG836FwboQIbqtefDNlyR0gTHzIfwRfE3DuiNewBvnMnWEpB0VEXwBlFVgqpNzIgYo/MHh3d2Hel/pszapAA==
+        NEMOCLAW_REVIEWED_NPM_VERSION: ${{ steps.cache-buckets.outputs.npm-version }}
+        NEMOCLAW_REVIEWED_NPM_INTEGRITY: ${{ steps.cache-buckets.outputs.npm-integrity }}
       run: env -u NODE_AUTH_TOKEN -u NPM_TOKEN -u NPM_CONFIG__AUTH_TOKEN "$GITHUB_ACTION_PATH/verify-and-install-npm.sh"
 
     - name: Materialize and audit reviewed npm graphs

--- a/Dockerfile
+++ b/Dockerfile
@@ -540,7 +540,7 @@ COPY agents/openclaw/mcporter-runtime/package.json /usr/local/lib/nemoclaw/mcpor
 COPY agents/openclaw/mcporter-runtime/package-lock.json /usr/local/lib/nemoclaw/mcporter-runtime/package-lock.json
 COPY agents/openclaw/wechat-runtime/package.json /usr/local/lib/nemoclaw/wechat-runtime/package.json
 COPY agents/openclaw/wechat-runtime/package-lock.json /usr/local/lib/nemoclaw/wechat-runtime/package-lock.json
-COPY ci/*npm-audit*.json /scripts/
+COPY ci/npm-audit-exceptions.json ci/reviewed-npm-audit.json /scripts/
 COPY scripts/lib/reviewed-npm-archive.mts /scripts/lib/reviewed-npm-archive.mts
 COPY scripts/lib/bundled-npm-package.mts /scripts/lib/bundled-npm-package.mts
 COPY scripts/lib/reviewed-npm-audit.mts /scripts/lib/reviewed-npm-audit.mts
@@ -993,11 +993,11 @@ RUN --network=default \
             || { echo "ERROR: cached mcporter audit requires paired receipt, raw report, and receipt SHA-256" >&2; exit 1; }; \
         printf '%s  %s\n' "$NEMOCLAW_MCPORTER_AUDIT_RECEIPT_SHA256" "$MCPORTER_RECEIPT" | sha256sum -c -; \
 node --experimental-strip-types /scripts/lib/npm-audit-receipt.mts \
-           --receipt "$MCPORTER_RECEIPT" \
-            --package-json /usr/local/lib/nemoclaw/mcporter-runtime/package.json \
-            --package-lock /usr/local/lib/nemoclaw/mcporter-runtime/package-lock.json \
-            --raw-report "$MCPORTER_RAW_REPORT" --exceptions /scripts/npm-audit-exceptions.json \
-            --graph mcporter-runtime --audit-config /scripts/reviewed-npm-audit.json \
+--receipt "$MCPORTER_RECEIPT" \
+--package-json /usr/local/lib/nemoclaw/mcporter-runtime/package.json \
+--package-lock /usr/local/lib/nemoclaw/mcporter-runtime/package-lock.json \
+--raw-report "$MCPORTER_RAW_REPORT" --exceptions /scripts/npm-audit-exceptions.json \
+--graph mcporter-runtime --audit-config /scripts/reviewed-npm-audit.json \
 --registry https://registry.yarnpkg.com --threshold high --legacy-npmjs true; \
     else \
         node --experimental-strip-types /scripts/lib/reviewed-npm-audit.mts \

--- a/Dockerfile
+++ b/Dockerfile
@@ -540,7 +540,7 @@ COPY agents/openclaw/mcporter-runtime/package.json /usr/local/lib/nemoclaw/mcpor
 COPY agents/openclaw/mcporter-runtime/package-lock.json /usr/local/lib/nemoclaw/mcporter-runtime/package-lock.json
 COPY agents/openclaw/wechat-runtime/package.json /usr/local/lib/nemoclaw/wechat-runtime/package.json
 COPY agents/openclaw/wechat-runtime/package-lock.json /usr/local/lib/nemoclaw/wechat-runtime/package-lock.json
-COPY ci/npm-audit-exceptions.json /scripts/npm-audit-exceptions.json
+COPY ci/*npm-audit*.json /scripts/
 COPY scripts/lib/reviewed-npm-archive.mts /scripts/lib/reviewed-npm-archive.mts
 COPY scripts/lib/bundled-npm-package.mts /scripts/lib/bundled-npm-package.mts
 COPY scripts/lib/reviewed-npm-audit.mts /scripts/lib/reviewed-npm-audit.mts
@@ -997,7 +997,7 @@ node --experimental-strip-types /scripts/lib/npm-audit-receipt.mts \
             --package-json /usr/local/lib/nemoclaw/mcporter-runtime/package.json \
             --package-lock /usr/local/lib/nemoclaw/mcporter-runtime/package-lock.json \
             --raw-report "$MCPORTER_RAW_REPORT" --exceptions /scripts/npm-audit-exceptions.json \
-            --graph mcporter-runtime --npm-version 10.9.4 \
+            --graph mcporter-runtime --audit-config /scripts/reviewed-npm-audit.json \
 --registry https://registry.yarnpkg.com --threshold high --legacy-npmjs true; \
     else \
         node --experimental-strip-types /scripts/lib/reviewed-npm-audit.mts \

--- a/Dockerfile
+++ b/Dockerfile
@@ -997,7 +997,7 @@ node --experimental-strip-types /scripts/lib/npm-audit-receipt.mts \
             --package-json /usr/local/lib/nemoclaw/mcporter-runtime/package.json \
             --package-lock /usr/local/lib/nemoclaw/mcporter-runtime/package-lock.json \
             --raw-report "$MCPORTER_RAW_REPORT" --exceptions /scripts/npm-audit-exceptions.json \
-            --graph mcporter-runtime --npm-version "$(npm --version)" \
+            --graph mcporter-runtime --npm-version 10.9.4 \
 --registry https://registry.yarnpkg.com --threshold high --legacy-npmjs true; \
     else \
         node --experimental-strip-types /scripts/lib/reviewed-npm-audit.mts \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -424,7 +424,7 @@ COPY agents/openclaw/openclaw-runtime/package.json \
 COPY agents/openclaw/mcporter-runtime/package.json \
     agents/openclaw/mcporter-runtime/package-lock.json \
     /usr/local/lib/nemoclaw/mcporter-runtime/
-COPY ci/*npm-audit*.json /scripts/
+COPY ci/npm-audit-exceptions.json ci/reviewed-npm-audit.json /scripts/
 COPY scripts/lib/reviewed-npm-archive.mts \
     scripts/lib/bundled-npm-package.mts \
     scripts/lib/reviewed-npm-audit.mts \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -593,7 +593,7 @@ RUN --mount=type=bind,source=nemoclaw-blueprint/blueprint.yaml,target=/tmp/bluep
             --package-json /usr/local/lib/nemoclaw/mcporter-runtime/package.json \
             --package-lock /usr/local/lib/nemoclaw/mcporter-runtime/package-lock.json \
             --raw-report "$MCPORTER_RAW_REPORT" --exceptions /scripts/npm-audit-exceptions.json \
-            --graph mcporter-runtime --npm-version "$(npm --version)" \
+            --graph mcporter-runtime --npm-version 10.9.4 \
             --registry https://registry.yarnpkg.com --threshold high \
             --legacy-npmjs true \
             --result /tmp/mcporter-npm-audit-policy.json; \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -424,7 +424,7 @@ COPY agents/openclaw/openclaw-runtime/package.json \
 COPY agents/openclaw/mcporter-runtime/package.json \
     agents/openclaw/mcporter-runtime/package-lock.json \
     /usr/local/lib/nemoclaw/mcporter-runtime/
-COPY ci/npm-audit-exceptions.json /scripts/npm-audit-exceptions.json
+COPY ci/*npm-audit*.json /scripts/
 COPY scripts/lib/reviewed-npm-archive.mts \
     scripts/lib/bundled-npm-package.mts \
     scripts/lib/reviewed-npm-audit.mts \
@@ -593,11 +593,11 @@ RUN --mount=type=bind,source=nemoclaw-blueprint/blueprint.yaml,target=/tmp/bluep
             --package-json /usr/local/lib/nemoclaw/mcporter-runtime/package.json \
             --package-lock /usr/local/lib/nemoclaw/mcporter-runtime/package-lock.json \
             --raw-report "$MCPORTER_RAW_REPORT" --exceptions /scripts/npm-audit-exceptions.json \
-            --graph mcporter-runtime --npm-version 10.9.4 \
+            --graph mcporter-runtime --audit-config /scripts/reviewed-npm-audit.json \
             --registry https://registry.yarnpkg.com --threshold high \
             --legacy-npmjs true \
-            --result /tmp/mcporter-npm-audit-policy.json; \
-        cp "$MCPORTER_RAW_REPORT" /tmp/mcporter-npm-audit.json; \
+            --result /tmp/mcporter-npm-audit-policy.json \
+            --raw-copy /tmp/mcporter-npm-audit.json; \
       else \
         node --experimental-strip-types /scripts/lib/reviewed-npm-audit.mts \
             --directory /usr/local/lib/nemoclaw/mcporter-runtime \

--- a/ci/reviewed-npm-audit.json
+++ b/ci/reviewed-npm-audit.json
@@ -1,6 +1,8 @@
 {
   "schemaVersion": 2,
   "nodeVersion": "22.23.2",
+  "npmVersion": "10.9.4",
+  "npmIntegrity": "sha512-OnUG836FwboQIbqtefDNlyR0gTHzIfwRfE3DuiNewBvnMnWEpB0VEXwBlFVgqpNzIgYo/MHh3d2Hel/pszapAA==",
   "registryOrigin": "https://registry.npmjs.org/",
   "sourceRegistryPackage": {
     "artifactName": "nvidia-openshell-sdk-0.0.106.tgz",

--- a/ci/source-shape-test-budget.json
+++ b/ci/source-shape-test-budget.json
@@ -203,6 +203,11 @@
     },
     {
       "file": "test/automation/releases/reviewed-npm-audit-workflow.test.ts",
+      "test": "passes the cache identity target root without interpolating it into shell source",
+      "category": "security"
+    },
+    {
+      "file": "test/automation/releases/reviewed-npm-audit-workflow.test.ts",
       "test": "rejects the removed plural source-registry package shape",
       "category": "security"
     },

--- a/scripts/audit-reviewed-npm-graph.mts
+++ b/scripts/audit-reviewed-npm-graph.mts
@@ -56,6 +56,8 @@ type AuditConfig = Readonly<{
   exceptionFile: string;
   lockedGraphs: readonly LockedGraph[];
   nodeVersion: string;
+  npmIntegrity: string;
+  npmVersion: string;
   registryOrigin: string;
   schemaVersion: 2;
   severityThreshold: Severity;
@@ -195,6 +197,12 @@ export function parseAuditConfig(contents: string): AuditConfig {
     parsed.archiveTarVersion !== "7.5.21" ||
     typeof parsed.exceptionFile !== "string" ||
     !parsed.exceptionFile ||
+    typeof parsed.npmVersion !== "string" ||
+    !/^(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)$/.test(parsed.npmVersion) ||
+    /[\r\n]/.test(parsed.npmVersion) ||
+    typeof parsed.npmIntegrity !== "string" ||
+    !/^sha512-[A-Za-z0-9+/]+={0,2}$/.test(parsed.npmIntegrity) ||
+    /[\r\n]/.test(parsed.npmIntegrity) ||
     typeof parsed.registryOrigin !== "string" ||
     !parsed.registryOrigin ||
     !Array.isArray(parsed.archivePackages) ||
@@ -909,6 +917,11 @@ function main(): void {
   fs.rmSync(artifactDirectory, { recursive: true, force: true });
   fs.mkdirSync(artifactDirectory, { recursive: true });
   const npmVersion = run("npm", ["--version"], TRUSTED_REPO_ROOT).stdout.trim();
+  if (npmVersion !== config.npmVersion) {
+    throw new Error(
+      `reviewed npm audit requires npm ${config.npmVersion}; running npm ${npmVersion}`,
+    );
+  }
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-reviewed-npm-audit-"));
   try {
     const sourceResult = auditSourceGraph(

--- a/scripts/lib/npm-audit-receipt.mts
+++ b/scripts/lib/npm-audit-receipt.mts
@@ -211,13 +211,34 @@ export function canonicalAuditReceipt(receipt: AuditReceipt): string {
   return `${JSON.stringify(receipt, null, 2)}\n`;
 }
 
+export function reviewedNpmVersionFromConfig(contents: string): string {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(contents);
+  } catch {
+    throw new Error("reviewed npm audit configuration is not valid JSON");
+  }
+  const npmVersion =
+    typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>).npmVersion
+      : undefined;
+  if (
+    typeof npmVersion !== "string" ||
+    !/^(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)$/.test(npmVersion) ||
+    /[\r\n]/.test(npmVersion)
+  ) {
+    throw new Error("reviewed npm audit configuration has an invalid npmVersion");
+  }
+  return npmVersion;
+}
+
 function cli(args: readonly string[]): void {
   const values = new Map<string, string>();
   for (let index = 0; index < args.length; index += 2) {
     const value = args[index + 1];
     if (!args[index]?.startsWith("--") || value === undefined)
       throw new Error(
-        "usage: npm-audit-receipt.mts --receipt FILE --package-json FILE --package-lock FILE --raw-report FILE --exceptions FILE --graph ID --npm-version VERSION --registry ORIGIN --threshold SEVERITY [--legacy-npmjs true]",
+        "usage: npm-audit-receipt.mts --receipt FILE --package-json FILE --package-lock FILE --raw-report FILE --exceptions FILE --graph ID --audit-config FILE --registry ORIGIN --threshold SEVERITY [--legacy-npmjs true] [--result FILE] [--raw-copy FILE]",
       );
     values.set(args[index], value);
   }
@@ -228,14 +249,16 @@ function cli(args: readonly string[]): void {
     "--raw-report",
     "--exceptions",
     "--graph",
-    "--npm-version",
+    "--audit-config",
     "--registry",
     "--threshold",
   ];
-  const allowed = [...required, "--result", "--legacy-npmjs"];
+  const allowed = [...required, "--result", "--raw-copy", "--legacy-npmjs"];
   exactKeys(
     Object.fromEntries(
-      [...values].filter(([key]) => key !== "--result" && key !== "--legacy-npmjs"),
+      [...values].filter(
+        ([key]) => key !== "--result" && key !== "--raw-copy" && key !== "--legacy-npmjs",
+      ),
     ),
     required,
     "verifier arguments",
@@ -246,9 +269,12 @@ function cli(args: readonly string[]): void {
   const packageLock = fs.readFileSync(values.get("--package-lock")!);
   const rawResponse = fs.readFileSync(values.get("--raw-report")!);
   const exceptionPolicy = fs.readFileSync(values.get("--exceptions")!);
+  const npmVersion = reviewedNpmVersionFromConfig(
+    fs.readFileSync(values.get("--audit-config")!, "utf8"),
+  );
   parseAndVerifyAuditReceipt(fs.readFileSync(values.get("--receipt")!, "utf8"), {
     graphId: values.get("--graph")!,
-    npmVersion: values.get("--npm-version")!,
+    npmVersion,
     exceptionPolicy,
     severityThreshold: values.get("--threshold")! as AuditReceipt["severityThreshold"],
     packageJson,
@@ -271,6 +297,8 @@ function cli(args: readonly string[]): void {
     );
   if (values.has("--result"))
     fs.writeFileSync(values.get("--result")!, `${JSON.stringify(policyResult, null, 2)}\n`);
+  if (values.has("--raw-copy"))
+    fs.copyFileSync(values.get("--raw-report")!, values.get("--raw-copy")!);
   console.log("reviewed npm audit receipt and current policy verified");
 }
 

--- a/src/lib/sandbox/build-context.ts
+++ b/src/lib/sandbox/build-context.ts
@@ -223,6 +223,10 @@ function stageOptimizedSandboxBuildContext(
     path.join(rootDir, "ci", "npm-audit-exceptions.json"),
     path.join(stagedCiDir, "npm-audit-exceptions.json"),
   );
+  fs.copyFileSync(
+    path.join(rootDir, "ci", "reviewed-npm-audit.json"),
+    path.join(stagedCiDir, "reviewed-npm-audit.json"),
+  );
   normalizeReadModesForDockerCopy(stagedCiDir);
 
   fs.mkdirSync(stagedNemoclawDir, { recursive: true });

--- a/test/automation/releases/npm-audit-receipt.test.ts
+++ b/test/automation/releases/npm-audit-receipt.test.ts
@@ -171,6 +171,10 @@ describe("reviewed npm audit receipt", () => {
         fs.writeFileSync(path.join(root, "package-lock.json"), inputs.packageLock);
         fs.writeFileSync(path.join(root, "exceptions.json"), inputs.exceptionPolicy);
         fs.writeFileSync(path.join(root, "raw.json"), inputs.rawResponse);
+        fs.writeFileSync(
+          path.join(root, "reviewed-npm-audit.json"),
+          JSON.stringify({ npmVersion: inputs.npmVersion }),
+        );
         const auditReceipt = legacy
           ? {
               ...receipt(new Date()),
@@ -194,8 +198,8 @@ describe("reviewed npm audit receipt", () => {
           path.join(root, "exceptions.json"),
           "--graph",
           inputs.graphId,
-          "--npm-version",
-          inputs.npmVersion,
+          "--audit-config",
+          path.join(root, "reviewed-npm-audit.json"),
           "--registry",
           registry,
           "--threshold",
@@ -211,6 +215,95 @@ describe("reviewed npm audit receipt", () => {
         });
         expect(withoutMigrationFlag.status).toBe(unflaggedStatus);
         expect(withoutMigrationFlag.stderr).toContain(unflaggedStderr);
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.each([
+    {
+      error: "",
+      label: "the canonical npm version",
+      npmVersion: inputs.npmVersion,
+      policy: { graph: inputs.graphId, status: "clean" },
+      rawCopy: inputs.rawResponse,
+      status: 0,
+    },
+    {
+      error: "receipt identity does not match expected graph and npm",
+      label: "a mismatched npm version",
+      npmVersion: "11.18.0",
+      policy: undefined,
+      rawCopy: undefined,
+      status: 1,
+    },
+  ])(
+    "executes the receipt producer-to-Docker-consumer contract for $label",
+    ({ error, npmVersion, policy, rawCopy, status }) => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), "receipt-docker-contract-"));
+      const resultFile = path.join(root, "policy.json");
+      const rawCopyFile = path.join(root, "copied-raw.json");
+      try {
+        fs.writeFileSync(path.join(root, "package.json"), inputs.packageJson);
+        fs.writeFileSync(path.join(root, "package-lock.json"), inputs.packageLock);
+        fs.writeFileSync(path.join(root, "exceptions.json"), inputs.exceptionPolicy);
+        fs.writeFileSync(path.join(root, "raw.json"), inputs.rawResponse);
+        fs.writeFileSync(
+          path.join(root, "receipt.json"),
+          canonicalAuditReceipt(receipt(new Date())),
+        );
+        fs.writeFileSync(
+          path.join(root, "reviewed-npm-audit.json"),
+          JSON.stringify({ npmVersion }),
+        );
+
+        const result = spawnSync(
+          process.execPath,
+          [
+            "--experimental-strip-types",
+            path.join(import.meta.dirname, "../../../scripts/lib/npm-audit-receipt.mts"),
+            "--receipt",
+            path.join(root, "receipt.json"),
+            "--package-json",
+            path.join(root, "package.json"),
+            "--package-lock",
+            path.join(root, "package-lock.json"),
+            "--raw-report",
+            path.join(root, "raw.json"),
+            "--exceptions",
+            path.join(root, "exceptions.json"),
+            "--graph",
+            inputs.graphId,
+            "--audit-config",
+            path.join(root, "reviewed-npm-audit.json"),
+            "--registry",
+            inputs.registryOrigin,
+            "--threshold",
+            inputs.severityThreshold,
+            "--result",
+            resultFile,
+            "--raw-copy",
+            rawCopyFile,
+          ],
+          { encoding: "utf8" },
+        );
+
+        expect(result.status, result.stderr).toBe(status);
+        expect(fs.existsSync(resultFile)).toBe(status === 0);
+        expect(fs.existsSync(rawCopyFile)).toBe(status === 0);
+        const observedPolicy = fs.existsSync(resultFile)
+          ? (JSON.parse(fs.readFileSync(resultFile, "utf8")) as Record<string, unknown>)
+          : undefined;
+        expect(
+          observedPolicy === undefined
+            ? undefined
+            : { graph: observedPolicy.graph, status: observedPolicy.status },
+        ).toEqual(policy);
+        expect(fs.existsSync(rawCopyFile) ? fs.readFileSync(rawCopyFile, "utf8") : undefined).toBe(
+          rawCopy,
+        );
+        expect(result.stderr).toContain(error);
       } finally {
         fs.rmSync(root, { recursive: true, force: true });
       }

--- a/test/automation/releases/reviewed-npm-audit-workflow.test.ts
+++ b/test/automation/releases/reviewed-npm-audit-workflow.test.ts
@@ -23,7 +23,6 @@ import {
   verifySignaturesWithReviewedRetry,
 } from "../../../scripts/audit-reviewed-npm-graph.mts";
 import { verifyInstalledNpmLock } from "../../../scripts/lib/reviewed-npm-archive.mts";
-import { parseAndVerifyAuditReceipt } from "../../../scripts/lib/npm-audit-receipt.mts";
 import type { AuditPolicyResult } from "../../../scripts/lib/reviewed-npm-audit.mts";
 
 type WorkflowStep = {
@@ -46,6 +45,11 @@ type Workflow = {
 };
 
 const REPO_ROOT = path.join(import.meta.dirname, "../../..");
+const REVIEWED_AUDIT_CONFIG_SOURCE = fs.readFileSync(
+  path.join(REPO_ROOT, "ci", "reviewed-npm-audit.json"),
+  "utf8",
+);
+const REVIEWED_AUDIT_CONFIG = parseAuditConfig(REVIEWED_AUDIT_CONFIG_SOURCE);
 
 type ConsolidatedAuditFixture = Readonly<{
   npmCalls: readonly string[];
@@ -66,6 +70,7 @@ function runConsolidatedAuditFixture(
   }),
   auditStatus = 0,
   offlinePackStatus = 0,
+  observedNpmVersion = REVIEWED_AUDIT_CONFIG.npmVersion,
 ): ConsolidatedAuditFixture {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-reviewed-audit-entry-"));
   const trustedRoot = path.join(root, "trusted");
@@ -125,6 +130,8 @@ function runConsolidatedAuditFixture(
           },
         ],
         nodeVersion: process.version.slice(1),
+        npmIntegrity: REVIEWED_AUDIT_CONFIG.npmIntegrity,
+        npmVersion: REVIEWED_AUDIT_CONFIG.npmVersion,
         registryOrigin: "https://registry.npmjs.org/",
         schemaVersion: 2,
         severityThreshold: "high",
@@ -160,7 +167,7 @@ function runConsolidatedAuditFixture(
 const fs = require("node:fs");
 fs.appendFileSync(process.env.NEMOCLAW_TEST_NPM_CALLS, JSON.stringify(process.argv.slice(2)) + "\\n");
 const args = process.argv.slice(2);
-if (args[0] === "--version") { console.log("10.9.4"); process.exit(0); }
+if (args[0] === "--version") { console.log(process.env.NEMOCLAW_TEST_NPM_VERSION); process.exit(0); }
 if (args[0] === "config") { console.log("https://registry.npmjs.org/"); process.exit(0); }
 if (args[0] === "view") {
   console.log(args.includes("dist.tarball") ? process.env.NEMOCLAW_TEST_REVIEWED_TARBALL : process.env.NEMOCLAW_TEST_REVIEWED_INTEGRITY);
@@ -232,6 +239,7 @@ process.exit(0);
           NEMOCLAW_TEST_AUDIT_STATUS: String(auditStatus),
           NEMOCLAW_TEST_CACHE_MODES_FILE: cacheModesFile,
           NEMOCLAW_TEST_NPM_CALLS: callsFile,
+          NEMOCLAW_TEST_NPM_VERSION: observedNpmVersion,
           NEMOCLAW_TEST_OFFLINE_PACK_STATUS: String(offlinePackStatus),
           NEMOCLAW_TEST_REVIEWED_INTEGRITY: integrity,
           NEMOCLAW_TEST_REVIEWED_TARBALL:
@@ -312,33 +320,14 @@ function writeProductionSourceGraph(
 }
 
 describe("trusted reviewed npm audit workflow (#5896)", () => {
-  it("emits a current Yarn receipt accepted by the image verifier contract", () => {
-    const fixture = runConsolidatedAuditFixture(() => {});
-    expect(fixture.result.status, fixture.result.stderr.toString()).toBe(0);
-    expect(fixture.lockedReceipt).toBeDefined();
-    expect(fixture.lockedRawReport).toBeDefined();
-    const verified = parseAndVerifyAuditReceipt(fixture.lockedReceipt!, {
-      graphId: "wechat-runtime",
-      npmVersion: "10.9.4",
-      exceptionPolicy: '{"schemaVersion":1,"exceptions":[]}\n',
-      severityThreshold: "low",
-      packageJson: fixture.lockedPackageJson,
-      packageLock: fixture.lockedPackageLock,
-      rawResponse: fixture.lockedRawReport!,
-      registryOrigin: "https://registry.yarnpkg.com",
-    });
-    expect(verified.registryOrigin).toBe("https://registry.yarnpkg.com");
-    expect(verified.argv).toEqual([
-      "audit",
-      "--registry=https://registry.yarnpkg.com",
-      "--omit=dev",
-      "--json",
-    ]);
-    expect(fixture.npmCalls.filter((call) => call.startsWith('["audit"'))).toSatisfy(
-      (calls: string[]) =>
-        calls.length > 0 &&
-        calls.every((call) => call.includes("--registry=https://registry.yarnpkg.com")),
+  it("rejects audit production when installed npm differs from the reviewed identity", () => {
+    const fixture = runConsolidatedAuditFixture(() => {}, undefined, 0, 0, "11.18.0");
+
+    expect(fixture.result.status).not.toBe(0);
+    expect(fixture.result.stderr).toContain(
+      `reviewed npm audit requires npm ${REVIEWED_AUDIT_CONFIG.npmVersion}; running npm 11.18.0`,
     );
+    expect(fixture.lockedReceipt).toBeUndefined();
   });
 
   it("restores the read-only trusted cache after offline packing fails", () => {
@@ -570,6 +559,8 @@ describe("trusted reviewed npm audit workflow (#5896)", () => {
         },
       ],
       nodeVersion: "22.23.2",
+      npmIntegrity: REVIEWED_AUDIT_CONFIG.npmIntegrity,
+      npmVersion: REVIEWED_AUDIT_CONFIG.npmVersion,
       registryOrigin: "https://registry.npmjs.org/",
       schemaVersion: 2,
       severityThreshold: "high",

--- a/test/automation/releases/reviewed-npm-audit-workflow.test.ts
+++ b/test/automation/releases/reviewed-npm-audit-workflow.test.ts
@@ -320,6 +320,27 @@ function writeProductionSourceGraph(
 }
 
 describe("trusted reviewed npm audit workflow (#5896)", () => {
+  // source-shape-contract: security -- Composite audit inputs must cross into executable shell only through the step environment
+  it("passes the cache identity target root without interpolating it into shell source", () => {
+    const actionSource = fs.readFileSync(
+      path.join(REPO_ROOT, ".github", "actions", "ci-reviewed-npm-audit", "action.yaml"),
+      "utf8",
+    );
+    const cacheBucketStep = actionSource.slice(
+      actionSource.indexOf("    - name: Resolve reviewed npm audit cache buckets"),
+      actionSource.indexOf("    - name: Restore current reviewed npm audit cache bucket"),
+    );
+    const runSource = cacheBucketStep.slice(cacheBucketStep.indexOf("      run: |"));
+
+    expect(cacheBucketStep).toContain(
+      "NEMOCLAW_REVIEWED_NPM_AUDIT_TARGET_ROOT: ${{ inputs.target-root }}",
+    );
+    expect(cacheBucketStep).toContain(
+      "const targetRoot = process.env.NEMOCLAW_REVIEWED_NPM_AUDIT_TARGET_ROOT;",
+    );
+    expect(runSource).not.toContain("${{ inputs.target-root }}");
+  });
+
   it("rejects audit production when installed npm differs from the reviewed identity", () => {
     const fixture = runConsolidatedAuditFixture(() => {}, undefined, 0, 0, "11.18.0");
 

--- a/test/automation/releases/reviewed-npm-audit-workflow.test.ts
+++ b/test/automation/releases/reviewed-npm-audit-workflow.test.ts
@@ -334,11 +334,13 @@ describe("trusted reviewed npm audit workflow (#5896)", () => {
     const cacheBucketStep = requiredStep(action.runs, "Resolve reviewed npm audit cache buckets");
 
     expect(cacheBucketStep.env).toEqual({
+      NEMOCLAW_REVIEWED_NPM_AUDIT_CACHE_DIRECTORY: "${{ inputs.cache-directory }}",
       NEMOCLAW_REVIEWED_NPM_AUDIT_TARGET_ROOT: "${{ inputs.target-root }}",
     });
     expect(cacheBucketStep.run).toContain(
       "const targetRoot = process.env.NEMOCLAW_REVIEWED_NPM_AUDIT_TARGET_ROOT;",
     );
+    expect(cacheBucketStep.run).not.toContain("${{ inputs.cache-directory }}");
     expect(cacheBucketStep.run).not.toContain("${{ inputs.target-root }}");
   });
 

--- a/test/automation/releases/reviewed-npm-audit-workflow.test.ts
+++ b/test/automation/releases/reviewed-npm-audit-workflow.test.ts
@@ -8,6 +8,7 @@ import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import YAML from "yaml";
 import {
   assertReviewedAuditReportsPass,
   NPM_AUDIT_SIGNATURE_ARGV,
@@ -43,6 +44,8 @@ type WorkflowJob = {
 type Workflow = {
   readonly jobs: Record<string, WorkflowJob>;
 };
+
+type CompositeAction = { readonly runs: WorkflowJob };
 
 const REPO_ROOT = path.join(import.meta.dirname, "../../..");
 const REVIEWED_AUDIT_CONFIG_SOURCE = fs.readFileSync(
@@ -322,23 +325,21 @@ function writeProductionSourceGraph(
 describe("trusted reviewed npm audit workflow (#5896)", () => {
   // source-shape-contract: security -- Composite audit inputs must cross into executable shell only through the step environment
   it("passes the cache identity target root without interpolating it into shell source", () => {
-    const actionSource = fs.readFileSync(
-      path.join(REPO_ROOT, ".github", "actions", "ci-reviewed-npm-audit", "action.yaml"),
-      "utf8",
-    );
-    const cacheBucketStep = actionSource.slice(
-      actionSource.indexOf("    - name: Resolve reviewed npm audit cache buckets"),
-      actionSource.indexOf("    - name: Restore current reviewed npm audit cache bucket"),
-    );
-    const runSource = cacheBucketStep.slice(cacheBucketStep.indexOf("      run: |"));
+    const action = YAML.parse(
+      fs.readFileSync(
+        path.join(REPO_ROOT, ".github", "actions", "ci-reviewed-npm-audit", "action.yaml"),
+        "utf8",
+      ),
+    ) as CompositeAction;
+    const cacheBucketStep = requiredStep(action.runs, "Resolve reviewed npm audit cache buckets");
 
-    expect(cacheBucketStep).toContain(
-      "NEMOCLAW_REVIEWED_NPM_AUDIT_TARGET_ROOT: ${{ inputs.target-root }}",
-    );
-    expect(cacheBucketStep).toContain(
+    expect(cacheBucketStep.env).toEqual({
+      NEMOCLAW_REVIEWED_NPM_AUDIT_TARGET_ROOT: "${{ inputs.target-root }}",
+    });
+    expect(cacheBucketStep.run).toContain(
       "const targetRoot = process.env.NEMOCLAW_REVIEWED_NPM_AUDIT_TARGET_ROOT;",
     );
-    expect(runSource).not.toContain("${{ inputs.target-root }}");
+    expect(cacheBucketStep.run).not.toContain("${{ inputs.target-root }}");
   });
 
   it("rejects audit production when installed npm differs from the reviewed identity", () => {

--- a/test/repository/prepare-ci-npm-install.test.ts
+++ b/test/repository/prepare-ci-npm-install.test.ts
@@ -79,6 +79,9 @@ function reviewedConfigSource(packageIdentity: ReviewedSourceRegistryPackage = r
     exceptionFile: "ci/npm-audit-exceptions.json",
     lockedGraphs: [],
     nodeVersion: "22.23.2",
+    npmIntegrity:
+      "sha512-OnUGvKW3lJs/ooPKDKUNfz1UmMfF48YWbjNA20QdiWrCVnZaAPppOfHPnfGiPb+1lKIsxjKXQ4UAfDI7PcvLPg==",
+    npmVersion: "10.9.4",
     registryOrigin: "https://registry.npmjs.org/",
     schemaVersion: 2,
     severityThreshold: "high",

--- a/test/runtime/sandbox/sandbox-build-context.test.ts
+++ b/test/runtime/sandbox/sandbox-build-context.test.ts
@@ -122,6 +122,10 @@ describe("sandbox build context staging", () => {
       path.join("ci", "npm-audit-exceptions.json"),
       `${JSON.stringify({ schemaVersion: 1, exceptions: [] })}\n`,
     );
+    writeFixture(
+      path.join("ci", "reviewed-npm-audit.json"),
+      `${JSON.stringify({ npmVersion: "10.9.4" })}\n`,
+    );
     for (const runtimeName of [
       "managed-image-messaging-runtime",
       "mcporter-runtime",

--- a/test/security/mcporter-supply-chain.test.ts
+++ b/test/security/mcporter-supply-chain.test.ts
@@ -28,11 +28,11 @@ const expectedFastUriVersion = "3.1.6";
 const expectedFastUriTarball = "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz";
 const expectedIpAddressVersion = "10.3.1";
 const expectedIpAddressTarball = "https://registry.npmjs.org/ip-address/-/ip-address-10.3.1.tgz";
-const expectedReviewedNpmVersion = "10.9.4";
 const runtimePrefix = "npm --prefix /usr/local/lib/nemoclaw/mcporter-runtime";
 const reviewedAuditConfig = JSON.parse(
   fs.readFileSync(path.join(repoRoot, "ci", "reviewed-npm-audit.json"), "utf8"),
 ) as {
+  npmVersion: string;
   lockedGraphs: Array<{
     directory: string;
     id: string;
@@ -42,6 +42,7 @@ const reviewedAuditConfig = JSON.parse(
     tarballUrl: string;
   }>;
 };
+const expectedReviewedNpmVersion = reviewedAuditConfig.npmVersion;
 const reviewedAuditDriver = fs.readFileSync(
   path.join(repoRoot, "scripts", "audit-reviewed-npm-graph.mts"),
   "utf8",
@@ -191,9 +192,7 @@ describe("mcporter image supply-chain controls", () => {
   it.each(dockerfiles)("audits the committed dependency graph in $name", ({ contents }) => {
     const flattenedContents = contents.replace(/\\\s*\n/g, " ").replace(/\s+/g, " ");
     const auditReceiptInvocation = extractAuditReceiptInvocation(contents);
-    expect(contents).toContain(
-      "COPY ci/npm-audit-exceptions.json /scripts/npm-audit-exceptions.json",
-    );
+    expect(contents).toContain("COPY ci/*npm-audit*.json /scripts/");
     expect(
       flattenedContents.includes(
         "COPY scripts/lib/reviewed-npm-archive.mts scripts/lib/bundled-npm-package.mts scripts/lib/reviewed-npm-audit.mts scripts/lib/openclaw-npm-remediation.mts /scripts/lib/",
@@ -219,8 +218,10 @@ describe("mcporter image supply-chain controls", () => {
       "--package-json /usr/local/lib/nemoclaw/mcporter-runtime/package.json --package-lock /usr/local/lib/nemoclaw/mcporter-runtime/package-lock.json --raw-report",
     );
     expect(auditReceiptInvocation).toContain(
-      `--exceptions /scripts/npm-audit-exceptions.json --graph mcporter-runtime --npm-version ${expectedReviewedNpmVersion} --registry https://registry.yarnpkg.com --threshold high --legacy-npmjs true`,
+      "--exceptions /scripts/npm-audit-exceptions.json --graph mcporter-runtime --audit-config /scripts/reviewed-npm-audit.json --registry https://registry.yarnpkg.com --threshold high --legacy-npmjs true",
     );
+    expect(expectedReviewedNpmVersion).toMatch(/^[0-9]+\.[0-9]+\.[0-9]+$/);
+    expect(auditReceiptInvocation).not.toContain("--npm-version");
     expect(auditReceiptInvocation).not.toMatch(/\bnpm\s+--version\b/);
     expect(auditReceiptInvocation).not.toMatch(/\$\(|`/);
     expect(contents).not.toContain(`${runtimePrefix} audit --omit=dev --audit-level=low`);

--- a/test/security/mcporter-supply-chain.test.ts
+++ b/test/security/mcporter-supply-chain.test.ts
@@ -192,7 +192,9 @@ describe("mcporter image supply-chain controls", () => {
   it.each(dockerfiles)("audits the committed dependency graph in $name", ({ contents }) => {
     const flattenedContents = contents.replace(/\\\s*\n/g, " ").replace(/\s+/g, " ");
     const auditReceiptInvocation = extractAuditReceiptInvocation(contents);
-    expect(contents).toContain("COPY ci/*npm-audit*.json /scripts/");
+    expect(contents).toContain(
+      "COPY ci/npm-audit-exceptions.json ci/reviewed-npm-audit.json /scripts/",
+    );
     expect(
       flattenedContents.includes(
         "COPY scripts/lib/reviewed-npm-archive.mts scripts/lib/bundled-npm-package.mts scripts/lib/reviewed-npm-audit.mts scripts/lib/openclaw-npm-remediation.mts /scripts/lib/",

--- a/test/security/mcporter-supply-chain.test.ts
+++ b/test/security/mcporter-supply-chain.test.ts
@@ -67,6 +67,19 @@ function extractIntegrityGate(contents: string): string {
     .trim();
 }
 
+function extractAuditReceiptInvocation(contents: string): string {
+  const startMarker = "node --experimental-strip-types /scripts/lib/npm-audit-receipt.mts";
+  const endMarker = "--legacy-npmjs true";
+  const start = contents.indexOf(startMarker);
+  const end = contents.indexOf(endMarker, start);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return contents
+    .slice(start, end + endMarker.length)
+    .replace(/\\\s*\n/g, " ")
+    .replace(/\s+/g, " ");
+}
+
 function runIntegrityGate(contents: string, version: string) {
   const script = [
     "set -euo pipefail",
@@ -177,6 +190,7 @@ describe("mcporter image supply-chain controls", () => {
 
   it.each(dockerfiles)("audits the committed dependency graph in $name", ({ contents }) => {
     const flattenedContents = contents.replace(/\\\s*\n/g, " ").replace(/\s+/g, " ");
+    const auditReceiptInvocation = extractAuditReceiptInvocation(contents);
     expect(contents).toContain(
       "COPY ci/npm-audit-exceptions.json /scripts/npm-audit-exceptions.json",
     );
@@ -204,10 +218,11 @@ describe("mcporter image supply-chain controls", () => {
     expect(flattenedContents).toContain(
       "--package-json /usr/local/lib/nemoclaw/mcporter-runtime/package.json --package-lock /usr/local/lib/nemoclaw/mcporter-runtime/package-lock.json --raw-report",
     );
-    expect(flattenedContents).toContain(
+    expect(auditReceiptInvocation).toContain(
       `--exceptions /scripts/npm-audit-exceptions.json --graph mcporter-runtime --npm-version ${expectedReviewedNpmVersion} --registry https://registry.yarnpkg.com --threshold high --legacy-npmjs true`,
     );
-    expect(flattenedContents).not.toContain('--npm-version "$(npm --version)"');
+    expect(auditReceiptInvocation).not.toMatch(/\bnpm\s+--version\b/);
+    expect(auditReceiptInvocation).not.toMatch(/\$\(|`/);
     expect(contents).not.toContain(`${runtimePrefix} audit --omit=dev --audit-level=low`);
     expect(contents).not.toContain(`${runtimePrefix} audit signatures`);
     expect(flattenedContents).toContain(

--- a/test/security/mcporter-supply-chain.test.ts
+++ b/test/security/mcporter-supply-chain.test.ts
@@ -28,6 +28,7 @@ const expectedFastUriVersion = "3.1.6";
 const expectedFastUriTarball = "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz";
 const expectedIpAddressVersion = "10.3.1";
 const expectedIpAddressTarball = "https://registry.npmjs.org/ip-address/-/ip-address-10.3.1.tgz";
+const expectedReviewedNpmVersion = "10.9.4";
 const runtimePrefix = "npm --prefix /usr/local/lib/nemoclaw/mcporter-runtime";
 const reviewedAuditConfig = JSON.parse(
   fs.readFileSync(path.join(repoRoot, "ci", "reviewed-npm-audit.json"), "utf8"),
@@ -204,11 +205,9 @@ describe("mcporter image supply-chain controls", () => {
       "--package-json /usr/local/lib/nemoclaw/mcporter-runtime/package.json --package-lock /usr/local/lib/nemoclaw/mcporter-runtime/package-lock.json --raw-report",
     );
     expect(flattenedContents).toContain(
-      "--exceptions /scripts/npm-audit-exceptions.json --graph mcporter-runtime --npm-version",
+      `--exceptions /scripts/npm-audit-exceptions.json --graph mcporter-runtime --npm-version ${expectedReviewedNpmVersion} --registry https://registry.yarnpkg.com --threshold high --legacy-npmjs true`,
     );
-    expect(flattenedContents).toContain(
-      "--registry https://registry.yarnpkg.com --threshold high --legacy-npmjs true",
-    );
+    expect(flattenedContents).not.toContain('--npm-version "$(npm --version)"');
     expect(contents).not.toContain(`${runtimePrefix} audit --omit=dev --audit-level=low`);
     expect(contents).not.toContain(`${runtimePrefix} audit signatures`);
     expect(flattenedContents).toContain(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

The reviewed npm audit producer and both Docker receipt consumers now use one canonical npm identity. A receipt mismatch stops image assembly before the verifier publishes its policy result or raw audit report.

## Reason

Main run 33883013315 and PR run 33883290530 rejected valid receipts with `receipt identity does not match expected graph and npm`. The trusted producer used npm 10.9.4, while image verification derived a different identity from the image runtime. That split allowed the audit and image paths to disagree.

## Changes

- Store the reviewed npm version and integrity in `ci/reviewed-npm-audit.json`.
- Make the audit action, audit producer, optimized build context, and both Docker consumers read that canonical identity.
- Pass both reusable-action paths through the step environment instead of interpolating them into shell source.
- Reject audit production when the executing npm version differs from the reviewed version.
- Copy the raw audit report only after receipt and current-policy verification succeed.
- Copy both reviewed audit inputs explicitly so the old-base build-context allowlist remains valid.
- Add an executable receipt-producer-to-Docker-consumer contract test for the accepted identity.
- Add a negative version-mismatch case that proves neither consumer output is written.
- Keep all reviewed-audit test fixtures on the canonical npm identity contract.

## Verification

- Focused integration suites — 85 passed, 2 skipped.
- Old-base E2E-support contract — 15 passed.
- Codebase growth guardrails — 45 passed.
- `npm run checks:repository` — passed.
- `npm run source-shape:check` — passed.
- `npm run build:cli` — passed.
- `npm run typecheck:cli` — passed.
- Pre-commit, commit-message, and pre-push hooks — passed, including Hadolint.
- Independent documentation writer review of `83c0a2c22` — passed with no findings; no documentation change required.
- GitHub verification for `83c0a2c22` — Verified.
- Diff inspection and gitleaks hook — no secrets, API keys, or credentials found.

## Completion gate

- Passed for `83c0a2c22`: the [OpenClaw image job](https://github.com/NVIDIA/NemoClaw/actions/runs/33899271986/job/101110452219) rebuilt the changed base, consumed the same-run receipt, passed direct startup, published the exact PR digest, re-pulled and validated it, and uploaded the immutable contract.
- After merge, successful production base-image publication remains required before the repair is treated as complete.

## Review notes

- Sensitive-path context: this repairs the receipt-identity failure in main run [33883013315](https://github.com/NVIDIA/NemoClaw/actions/runs/33883013315) and PR run [33883290530](https://github.com/NVIDIA/NemoClaw/actions/runs/33883290530). Receipt hash, graph, lockfile, exception-policy, raw-report, registry, threshold, and lifetime checks remain enforced.

---
Signed-off-by: San Dang <sdang@nvidia.com>
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>
