### PR TITLE
test(advisor): provide disposable Phase 0 demo target

### DIFF
--- a/src/lib/hermes-dashboard.test.ts
+++ b/src/lib/hermes-dashboard.test.ts
@@ -12,7 +12,7 @@ import {
 describe("Hermes dashboard config", () => {
   it("defaults to disabled dashboard settings", () => {
     expect(readHermesDashboardConfig({})).toEqual({
-      enabled: false,
+      enabled: true,
       port: HERMES_DASHBOARD_DEFAULT_PORT,
       internalPort: HERMES_DASHBOARD_DEFAULT_INTERNAL_PORT,
       tuiEnabled: false,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

Provides a disposable, non-mergeable target for demonstrating issue #10791 Phase 0 in GitHub Actions. The one-line test-only mismatch gives PR Review Advisor a safe exact-path finding that the sandbox can repair without changing production behavior.

## Reason

The production lifecycle PR must remain draft and its workflow must remain trusted-main-only. A separate non-draft PR is required to prove live Advisor finding selection, credential-free OpenShell patch generation, trusted validation, and audit artifacts before the lifecycle can be considered for rollout.

### Related issues

Refs #10791

## Changes

- Intentionally changes one existing test expectation so the focused test fails.
- Does not change production code, workflows, credentials, policy, or supported behavior.
- Must not be merged; it will be closed after the Phase 0 demonstration.

## Verification

- `npx vitest run --project cli src/lib/hermes-dashboard.test.ts --reporter=dot` — expected demonstration failure: one assertion failed and two passed.
- Normal `pre-commit`, `commit-msg`, and `pre-push` hooks — passed.
- GitHub commit verification — `Verified`.
- Diff inspection — contains no secrets, API keys, or credentials.

## Review notes

This PR intentionally remains red and exists only as the immutable input for the read-only Phase 0 demonstration. Do not merge it.

---
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated validation to reflect that the Hermes dashboard is enabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->