### PR TITLE
fix(cli): resolve the pinned base when rebuild has no hint

### DIFF
--- a/src/lib/actions/sandbox/rebuild-agent-base-image-preflight.test.ts
+++ b/src/lib/actions/sandbox/rebuild-agent-base-image-preflight.test.ts
@@ -48,6 +48,10 @@ function loadDockerImage(): DockerImageModule {
   return requireDist(dockerImagePath);
 }
 
+function failUnreachableSourceBuild(): never {
+  throw new Error("Failed to build Hermes Agent base image (exit 1)");
+}
+
 function makeBail(): (msg: string, code?: number) => never {
   return (msg: string) => {
     throw new Error(`bail: ${msg}`);
@@ -129,17 +133,61 @@ describe("ensureRebuildAgentBaseImage", () => {
     });
   });
 
-  it("preserves the forced local rebuild path for legacy sandboxes without a hint (#4680)", () => {
+  it("resolves the release-pinned base for a managed sandbox with no cached hint (#10903)", () => {
     const { agent, ensureAgentBaseImage } = setup();
+    // The reporter upgraded a v0.0.109 managed sandbox whose image carried no
+    // resolution metadata. A source build on that host died fetching libssh2,
+    // so recovery must reach the release's published base instead.
+    ensureAgentBaseImage.mockImplementation((_agent, options = {}) =>
+      options.forceBaseImageRebuild
+        ? failUnreachableSourceBuild()
+        : { imageTag: cachedRemoteRef, built: false },
+    );
+    const { ensureRebuildAgentBaseImage } = loadRebuildFlowHelpers();
+
+    expect(ensureRebuildAgentBaseImage("hermes", makeBail())).toEqual({
+      ok: true,
+      imageRef: cachedRemoteRef,
+      overrideEnvVar,
+    });
+    expect(ensureAgentBaseImage).toHaveBeenCalledOnce();
+    expect(ensureAgentBaseImage).toHaveBeenCalledWith(agent, {
+      forceBaseImageRebuild: false,
+    });
+  });
+
+  it("still binds a resolver-selected fresh local base to a forced build (#10903)", () => {
+    const { ensureAgentBaseImage } = setup();
+    const freshLocalMetadata = {
+      key: "fresh-local",
+      ref: rebuiltLocalRef,
+      digest: null,
+      source: "local",
+      imageId: `sha256:${"c".repeat(64)}`,
+    } as SandboxBaseImageResolutionMetadata;
+    ensureAgentBaseImage
+      .mockReturnValueOnce({
+        imageTag: rebuiltLocalRef,
+        built: false,
+        resolutionMetadata: freshLocalMetadata,
+      })
+      .mockReturnValueOnce({
+        imageTag: rebuiltLocalRef,
+        built: true,
+        resolutionMetadata: freshLocalMetadata,
+        trustedLocalOverride: rebuiltLocalTrust,
+      });
     const { ensureRebuildAgentBaseImage } = loadRebuildFlowHelpers();
 
     expect(ensureRebuildAgentBaseImage("hermes", makeBail())).toEqual({
       ok: true,
       imageRef: rebuiltLocalRef,
       overrideEnvVar,
+      resolutionMetadata: freshLocalMetadata,
       trustedLocalOverride: rebuiltLocalTrust,
     });
-    expect(ensureAgentBaseImage).toHaveBeenCalledWith(agent, {
+    expect(ensureAgentBaseImage).toHaveBeenCalledTimes(2);
+    expect(ensureAgentBaseImage).toHaveBeenNthCalledWith(2, expect.anything(), {
       forceBaseImageRebuild: true,
     });
   });

--- a/src/lib/actions/sandbox/rebuild-flow-helpers.test.ts
+++ b/src/lib/actions/sandbox/rebuild-flow-helpers.test.ts
@@ -164,7 +164,7 @@ describe("rebuild agent base image preflight", () => {
     };
   }
 
-  it("forces a repository-local build and returns its exact ref when no override exists", () => {
+  it("returns the exact repository-local ref the resolver selected when no override exists", () => {
     const imageRef = `nemoclaw-hermes-sandbox-base-local:image-${"a".repeat(64)}`;
     const trustedLocalOverride = {
       ref: imageRef,
@@ -180,7 +180,7 @@ describe("rebuild agent base image preflight", () => {
     const result = ensureRebuildAgentBaseImage("hermes", makeBail());
 
     expect(ensureAgentBaseImage).toHaveBeenCalledWith(expect.objectContaining({ name: "hermes" }), {
-      forceBaseImageRebuild: true,
+      forceBaseImageRebuild: false,
     });
     expect(result).toEqual({
       ok: true,

--- a/src/lib/actions/sandbox/rebuild-flow-helpers.ts
+++ b/src/lib/actions/sandbox/rebuild-flow-helpers.ts
@@ -294,7 +294,14 @@ export function ensureRebuildAgentBaseImage(
     let result: ReturnType<typeof ensureAgentBaseImage>;
     try {
       result = ensureAgentBaseImage(agentDef, {
-        forceBaseImageRebuild: !hasExplicitOverride && !options.resolutionHint,
+        // A missing resolution hint is a cache miss, not authority to compile
+        // a base image from source. The resolver already routes genuine local
+        // intent — changed base inputs, or a repository-built local image — to
+        // a validated local build, and otherwise resolves the release's pinned
+        // published base. Forcing a rebuild here made a stock managed upgrade
+        // depend on reaching every source archive the Dockerfile fetches
+        // (#10903).
+        forceBaseImageRebuild: false,
         ...(options.resolutionHint !== undefined ? { resolutionHint: options.resolutionHint } : {}),
         ...(options.forceBaseImageRefresh !== undefined
           ? { forceBaseImageRefresh: options.forceBaseImageRefresh }


### PR DESCRIPTION
## Outcome

Recovering a managed sandbox whose image carries no cached base-image resolution metadata now resolves the release's pinned published Hermes base instead of compiling `agents/hermes/Dockerfile.base` locally. Before this change a stock `lkg` upgrade entered a network-dependent source build and could fail on an unreachable source archive; after it the same upgrade uses the immutable base the release already publishes and validates. The sandbox is untouched either way, because this runs in rebuild preflight.

## Reason

`ensureRebuildAgentBaseImage` passed `forceBaseImageRebuild: !hasExplicitOverride && !options.resolutionHint`, which made a missing hint sufficient to force local compilation. The hint is read from the existing sandbox image, so a sandbox created before cached resolution metadata existed never supplies one. The reported v0.0.109 to v0.0.118 upgrade therefore compiled the base locally and exhausted its `curl` attempts fetching libssh2, even though v0.0.118 pins a validated published Hermes base.

Absence of a hint is a cache and provenance miss. It is not a request to build from source.

### Related issues

Fixes #10903
Refs #10942

## Changes

- `src/lib/actions/sandbox/rebuild-flow-helpers.ts`: rebuild preflight no longer derives local-build authority from hint absence. Base selection stays with `resolveSandboxBaseImage`, which already separates the two intents:
  - genuine local intent, meaning base inputs that are dirty (`baseImageInputsDirty`) or diverged from main (`baseImageInputsChangedSinceMain`), still reaches a validated local build through `resolveChangedInputs`;
  - otherwise Hermes resolves its Dockerfile-pinned remote ref under `requirePinnedRemoteRef` and applies the existing repository, immutable digest, platform, OpenShell ABI, MCP Streamable HTTP and ACP, and security-inventory checks before the ref is returned.
- No new mechanism. The existing fallback in the same function still re-runs a forced, provenance-bound build whenever the resolver selects a local image without a trust lease, so the local path keeps its exact in-memory lease and its canonical image binding.
- Tests: a regression test whose resolver fails every source build and still recovers through the published base (this is red on `main`), and a test that the resolver-selected fresh local base still gets its forced provenance rebuild. Two existing expectations that asserted the forced call are updated.

Checked adjacent callers: `rebuild-dcode-preflight.ts` does not share this defect. It attempts `forceBaseImageRefresh: true` first and only falls back to `forceBaseImageRebuild: true` when that throws, and Deep Agents Code rebuilds skip this helper entirely. `#4680`'s original hint-present coverage is unchanged and still asserted by the sibling test in the same file.

## Verification

- `npm run validate:pr` — passed
- `npm run typecheck:cli` — passed
- `npm run checks:repository` — passed
- `npx vitest run --project cli src/lib/actions/sandbox/rebuild-agent-base-image-preflight.test.ts src/lib/actions/sandbox/rebuild-flow-helpers.test.ts src/lib/actions/sandbox/rebuild-base-image-resolution-flow.test.ts` — 3 files, 40 tests passed
- Red proof: with only `rebuild-flow-helpers.ts` reverted to `main`, the new test fails with the reported symptom, `Rebuild preflight failed: agent base image could not be built. Sandbox is untouched`
- `npx vitest run --project cli --no-file-parallelism src/lib/actions/sandbox/ src/lib/agent/ src/lib/sandbox-base-image*.test.ts` — 4137 passed; the 4 failures reproduce identically on `origin/main` with this change reverted and are unrelated to base-image resolution
- No secrets, API keys, or credentials in the diff

## Review notes

Scope. This closes the reported defect and the acceptance criteria that follow from it: the hintless qualified upgrade uses the release's exact published base, does not run `Dockerfile.base` or contact `libssh2.org`, validates before any destructive phase, persists reusable resolution metadata through the existing handoff, and keeps the explicit provenance-bound local rebuild working.

Two items from the issue are deliberately not in this change:

- "never falls back to local compilation" on a pinned-image pull or validation failure. That fallback lives in `resolveSandboxBaseImage` and is shared with onboarding, so changing it alters behavior well outside recovery and deserves its own issue and its own regression evidence.
- The live end-to-end target that denies `libssh2.org`. The nearest existing coverage is the Hermes rebuild bootstrap, which already resolves the current base with `NEMOCLAW_SANDBOX_BASE_LOCAL_BUILD=0` and asserts the direct script never passes `forceBaseImageRebuild`. Recording this as a combinatorial gap rather than adding a speculative target: the missing dimension is a denied source host during an installer-driven upgrade of a hintless managed sandbox, and it needs the qualified-legacy-sandbox fixture that #10903's reproducer describes.

One known cost. In a source checkout whose base inputs differ from main and that has no cached hint, the resolver's own local build is now followed by the existing forced provenance build, so that path performs two builds instead of one. The second is served from Docker's layer cache, and it is the same cost the stale-hint path already pays today.

One residual behavior note. A source tree with no Git metadata cannot prove its base inputs differ from main, so an edited `Dockerfile.base` there is not detected as local intent and the pinned published base is used. That already matches what onboarding does in the same tree; `NEMOCLAW_HERMES_SANDBOX_BASE_IMAGE_REF` remains the explicit override.

---
Signed-off-by: harjoth <harjoth.khara@gmail.com>

P.S. I'm looking for a job — if my work here is useful, I'd love to talk: harjoth.khara@gmail.com


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Sandbox rebuilds no longer unnecessarily require access to source archives when a validated local or release-pinned base image is available.
  - Improved fallback behavior for managed sandboxes without cached image-resolution metadata.
  - Rebuilds now correctly use freshly resolved local base images while preserving trusted image handoff behavior.
- **Tests**
  - Expanded coverage for unavailable source builds, cached fallback images, and resolver-selected local images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->