### PR TITLE
fix(readiness): record host OS distribution and warn on unqualified release (#11026)

### DIFF
--- a/src/lib/inference/serving/adapter-registry.ts
+++ b/src/lib/inference/serving/adapter-registry.ts
@@ -886,6 +886,14 @@ const SERVING_READINESS_REGISTRY: ServingCatalogRegistries["readiness"] =
     ],
     ["host.os.wsl", { kind: "observation", valueType: "boolean" }],
     [
+      "host.os.distribution",
+      { kind: "observation", valueType: "string" },
+    ],
+    [
+      "host.os.version",
+      { kind: "observation", valueType: "string" },
+    ],
+    [
       "host.docker.runtime",
       { kind: "observation", valueType: "string", role: "container-runtime" },
     ],

--- a/src/lib/readiness/host.test.ts
+++ b/src/lib/readiness/host.test.ts
@@ -32,6 +32,8 @@ function emptyPlatformIdentity() {
     nvidiaPlatform: null,
     stationProfile: null,
     stationGb300PciGpu: null,
+    osId: "ubuntu",
+    osVersionId: "24.04",
   };
 }
 
@@ -334,6 +336,77 @@ describe("host readiness projection (#7408)", () => {
         { id: "host.gpu.driver_version", state: "present", value: "580.65.06" },
       ]),
     );
+  });
+
+  it("projects host OS distribution and version observations (#11026)", () => {
+    const result = report(
+      {},
+      {
+        platformIdentity: {
+          productName: null,
+          nvidiaPlatform: null,
+          stationProfile: null,
+          stationGb300PciGpu: null,
+          osId: "ubuntu",
+          osVersionId: "24.04.4 LTS (Noble Numbat)",
+        },
+      },
+    );
+
+    expect(result.observations).toEqual(
+      expect.arrayContaining([
+        { id: "host.os.distribution", state: "present", value: "ubuntu" },
+        {
+          id: "host.os.version",
+          state: "present",
+          value: "24.04.4 LTS (Noble Numbat)",
+        },
+      ]),
+    );
+  });
+
+  it("warns about an unqualified host operating system release (#11026)", () => {
+    const result = report(
+      {},
+      {
+        platformIdentity: {
+          productName: null,
+          nvidiaPlatform: null,
+          stationProfile: null,
+          stationGb300PciGpu: null,
+          osId: "fedora",
+          osVersionId: "40",
+        },
+      },
+    );
+
+    expect(result.status).toBe("supported");
+    expect(result.findings).toContainEqual(
+      expect.objectContaining({
+        id: "host.platform.os_unqualified",
+        severity: "warning",
+        summary:
+          "Host operating system release 'fedora 40' is not qualified. NemoClaw is qualified on Ubuntu 24.04.",
+      }),
+    );
+  });
+
+  it("does not warn about qualified Ubuntu 24.04 operating system release (#11026)", () => {
+    const result = report(
+      {},
+      {
+        platformIdentity: {
+          productName: null,
+          nvidiaPlatform: null,
+          stationProfile: null,
+          stationGb300PciGpu: null,
+          osId: "ubuntu",
+          osVersionId: "24.04",
+        },
+      },
+    );
+
+    expect(result.findings.map(({ id }) => id)).not.toContain("host.platform.os_unqualified");
   });
 
   it("keeps the default WSL Docker Desktop GPU observation container-free", () => {

--- a/src/lib/readiness/host.ts
+++ b/src/lib/readiness/host.ts
@@ -253,6 +253,7 @@ function observeHost(
             collectPlatformIdentity({
               ...options.platformIdentityOptions,
               isWsl: assessment.isWsl,
+              platform: assessment.platform,
               runCaptureImpl,
             }))
         )(),
@@ -300,6 +301,8 @@ function unknownProjection(evidenceIds: readonly string[]): {
     "host.os.platform",
     "host.os.architecture",
     "host.os.wsl",
+    "host.os.distribution",
+    "host.os.version",
     "host.session.headless",
     "host.docker.installed",
     "host.docker.reachable",
@@ -424,6 +427,8 @@ export function projectHostReadiness(
       observation("host.os.platform", host.platform),
       observation("host.os.architecture", host.architecture),
       observation("host.os.wsl", host.isWsl),
+      observation("host.os.distribution", host.platformIdentity?.osId),
+      observation("host.os.version", host.platformIdentity?.osVersionId),
       observation("host.session.headless", host.isHeadlessLikely),
       observation("host.docker.installed", host.dockerInstalled),
       observation("host.docker.reachable", dockerHostBlocks ? undefined : host.dockerReachable),

--- a/src/lib/readiness/platform-qualification.test.ts
+++ b/src/lib/readiness/platform-qualification.test.ts
@@ -847,4 +847,127 @@ describe("platform readiness qualification (#7410)", () => {
       n1xPciGpu: undefined,
     });
   });
+
+  it("collects host OS distribution and version from os-release across platforms (#11026)", () => {
+    const linuxIdentity = collectPlatformIdentity({
+      osReleasePath: "/fixtures/os-release",
+      readFile: (filePath) =>
+        filePath === "/fixtures/os-release"
+          ? 'NAME="Ubuntu"\nVERSION_ID="24.04.4 LTS (Noble Numbat)"\nID=ubuntu\n'
+          : unexpectedFixturePath(filePath),
+    });
+    expect(linuxIdentity.osId).toBe("ubuntu");
+    expect(linuxIdentity.osVersionId).toBe("24.04.4 LTS (Noble Numbat)");
+
+    const singleQuoteIdentity = collectPlatformIdentity({
+      osReleasePath: "/fixtures/os-release",
+      readFile: (filePath) =>
+        filePath === "/fixtures/os-release"
+          ? "ID='fedora'\nVERSION_ID='40'\n"
+          : unexpectedFixturePath(filePath),
+    });
+    expect(singleQuoteIdentity.osId).toBe("fedora");
+    expect(singleQuoteIdentity.osVersionId).toBe("40");
+
+    const wslIdentity = collectPlatformIdentity({
+      isWsl: true,
+      osReleasePath: "/fixtures/os-release",
+      readFile: (filePath) =>
+        filePath === "/fixtures/os-release"
+          ? 'ID="ubuntu"\nVERSION_ID="24.04"\n'
+          : unexpectedFixturePath(filePath),
+    });
+    expect(wslIdentity.osId).toBe("ubuntu");
+    expect(wslIdentity.osVersionId).toBe("24.04");
+
+    const macosIdentity = collectPlatformIdentity({
+      platform: "darwin",
+    });
+    expect(macosIdentity.osId).toBe("macos");
+    expect(typeof macosIdentity.osVersionId).toBe("string");
+  });
+
+  it("warns when host operating system release is not qualified (#11026)", () => {
+    const fedoraResult = projectPlatformQualification(
+      input({
+        platform: "linux",
+        architecture: "x64",
+        osId: "fedora",
+        osVersionId: "40",
+      }),
+    );
+    expect(capability(fedoraResult, "host.platform.linux_supported")).toBe("present");
+    expect(fedoraResult.findings).toContainEqual(
+      expect.objectContaining({
+        id: "host.platform.os_unqualified",
+        severity: "warning",
+        capabilityIds: ["host.platform.linux_supported"],
+        evidenceIds: ["host.platform.identity"],
+        summary:
+          "Host operating system release 'fedora 40' is not qualified. NemoClaw is qualified on Ubuntu 24.04.",
+      }),
+    );
+
+    const oldUbuntuResult = projectPlatformQualification(
+      input({
+        platform: "linux",
+        architecture: "x64",
+        osId: "ubuntu",
+        osVersionId: "22.04",
+      }),
+    );
+    expect(oldUbuntuResult.findings).toContainEqual(
+      expect.objectContaining({
+        id: "host.platform.os_unqualified",
+        severity: "warning",
+        summary:
+          "Host operating system release 'ubuntu 22.04' is not qualified. NemoClaw is qualified on Ubuntu 24.04.",
+      }),
+    );
+
+    const missingOsResult = projectPlatformQualification(
+      input({
+        platform: "linux",
+        architecture: "x64",
+        osId: null,
+        osVersionId: null,
+      }),
+    );
+    expect(missingOsResult.findings).toContainEqual(
+      expect.objectContaining({
+        id: "host.platform.os_unqualified",
+        severity: "warning",
+        summary:
+          "Host operating system release is not qualified. NemoClaw is qualified on Ubuntu 24.04.",
+      }),
+    );
+  });
+
+  it("does not warn about qualified Ubuntu 24.04, macOS, or N1x releases (#11026)", () => {
+    const ubuntu2404Result = projectPlatformQualification(
+      input({
+        platform: "linux",
+        architecture: "x64",
+        osId: "ubuntu",
+        osVersionId: "24.04.4 LTS (Noble Numbat)",
+      }),
+    );
+    expect(ubuntu2404Result.findings.map(({ id }) => id)).not.toContain(
+      "host.platform.os_unqualified",
+    );
+
+    const macosResult = projectPlatformQualification(
+      input({
+        platform: "darwin",
+        architecture: "arm64",
+        runtime: "docker-desktop",
+        dockerReachable: true,
+        osId: "macos",
+        osVersionId: "25.5.0",
+      }),
+    );
+    expect(macosResult.findings.map(({ id }) => id)).not.toContain(
+      "host.platform.os_unqualified",
+    );
+  });
 });

--- a/src/lib/readiness/platform-qualification.ts
+++ b/src/lib/readiness/platform-qualification.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import type { NvidiaPlatform } from "../inference/nim.js";
 import { collectN1xIdentity, type N1xIdentityOptions } from "../inference/platform-identity/n1x.js";
@@ -61,6 +62,7 @@ export interface CollectPlatformIdentityOptions extends N1xIdentityOptions {
   stationReleasePath?: string;
   osReleasePath?: string;
   isWsl?: boolean;
+  platform?: string;
   runCaptureImpl?: (
     command: readonly string[],
     options?: { ignoreError?: boolean },
@@ -134,11 +136,12 @@ function nvidiaPlatformFromProduct(productName: string | undefined): NvidiaPlatf
 function parseOsRelease(contents: string): { osId?: string; osVersionId?: string } {
   const values = new Map<string, string>();
   for (const line of contents.split("\n")) {
-    const match = /^(ID|VERSION_ID)=(?:"([^"]*)"|([A-Za-z0-9._-]+))$/.exec(line);
+    const trimmed = line.trim();
+    const match = /^(ID|VERSION_ID)=(?:"([^"]*)"|'([^']*)'|([A-Za-z0-9._-]+))$/.exec(trimmed);
     if (!match) continue;
-    const [, key, quotedValue, plainValue] = match;
+    const [, key, doubleQuoted, singleQuoted, plainValue] = match;
     if (!key || values.has(key)) continue;
-    values.set(key, quotedValue ?? plainValue ?? "");
+    values.set(key, doubleQuoted ?? singleQuoted ?? plainValue ?? "");
   }
   return {
     osId: values.get("ID"),
@@ -274,6 +277,14 @@ export function collectPlatformIdentity(
   );
   const n1xWslProduct = collectN1xWslProduct(options);
   const wslIdentity = options.isWsl ? { n1xWslProduct } : {};
+
+  const osRelease = readOptional(readFile, options.osReleasePath ?? "/etc/os-release");
+  let { osId, osVersionId } = osRelease ? parseOsRelease(osRelease) : {};
+  if (!osId && options.platform === "darwin") {
+    osId = "macos";
+    osVersionId = os.release();
+  }
+
   let nvidiaPlatform = nvidiaPlatformFromProduct(productName);
   if (nvidiaPlatform === undefined) {
     const n1xIdentity = collectN1xIdentity({
@@ -296,12 +307,20 @@ export function collectPlatformIdentity(
         n1xCandidate: true,
         n1xFastOsMarker: n1xIdentity.fastOsMarker,
         n1xPciGpu: n1xIdentity.pciGpu,
+        ...(osId !== undefined ? { osId } : {}),
+        ...(osVersionId !== undefined ? { osVersionId } : {}),
       };
     }
   }
-  if (nvidiaPlatform !== "station") return { nvidiaPlatform, productName, ...wslIdentity };
-  const osRelease = readOptional(readFile, options.osReleasePath ?? "/etc/os-release");
-  const { osId, osVersionId } = osRelease ? parseOsRelease(osRelease) : {};
+  if (nvidiaPlatform !== "station") {
+    return {
+      nvidiaPlatform,
+      productName,
+      ...wslIdentity,
+      ...(osId !== undefined ? { osId } : {}),
+      ...(osVersionId !== undefined ? { osVersionId } : {}),
+    };
+  }
 
   const stationReleasePath = options.stationReleasePath ?? "/etc/dgx-release";
   let stationProfile: StationProfile = "generic-ubuntu";
@@ -340,8 +359,8 @@ export function collectPlatformIdentity(
       readdir,
       options.pciDevicesPath ?? "/sys/bus/pci/devices",
     ),
-    osId,
-    osVersionId,
+    ...(osId !== undefined ? { osId } : {}),
+    ...(osVersionId !== undefined ? { osVersionId } : {}),
   };
 }
 
@@ -393,6 +412,16 @@ function deriveN1xWslQualification(
     input.hasNvidiaGpu
     ? "qualified"
     : "unqualified";
+}
+
+function formatUnqualifiedOsSummary(
+  osId: string | null | undefined,
+  osVersionId: string | null | undefined,
+): string {
+  const label = [osId, osVersionId].filter(Boolean).join(" ");
+  return label
+    ? `Host operating system release '${label}' is not qualified. NemoClaw is qualified on Ubuntu 24.04.`
+    : "Host operating system release is not qualified. NemoClaw is qualified on Ubuntu 24.04.";
 }
 
 export function projectPlatformQualification(
@@ -671,6 +700,37 @@ export function projectPlatformQualification(
       summary: "N1x qualification is inconclusive and fails closed.",
       capabilityIds: ["host.platform.n1x", "host.platform.supported"],
       ...(evidence.length ? { evidenceIds: ["host.platform.identity"] } : {}),
+    });
+  }
+  const linuxOsQualified =
+    input.platform !== "linux" ||
+    n1x.identity ||
+    (input.osId === "ubuntu" && Boolean(input.osVersionId?.startsWith("24.04")));
+  if (!linuxOsQualified) {
+    if (!evidence.some(({ id }) => id === "host.platform.identity")) {
+      evidence.push({
+        id: "host.platform.identity",
+        summary: "Bounded platform identity used for qualification.",
+        details: {
+          product: input.productName?.slice(0, 256) ?? null,
+          nvidiaPlatform: input.nvidiaPlatform ?? null,
+          n1xCandidate: input.n1xCandidate ?? null,
+          n1xFastOsMarker: input.n1xFastOsMarker ?? null,
+          n1xPciGpu: input.n1xPciGpu ?? null,
+          n1xWslProduct: input.n1xWslProduct ?? null,
+          stationProfile: input.stationProfile ?? null,
+          stationGb300PciGpu: input.stationGb300PciGpu ?? null,
+          osId: input.osId ?? null,
+          osVersionId: input.osVersionId ?? null,
+        },
+      });
+    }
+    findings.push({
+      id: "host.platform.os_unqualified",
+      severity: "warning",
+      summary: formatUnqualifiedOsSummary(input.osId, input.osVersionId),
+      capabilityIds: ["host.platform.linux_supported"],
+      evidenceIds: ["host.platform.identity"],
     });
   }
   if (


### PR DESCRIPTION
## Scope

Fixes #11026.

`nemoclaw host probe` previously omitted the host operating system distribution and version, recording only platform family (`host.os.platform`), architecture, and WSL presence. As a result, hosts running unsupported or untested Linux operating system releases were never surfaced to the user before installation or onboarding proceeded, and no finding of any severity was emitted.

## Changes

1. **Host Readiness Observations (`src/lib/readiness/host.ts`)**:
   - Added `host.os.distribution` and `host.os.version` to host readiness observations, populated from `host.platformIdentity?.osId` and `host.platformIdentity?.osVersionId`.
   - Included both observations in the fail-closed `unknownProjection` observation list.
   - Passed `platform: assessment.platform` to `collectPlatformIdentity`.

2. **Platform Qualification & Warning Finding (`src/lib/readiness/platform-qualification.ts`)**:
   - Updated `collectPlatformIdentity()` to parse `/etc/os-release` across all Linux/WSL platforms rather than limiting it to DGX Station, extracting `osId` and `osVersionId` with support for double-quoted, single-quoted, and unquoted values.
   - Populated `osId: "macos"` and `osVersionId: os.release()` when `platform === "darwin"`.
   - Added `host.platform.os_unqualified` warning finding when running an unqualified Linux operating system release (NemoClaw is qualified on Ubuntu 24.04). Because the finding has severity `warning`, `outcomeFor` preserves deterministic exit code 0 (`supported`) while alerting users early in text and JSON output.

3. **Serving Readiness Registry (`src/lib/inference/serving/adapter-registry.ts`)**:
   - Registered `host.os.distribution` and `host.os.version` as valid string observation entries in `SERVING_READINESS_REGISTRY`.

4. **Testing & Coverage**:
   - Added comprehensive unit tests in `src/lib/readiness/platform-qualification.test.ts` covering `/etc/os-release` parsing across platforms, warning emissions on unqualified distributions (e.g. Fedora 40, Ubuntu 22.04, missing OS release), and clean qualification for Ubuntu 24.04, macOS, and N1x.
   - Added unit tests in `src/lib/readiness/host.test.ts` verifying host OS distribution and version observations and warning finding behavior.
   - Updated `emptyPlatformIdentity()` test fixture baseline to reflect standard qualified Linux host.

## Verification

- `npx vitest run src/lib/readiness/` passed (258/258 tests across 12 files).
- `npx vitest run src/lib/inference/serving/catalog.test.ts` passed (112/112 tests).
- `npx vitest run src/commands/host/probe.test.ts` passed (8/8 tests).
- `npx vitest run test/automation/pull-requests/growth-guardrails.test.ts` passed (45/45 tests).
- `npm run catalog:check` passed with zero errors.
- `npm run typecheck:cli` passed with zero errors.
- `./tools/lint/format-added-files.sh --check` passed cleanly.
- Commit signed with SSH key (`-S`) and DCO signed-off (`-s`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Readiness reports now include the host operating system distribution and version.
  * Platform detection now supports Linux, WSL, macOS, and N1x environments.
* **Bug Fixes**
  * Improved recognition of Linux OS details, including quoted values and formatted entries.
* **Warnings**
  * Readiness checks now clearly warn when Linux is missing OS details or is not Ubuntu 24.04.
  * Ubuntu 24.04, macOS, and N1x environments are reported without platform qualification warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->