### PR TITLE
fix: add Ollama timeout recovery hint

### DIFF
--- a/src/lib/inference/local.test.ts
+++ b/src/lib/inference/local.test.ts
@@ -619,44 +619,20 @@ describe("local inference helpers", () => {
     expect(result?.ok).toBe(expected);
   });
 
-  it("reports a clear local provider outage when the host probe cannot connect", () => {
+  it.each([
+    { curlStatus: 7, message: "Failed to connect", recoveryHint: false },
+    { curlStatus: 28, message: "Operation timed out", recoveryHint: true },
+  ])("reports local Ollama outage details for curl exit $curlStatus", ({ curlStatus, message, recoveryHint }) => {
     const result = probeLocalProviderHealth("ollama-local", {
-      runCurlProbeImpl: () => ({
-        ok: false,
-        httpStatus: 0,
-        curlStatus: 7,
-        body: "",
-        stderr: "Failed to connect",
-        message: "curl failed (exit 7): Failed to connect",
-      }),
+      runCurlProbeImpl: () => ({ ok: false, httpStatus: 0, curlStatus, body: "", stderr: message, message }),
       loadOllamaProxyTokenImpl: () => null,
     });
 
     expect(result?.ok).toBe(false);
     expect(result?.detail).toContain("Local Ollama is selected for inference");
     expect(result?.detail).toContain("Start Ollama and retry");
-    expect(result?.detail).not.toContain("sudo systemctl restart ollama");
     expect(result?.detail).toContain("http://127.0.0.1:11434/api/tags");
-    expect(result?.probeLabel).toBe("ollama backend");
-  });
-
-  it("suggests restarting Ollama when the local backend probe times out (#10674)", () => {
-    const result = probeLocalProviderHealth("ollama-local", {
-      runCurlProbeImpl: () => ({
-        ok: false,
-        httpStatus: 0,
-        curlStatus: 28,
-        body: "",
-        stderr: "Operation timed out",
-        message: "curl failed (exit 28): Operation timed out",
-      }),
-      loadOllamaProxyTokenImpl: () => null,
-    });
-
-    expect(result?.ok).toBe(false);
-    expect(result?.detail).toContain("stale runner processes from a previous model");
-    expect(result?.detail).toContain("holding GPU memory");
-    expect(result?.detail).toContain("sudo systemctl restart ollama");
+    expect(result?.detail.includes("sudo systemctl restart ollama")).toBe(recoveryHint);
     expect(result?.probeLabel).toBe("ollama backend");
   });
 

--- a/src/lib/inference/local.test.ts
+++ b/src/lib/inference/local.test.ts
@@ -635,7 +635,28 @@ describe("local inference helpers", () => {
     expect(result?.ok).toBe(false);
     expect(result?.detail).toContain("Local Ollama is selected for inference");
     expect(result?.detail).toContain("Start Ollama and retry");
+    expect(result?.detail).not.toContain("sudo systemctl restart ollama");
     expect(result?.detail).toContain("http://127.0.0.1:11434/api/tags");
+    expect(result?.probeLabel).toBe("ollama backend");
+  });
+
+  it("suggests restarting Ollama when the local backend probe times out (#10674)", () => {
+    const result = probeLocalProviderHealth("ollama-local", {
+      runCurlProbeImpl: () => ({
+        ok: false,
+        httpStatus: 0,
+        curlStatus: 28,
+        body: "",
+        stderr: "Operation timed out",
+        message: "curl failed (exit 28): Operation timed out",
+      }),
+      loadOllamaProxyTokenImpl: () => null,
+    });
+
+    expect(result?.ok).toBe(false);
+    expect(result?.detail).toContain("stale runner processes from a previous model");
+    expect(result?.detail).toContain("holding GPU memory");
+    expect(result?.detail).toContain("sudo systemctl restart ollama");
     expect(result?.probeLabel).toBe("ollama backend");
   });
 

--- a/src/lib/inference/local.test.ts
+++ b/src/lib/inference/local.test.ts
@@ -633,6 +633,8 @@ describe("local inference helpers", () => {
     expect(result?.detail).toContain("Start Ollama and retry");
     expect(result?.detail).toContain("http://127.0.0.1:11434/api/tags");
     expect(result?.detail.includes("sudo systemctl restart ollama")).toBe(recoveryHint);
+    expect(result?.detail.includes("stale runner processes from a previous model")).toBe(recoveryHint);
+    expect(result?.detail.includes("holding GPU memory")).toBe(recoveryHint);
     expect(result?.probeLabel).toBe("ollama backend");
   });
 

--- a/src/lib/inference/local.ts
+++ b/src/lib/inference/local.ts
@@ -1029,11 +1029,16 @@ function buildLocalProviderProbeDetail(
   const label = getLocalProviderLabel(provider) || "Local inference provider";
   if (result.httpStatus === 0) {
     switch (provider) {
-      case "ollama-local":
+      case "ollama-local": {
+        const timeoutRecovery =
+          result.curlStatus === 28
+            ? " If Ollama is running but the probe times out, stale runner processes from a previous model may be holding GPU memory; run 'sudo systemctl restart ollama' and retry."
+            : "";
         return (
           `${label} is selected for inference, but the host probe to ${endpoint} failed. ` +
-          `Start Ollama and retry. (${result.message})`
+          `Start Ollama and retry.${timeoutRecovery} (${result.message})`
         );
+      }
       case "vllm-local":
         return (
           `${label} is selected for inference, but the host probe to ${endpoint} failed. ` +


### PR DESCRIPTION
## Outcome

Local Ollama timeout diagnostics now point users at the likely stale-runner recovery path. When the backend probe times out, the status detail keeps the existing "Start Ollama" guidance and adds that stale runner processes from a previous model may be holding GPU memory, with `sudo systemctl restart ollama` as the recovery command.

## Reason

A timed-out local Ollama probe can mean the daemon is present but blocked by resident runners holding GPU memory. The previous generic outage message did not surface that documented condition or tell Linux users how to recover.

### Related issues

Fixes #10674

## Changes

- Add an Ollama-specific curl timeout branch to the local provider health detail.
- Keep generic connection failures on the shorter "Start Ollama and retry" path so non-timeout outages do not receive stale-runner guidance.
- Add regression coverage for both the timeout recovery hint and the non-timeout path.

## Verification

- `npm run catalog:compile && ./node_modules/.bin/vitest run --project cli src/lib/inference/local.test.ts` — passed, 98 tests.
- `git diff --check origin/main...HEAD` — passed.
- `git diff origin/main...HEAD | grep -Ei "(token|secret|api[_-]?key|password|bearer|authorization|BEGIN .*PRIVATE|NV_API_KEY|GH_TOKEN)" || true` — no secret material found; only the existing test helper name `loadOllamaProxyTokenImpl` matched.

---
Signed-off-by: Glenn-Agent <glenn_agent@163.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Ollama connection error messages by recommending a restart when a timeout may indicate stale processes using GPU memory.
  - Connection failures that are not timeouts no longer suggest restarting Ollama.
  - Timeout and connection-failure handling now provides more targeted guidance based on the failure type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->