### PR TITLE
docs: prepare v0.0.120 release

### DIFF
--- a/docs/changelog/2026-09-04.mdx
+++ b/docs/changelog/2026-09-04.mdx
@@ -1,0 +1,61 @@
+{/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */}
+
+## v0.0.120
+
+NemoClaw v0.0.120 adds secret-free verified configuration export and a global host and gateway doctor.
+It updates the supported Hermes runtime to 0.20.6, retires Shields from NemoClaw core, and moves managed host forwarding to OpenShell service forwarding.
+It also hardens sandbox recovery, onboarding, inference validation, MCP lifecycle operations, mTLS selection, and credential-bound messaging policy.
+
+- `nemoclaw config export <sandbox> --output <path|->` now writes a canonical `nemoclaw.nvidia.com/v1` configuration document after cross-checking registry, lifecycle, gateway, workload, image, inference, policy, and credential-reference state.
+  The command keeps secrets out of YAML and JSON output and fails closed on inconsistent evidence.
+  On Linux, file output uses owner-only atomic publication; `--output -` writes YAML to standard output on another supported host or in a pipeline.
+  Related change: [PR #11015](https://github.com/NVIDIA/NemoClaw/pull/11015).
+  For more information, refer to the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
+- `nemoclaw doctor` now runs read-only host and gateway checks before onboarding or without selecting a sandbox.
+  It supports human-readable and redacted JSON reports, leaves gateway and sandbox state unchanged, and returns a nonzero status when a required check fails.
+  Related change: [PR #11012](https://github.com/NVIDIA/NemoClaw/pull/11012).
+  For more information, refer to [System Readiness](/user-guide/openclaw/reference/system-readiness) and the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
+- The managed Hermes runtime is now 0.20.6 with retargeted compatibility patches, reviewed lazy Hindsight dependencies, workspace-aware session previews, scheduled-task recovery, and the maintained managed-image security boundaries.
+  Gateway startup preserves the validated lazy-install target for both direct root-entrypoint and OpenShell-managed same-UID topologies.
+  Legacy rebuilds with no image hint now require the release-pinned immutable Hermes base and stop before mutation if it cannot be resolved and validated.
+  Related changes: [PR #10595](https://github.com/NVIDIA/NemoClaw/pull/10595), [PR #11071](https://github.com/NVIDIA/NemoClaw/pull/11071), and [PR #11024](https://github.com/NVIDIA/NemoClaw/pull/11024).
+  For more information, refer to [Install Hermes Plugins](/user-guide/hermes/manage-sandboxes/install-hermes-plugins) and [Recover and Rebuild Sandboxes](/user-guide/hermes/manage-sandboxes/operate-sandboxes/recover-and-rebuild-sandboxes).
+- Hermes Portable stopped-runtime recovery now reuses validated Podman and executable evidence inside each qualified lifecycle transaction, performs one bounded readiness wait inside the sandbox, and retries only transient final readiness-publication failures.
+  Required host forwards settle together from a strict ownership snapshot with in-process TCP liveness checks, while full entry and final qualification, credential-bearing health, authority fences, and rollback remain enforced.
+  Related changes: [PR #10927](https://github.com/NVIDIA/NemoClaw/pull/10927), [PR #10983](https://github.com/NVIDIA/NemoClaw/pull/10983), [PR #10988](https://github.com/NVIDIA/NemoClaw/pull/10988), [PR #10999](https://github.com/NVIDIA/NemoClaw/pull/10999), and [PR #11019](https://github.com/NVIDIA/NemoClaw/pull/11019).
+  For more information, refer to [Recover and Rebuild Sandboxes](/user-guide/hermes/manage-sandboxes/operate-sandboxes/recover-and-rebuild-sandboxes).
+- Shields has been retired from NemoClaw core, including its commands, plugin status, timers, policies, state-lock plans, and runtime-provider mutation contract.
+  Upgrades preserve and report legacy Shields state instead of interpreting or deleting it, and affected installations must follow the printed fail-closed quarantine and rebuild guidance before ordinary mutation.
+  Legacy OpenClaw migration also preserves the prepared rebuild context and exact candidate managed-image selection across replacement creation.
+  Related changes: [PR #10722](https://github.com/NVIDIA/NemoClaw/pull/10722) and [PR #10996](https://github.com/NVIDIA/NemoClaw/pull/10996).
+  For more information, refer to [Recover and Rebuild Sandboxes](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/recover-and-rebuild-sandboxes) and [Security Best Practices](/user-guide/openclaw/security/best-practices).
+- NemoClaw now uses detached `openshell forward service` processes for managed dashboard, messaging, and MCP host forwards instead of owning SSH forwarding processes and receipt state.
+  The forward lifecycle follows sandbox and gateway availability, refuses an occupied host port, verifies reachability before success, and relaunches through normal recovery.
+  MCP lifecycle work and typed policy reads also retain the sandbox's recorded gateway, workspace, TLS, and mTLS authority instead of inheriting ambient selectors.
+  Related changes: [PR #10695](https://github.com/NVIDIA/NemoClaw/pull/10695), [PR #10814](https://github.com/NVIDIA/NemoClaw/pull/10814), [PR #10815](https://github.com/NVIDIA/NemoClaw/pull/10815), and [PR #10810](https://github.com/NVIDIA/NemoClaw/pull/10810).
+  For more information, refer to [Understand Gateway Lifecycle Control](/user-guide/openclaw/manage-sandboxes/configure-sandboxes/understand-gateway-lifecycle-control) and [About Managed MCP Servers](/user-guide/openclaw/manage-sandboxes/mcp-servers/about-managed-mcp-servers).
+- Onboarding can restore a validated managed snapshot into a replacement sandbox before it publishes the replacement registry entry, preserving the snapshot and leaving the replacement unregistered when restore or authority checks fail.
+  Native Podman providers can own their Docker-less readiness checks, qualified N1x users who decline the Deferred Express preview continue into ordinary provider selection, and managed vLLM preserves the catalog's served model when a resume checkpoint records a short alias.
+  Plain sandboxes without a Portable receipt also avoid the Hermes lifecycle-lock path when they use a non-default gateway port.
+  Related changes: [PR #10690](https://github.com/NVIDIA/NemoClaw/pull/10690), [PR #10900](https://github.com/NVIDIA/NemoClaw/pull/10900), [PR #11046](https://github.com/NVIDIA/NemoClaw/pull/11046), [PR #10882](https://github.com/NVIDIA/NemoClaw/pull/10882), and [PR #10864](https://github.com/NVIDIA/NemoClaw/pull/10864).
+  For more information, refer to the [NemoClaw Quickstart with OpenClaw](/user-guide/openclaw/get-started/quickstart), [Use vLLM](/user-guide/openclaw/inference/local-inference/set-up-vllm), and [Recover and Rebuild Sandboxes](/user-guide/openclaw/manage-sandboxes/operate-sandboxes/recover-and-rebuild-sandboxes).
+- Inference status retries transient HTTP `429`, `502`, `503`, and `504` results up to three total attempts while preserving redacted JSON stdout and the final unhealthy result when every attempt fails.
+  NVIDIA Nemotron 3 Super endpoint validation now sends its required sampling and chat-template parameters, and the default Model Router pool replaces the retired Nemotron Nano route with GPT-OSS 20B High.
+  Related changes: [PR #10956](https://github.com/NVIDIA/NemoClaw/pull/10956), [PR #10910](https://github.com/NVIDIA/NemoClaw/pull/10910), and [PR #11070](https://github.com/NVIDIA/NemoClaw/pull/11070).
+  For more information, refer to [Verify the Inference Route](/user-guide/openclaw/inference/validate-inference/verify-inference-route), [Set Up Model Router](/user-guide/openclaw/inference/hosted-inference/set-up-model-router), and the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
+- Deep Agents MCP status now rejects symbolic links, dangling symbolic links, FIFOs, and other unsafe managed projection entries instead of reporting an ordinary adapter mismatch.
+  Snapshot restore can reconstruct the NemoClaw-owned projection through an atomic no-follow replacement while preserving directory targets for explicit operator recovery.
+  Related changes: [PR #10911](https://github.com/NVIDIA/NemoClaw/pull/10911) and [PR #10909](https://github.com/NVIDIA/NemoClaw/pull/10909).
+  For more information, refer to [Create and Restore Snapshots](/user-guide/deepagents/manage-sandboxes/state-and-backups/create-and-restore-snapshots) and [About Managed MCP Servers](/user-guide/deepagents/manage-sandboxes/mcp-servers/about-managed-mcp-servers).
+- Messaging and web-search provider setup now verifies the exact checked-in OpenShell profile before registration or Ready reuse.
+  An existing refreshing bridge keeps its working credential until replacement minting succeeds, and lookup, update, cleanup, and recovery failures remain distinct, redacted, and fail closed.
+  Named gateway operations also reject an ambient OpenShell endpoint that could redirect provider preparation.
+  Related changes: [PR #10884](https://github.com/NVIDIA/NemoClaw/pull/10884) and [PR #10895](https://github.com/NVIDIA/NemoClaw/pull/10895).
+  For more information, refer to [Manage Messaging Channels](/user-guide/openclaw/manage-sandboxes/messaging-channels/manage-messaging-channels) and [Credential Storage](/user-guide/openclaw/security/credential-storage).
+- Hermes Discord policy now authorizes only the Hermes and Python runtime binaries used for Discord traffic and removes the unused generic Node.js grant.
+  Existing Hermes Discord sandboxes can reapply the maintained preset to remove the durable old grant without changing unrelated policy entries.
+  Related change: [PR #10682](https://github.com/NVIDIA/NemoClaw/pull/10682).
+  For more information, refer to [Apply Policy Presets](/user-guide/hermes/network-policy/configure-policies/apply-policy-presets).

--- a/docs/manage-sandboxes/recover-rebuild-sandboxes.mdx
+++ b/docs/manage-sandboxes/recover-rebuild-sandboxes.mdx
@@ -248,6 +248,14 @@ $$nemoclaw <sandbox-name> rebuild
 On WSL with Docker Desktop, a generated replacement image build uses a temporary credential-free Docker configuration when the configured Docker Desktop credential helper is unavailable. NemoClaw removes the temporary configuration after the build and does not modify your Docker configuration. An explicit custom Dockerfile continues to use your configured Docker credentials because its base image or build steps might require a private registry. If that custom rebuild cannot reach the credential helper, restore the Docker Desktop session or credential-helper access before retrying.
 
 Rebuild creates the replacement from the base image selected during preflight, even when the source sandbox records an older base-image hint.
+
+<AgentOnly variant="hermes">
+
+For a legacy Hermes sandbox with no base-image hint or explicit image override, rebuild requires the release-pinned immutable Hermes base image.
+If NemoClaw cannot resolve and validate that image, rebuild stops before it changes the sandbox or its registry.
+
+</AgentOnly>
+
 When the target manifest declares an agent version, NemoClaw runs a fresh live version probe after state restoration.
 It records the replacement version and reports success only when the observed version matches the rebuild target.
 An unavailable or different version ends the rebuild with a nonzero status instead of recording the target version as observed.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

Adds the canonical dated documentation entry for v0.0.120 and records the release's material user-facing changes before tag planning. The Hermes rebuild guide now also documents the fail-closed immutable-base requirement for legacy sandboxes without an image hint.

## Reason

Release planning requires a merged `docs/changelog/2026-09-04.mdx` containing exactly one `## v0.0.120` heading. The existing automation draft does not contain that required changelog and does not cover the full release scope, so this PR provides a fresh, independently reviewed release-docs update.

### Related issues

Relates to #10919

## Changes

- Add three release-note lead paragraphs and detailed, user-facing v0.0.120 changes with canonical documentation routes.
- Cover configuration export and doctor (#11015, #11012); Hermes runtime, recovery, and Discord policy (#10595, #11071, #11024, #10927, #10983, #10988, #10999, #11019, #10682); Shields retirement (#10722, #10996); OpenShell forwarding and runtime authority (#10695, #10814, #10815, #10810); onboarding and recovery (#10690, #10900, #11046, #10882, #10864); inference behavior (#10956, #10910, #11070); Deep Agents MCP projection safety (#10911, #10909); and provider-profile validation (#10884, #10895).
- Scope the legacy Hermes immutable-base rebuild guidance to the Hermes-rendered recovery page.

## Verification

- `npx vitest run --project integration test/generation/check-docs-links.test.ts test/generation/check-docs-published-routes.test.ts test/generation/post-merge-docs.test.ts` — 3 files and 125 tests passed.
- `npm run docs` — passed with 0 errors and 5 existing Fern warnings.
- Independent documentation audit — reconciled all 71 commits in `v0.0.119..origin/main`, validated all 29 PR links and published routes, and found no unsupported product claims or remaining corrections.
- Normal `pre-commit`, `commit-msg`, and `pre-push` hooks — passed.
- `git diff --check` — passed.
- GitHub commit verification — `a22fe0989fd72c7daaa9b2e7a4734a3edc069aba` is Verified with reason `valid`.
- Secret review — the diff contains no secrets, API keys, or credentials.

## Review notes

The existing automation draft #10919 is intentionally left untouched. This PR supersedes its release-docs content with the complete canonical changelog and a variant-correct Hermes recovery update.

---
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added release notes covering verified configuration export, host and gateway diagnostics, service forwarding, sandbox recovery, onboarding safeguards, inference retries, MCP projection safety, provider setup, and Discord runtime policy.
  - Clarified sandbox rebuild behavior, including use of the release-pinned immutable base image when required.
  - Documented that rebuilds stop before modifying sandbox data when the required image cannot be resolved or validated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->