### PR TITLE
docs: clarify Hermes rebuild image override

### DIFF
--- a/docs/manage-sandboxes/recover-rebuild-sandboxes.mdx
+++ b/docs/manage-sandboxes/recover-rebuild-sandboxes.mdx
@@ -251,7 +251,8 @@ Rebuild creates the replacement from the base image selected during preflight, e
 
 <AgentOnly variant="hermes">
 
-For a legacy Hermes sandbox with no base-image hint or explicit image override, rebuild requires the release-pinned immutable Hermes base image.
+For a legacy Hermes sandbox with no base-image hint or `NEMOCLAW_HERMES_SANDBOX_BASE_IMAGE_REF` override, rebuild requires the release-pinned immutable Hermes base image.
+The override must use the official remote repository and resolve to a trusted immutable digest as described in the [NemoClaw CLI Commands Reference](/user-guide/hermes/reference/commands).
 If NemoClaw cannot resolve and validate that image, rebuild stops before it changes the sandbox or its registry.
 
 </AgentOnly>

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -3884,7 +3884,7 @@ Set `NEMOCLAW_LANGCHAIN_DEEPAGENTS_CODE_SANDBOX_BASE_IMAGE_REF` to a LangChain D
 
 <AgentOnly variant="hermes">
 
-Set `NEMOCLAW_HERMES_SANDBOX_BASE_IMAGE_REF` to a Hermes sandbox-base tag or digest to override base-image resolution during onboarding. NemoClaw requires environment overrides to use the official remote repository and resolve to a repository digest, validates the requested image for the required MCP runtime, and keeps the final image bound to that trusted base. NemoClaw accepts local bases only when it builds and pins them during onboarding.
+Set `NEMOCLAW_HERMES_SANDBOX_BASE_IMAGE_REF` to a Hermes sandbox-base tag or digest to override base-image resolution during onboarding or rebuild. NemoClaw requires environment overrides to use the official remote repository and resolve to a repository digest, validates the requested image for the required MCP runtime, and keeps the final image bound to that trusted base. NemoClaw accepts local bases only when it builds and pins them during onboarding.
 
 </AgentOnly>
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

Clarifies that `NEMOCLAW_HERMES_SANDBOX_BASE_IMAGE_REF` applies to both Hermes onboarding and rebuild. The legacy Hermes recovery guidance now names the override and preserves its official-repository, immutable-digest constraints.

## Reason

The PR Review Advisor on #11100 correctly found that the recovery page mentioned an explicit image override while the commands reference still described that override as onboarding-only. The implementation reads the same variable during rebuild before deciding whether the legacy release-pinned base is required.

### Related issues

Follow-up to #11100

## Changes

- Document the Hermes base-image override as an onboarding and rebuild input.
- Name the override in the legacy recovery condition and link the Hermes commands reference.
- Keep the guidance scoped to Hermes and retain the official remote repository and trusted immutable digest requirements.

## Verification

- `npx vitest run --project integration test/generation/check-docs-links.test.ts test/generation/check-docs-published-routes.test.ts test/generation/post-merge-docs.test.ts` — 3 files and 125 tests passed.
- `npm run docs` — passed with 0 errors and 5 existing Fern warnings.
- Independent documentation audit — approved the repair as source-accurate, Hermes-scoped, and publication-safe.
- Normal `pre-commit`, `commit-msg`, and `pre-push` hooks — passed.
- `git diff --check` — passed.
- GitHub commit verification — `396dbd300e26909589a54cdfc803103082d8ed9e` is Verified with reason `valid`.
- Secret review — the diff contains no secrets, API keys, or credentials.

## Review notes

This is the complete disposition of the one valid Advisor finding on the merged release-docs PR #11100. All other Advisor specialists and CodeRabbit reported no issue.

---
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that the Hermes sandbox base-image override applies during both onboarding and rebuild.
  - Documented fallback behavior when no image hint or override is provided.
  - Clarified that overrides must use the official remote repository and a trusted immutable digest.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->