### PR TITLE
docs: document trusted Hermes rebuild aliases

### DIFF
--- a/docs/manage-sandboxes/recover-rebuild-sandboxes.mdx
+++ b/docs/manage-sandboxes/recover-rebuild-sandboxes.mdx
@@ -252,7 +252,9 @@ Rebuild creates the replacement from the base image selected during preflight, e
 <AgentOnly variant="hermes">
 
 For a legacy Hermes sandbox with no base-image hint or `NEMOCLAW_HERMES_SANDBOX_BASE_IMAGE_REF` override, rebuild requires the release-pinned immutable Hermes base image.
-The override must use the official remote repository and resolve to a trusted immutable digest as described in the [NemoClaw CLI Commands Reference](/user-guide/hermes/reference/commands).
+Remote overrides must use the official repository and resolve to a trusted immutable digest.
+During rebuild, NemoClaw accepts a caller-supplied local alias only when Docker proves that the alias and the tracked official image have the same image ID, operating system, architecture, and official repository digest; other local aliases are rejected.
+On Linux, accepted images must pass the OpenShell ABI check. On every platform, they must pass the required MCP and ACP runtime and immutable security package inventory checks described in the [NemoClaw CLI Commands Reference](/user-guide/hermes/reference/commands).
 If NemoClaw cannot resolve and validate that image, rebuild stops before it changes the sandbox or its registry.
 
 </AgentOnly>

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -3884,7 +3884,7 @@ Set `NEMOCLAW_LANGCHAIN_DEEPAGENTS_CODE_SANDBOX_BASE_IMAGE_REF` to a LangChain D
 
 <AgentOnly variant="hermes">
 
-Set `NEMOCLAW_HERMES_SANDBOX_BASE_IMAGE_REF` to a Hermes sandbox-base tag or digest to override base-image resolution during onboarding or rebuild. NemoClaw requires environment overrides to use the official remote repository and resolve to a repository digest, validates the requested image for the required MCP runtime, and keeps the final image bound to that trusted base. NemoClaw accepts local bases only when it builds and pins them during onboarding.
+Set `NEMOCLAW_HERMES_SANDBOX_BASE_IMAGE_REF` to a Hermes sandbox-base tag or digest to override base-image resolution during onboarding or rebuild. Remote overrides must use the official repository and resolve to a repository digest. During rebuild, NemoClaw accepts a caller-supplied local alias only when Docker proves that the alias and the tracked official image have the same image ID, operating system, architecture, and official repository digest; the recreate handoff uses that immutable digest. On Linux, accepted images must pass the OpenShell ABI check. On every platform, they must pass the required MCP and ACP runtime and immutable security package inventory checks. During onboarding, NemoClaw accepts local bases only when it builds and pins them itself; a local image reference supplied through this environment variable is rejected.
 
 </AgentOnly>
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

Documents the exact trust checks for a caller-supplied local Hermes base-image alias during rebuild. The guidance now distinguishes Linux-only OpenShell ABI validation from the runtime and immutable security-inventory checks required on every platform.

## Reason

The final PR Review Advisor and CodeRabbit reviews on merged PR #11101 correctly found that the release documentation conflated the caller-alias identity path with NemoClaw's separate local-build provenance path and described the OpenShell ABI check as unconditional.

### Related issues

Follow-up to #11101

## Changes

- Describe the rebuild-only caller-alias proof as matching Docker image ID, operating system, architecture, and official repository digest.
- State that recreation uses the resolved immutable digest.
- Document Linux-only OpenShell ABI validation and platform-independent MCP/ACP runtime and immutable security package inventory validation.
- Preserve onboarding's rejection of caller-supplied local image overrides.

## Verification

- `npx vitest run --project integration test/generation/check-docs-links.test.ts test/generation/check-docs-published-routes.test.ts test/generation/post-merge-docs.test.ts` — 3 files and 125 tests passed.
- `npm run docs` — passed with 0 errors and 5 existing Fern warnings.
- Independent documentation source audit — approved the final wording with no remaining mismatch.
- Normal `pre-commit`, `commit-msg`, and `pre-push` hooks — passed.
- `git diff --check` — passed.
- GitHub commit verification — `e4c8f22609ba010cf6e982337f0f00d3c19de2c7` is Verified with reason `valid`.
- Secret review — the diff contains no secrets, API keys, or credentials.

## Review notes

This PR is the complete disposition of the duplicated Advisor and CodeRabbit finding on merged PR #11101. It is release-blocking documentation cleanup for v0.0.120.

---
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated sandbox rebuild guidance to require official repository images with trusted immutable digests.
  - Clarified validation requirements for MCP, ACP, immutable security packages, and the Linux OpenShell ABI.
  - Documented restrictions on local image aliases during rebuilds and onboarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->