### PR TITLE
fix(macos): recognize Homebrew 6 gateway labels

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3280,35 +3280,42 @@ stop_legacy_openshell_gateway_process() {
 stop_macos_openshell_gateway_user_service() {
   [ "$(uname -s)" = "Darwin" ] || return 1
 
-  local gateway_port service_label service_path service_domain service_program
-  local brew_prefix expected_program active_service active_program
+  local gateway_port service_domain
+  local brew_prefix expected_program
+  local candidate_label candidate_path candidate_program candidate_domain candidate_service
+  local candidate_active_program
   gateway_port="$(resolve_nemoclaw_gateway_port)" || return 1
   [ "$gateway_port" -eq 8080 ] || return 1
   command_exists brew || return 1
   command_exists launchctl || return 1
   command_exists plutil || return 1
 
-  service_label="homebrew.mxcl.openshell"
-  service_path="${HOME}/Library/LaunchAgents/${service_label}.plist"
-  [ -f "$service_path" ] || return 1
-  if [ -L "$service_path" ] || ! [ -O "$service_path" ]; then
-    error "Refusing to retire the OpenShell gateway from an untrusted macOS user service: ${service_path}"
-  fi
-
-  service_program="$(plutil -extract ProgramArguments.0 raw -o - "$service_path" 2>/dev/null || true)"
-  [ "$(plutil -extract Label raw -o - "$service_path" 2>/dev/null || true)" = "$service_label" ] \
-    || error "Refusing to retire an OpenShell gateway from a macOS user service with an unexpected label: ${service_path}"
   brew_prefix="$(brew --prefix 2>/dev/null || true)"
   [ -n "$brew_prefix" ] || return 1
   expected_program="${brew_prefix%/}/opt/openshell/libexec/openshell-gateway-homebrew-service"
-  [ "$service_program" = "$expected_program" ] && [ -x "$service_program" ] \
-    || error "Refusing to retire an OpenShell gateway from a macOS user service with an untrusted executable: ${service_program:-<empty>}"
+  for candidate_label in sh.brew.openshell homebrew.mxcl.openshell; do
+    candidate_path="${HOME}/Library/LaunchAgents/${candidate_label}.plist"
+    [ -f "$candidate_path" ] || continue
+    if [ -L "$candidate_path" ] || ! [ -O "$candidate_path" ]; then
+      error "Refusing to retire the OpenShell gateway from an untrusted macOS user service: ${candidate_path}"
+    fi
 
-  service_domain="gui/$(id -u)/${service_label}"
-  active_service="$(launchctl print "$service_domain" 2>/dev/null)" || return 1
-  active_program="$(printf '%s\n' "$active_service" | sed -n 's/^[[:space:]]*program = //p' | head -1)"
-  [ "$active_program" = "$expected_program" ] \
-    || error "Refusing to retire an OpenShell gateway from an active macOS user service with an untrusted executable: ${active_program:-<empty>}"
+    candidate_program="$(plutil -extract ProgramArguments.0 raw -o - "$candidate_path" 2>/dev/null || true)"
+    [ "$(plutil -extract Label raw -o - "$candidate_path" 2>/dev/null || true)" = "$candidate_label" ] \
+      || error "Refusing to retire an OpenShell gateway from a macOS user service with an unexpected label: ${candidate_path}"
+    [ "$candidate_program" = "$expected_program" ] && [ -x "$candidate_program" ] \
+      || error "Refusing to retire an OpenShell gateway from a macOS user service with an untrusted executable: ${candidate_program:-<empty>}"
+
+    candidate_domain="gui/$(id -u)/${candidate_label}"
+    candidate_service="$(launchctl print "$candidate_domain" 2>/dev/null)" || continue
+    candidate_active_program="$(printf '%s\n' "$candidate_service" | sed -n 's/^[[:space:]]*program = //p' | head -1)"
+    [ "$candidate_active_program" = "$expected_program" ] \
+      || error "Refusing to retire an OpenShell gateway from an active macOS user service with an untrusted executable: ${candidate_active_program:-<empty>}"
+    [ -z "$service_domain" ] \
+      || error "Refusing to retire an OpenShell gateway because multiple trusted Homebrew user services are active."
+    service_domain="$candidate_domain"
+  done
+  [ -n "$service_domain" ] || return 1
   launchctl bootout "$service_domain" >/dev/null 2>&1 \
     || error "Could not stop the trusted OpenShell Homebrew gateway user service. Run 'launchctl print ${service_domain}' for details."
   launchctl print "$service_domain" >/dev/null 2>&1 \

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3283,7 +3283,7 @@ stop_macos_openshell_gateway_user_service() {
   local gateway_port service_domain=""
   local brew_prefix expected_program
   local candidate_label candidate_path candidate_program candidate_domain candidate_service
-  local candidate_active_program
+  local candidate_active_program candidate_state
   gateway_port="$(resolve_nemoclaw_gateway_port)" || return 1
   [ "$gateway_port" -eq 8080 ] || return 1
   command_exists brew || return 1
@@ -3296,6 +3296,8 @@ stop_macos_openshell_gateway_user_service() {
   for candidate_label in sh.brew.openshell homebrew.mxcl.openshell; do
     candidate_domain="gui/$(id -u)/${candidate_label}"
     candidate_service="$(launchctl print "$candidate_domain" 2>/dev/null)" || continue
+    candidate_state="$(printf '%s\n' "$candidate_service" | sed -n 's/^[[:space:]]*state = //p' | head -1)"
+    [ "$candidate_state" = "running" ] || continue
     candidate_path="${HOME}/Library/LaunchAgents/${candidate_label}.plist"
     [ -f "$candidate_path" ] \
       || error "Refusing to retire the active OpenShell gateway without its expected macOS user service file: ${candidate_path}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3280,7 +3280,7 @@ stop_legacy_openshell_gateway_process() {
 stop_macos_openshell_gateway_user_service() {
   [ "$(uname -s)" = "Darwin" ] || return 1
 
-  local gateway_port service_domain
+  local gateway_port service_domain=""
   local brew_prefix expected_program
   local candidate_label candidate_path candidate_program candidate_domain candidate_service
   local candidate_active_program
@@ -3303,8 +3303,9 @@ stop_macos_openshell_gateway_user_service() {
     candidate_program="$(plutil -extract ProgramArguments.0 raw -o - "$candidate_path" 2>/dev/null || true)"
     [ "$(plutil -extract Label raw -o - "$candidate_path" 2>/dev/null || true)" = "$candidate_label" ] \
       || error "Refusing to retire an OpenShell gateway from a macOS user service with an unexpected label: ${candidate_path}"
-    [ "$candidate_program" = "$expected_program" ] && [ -x "$candidate_program" ] \
-      || error "Refusing to retire an OpenShell gateway from a macOS user service with an untrusted executable: ${candidate_program:-<empty>}"
+    if [ "$candidate_program" != "$expected_program" ] || ! [ -x "$candidate_program" ]; then
+      error "Refusing to retire an OpenShell gateway from a macOS user service with an untrusted executable: ${candidate_program:-<empty>}"
+    fi
 
     candidate_domain="gui/$(id -u)/${candidate_label}"
     candidate_service="$(launchctl print "$candidate_domain" 2>/dev/null)" || continue

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3294,8 +3294,11 @@ stop_macos_openshell_gateway_user_service() {
   [ -n "$brew_prefix" ] || return 1
   expected_program="${brew_prefix%/}/opt/openshell/libexec/openshell-gateway-homebrew-service"
   for candidate_label in sh.brew.openshell homebrew.mxcl.openshell; do
+    candidate_domain="gui/$(id -u)/${candidate_label}"
+    candidate_service="$(launchctl print "$candidate_domain" 2>/dev/null)" || continue
     candidate_path="${HOME}/Library/LaunchAgents/${candidate_label}.plist"
-    [ -f "$candidate_path" ] || continue
+    [ -f "$candidate_path" ] \
+      || error "Refusing to retire the active OpenShell gateway without its expected macOS user service file: ${candidate_path}"
     if [ -L "$candidate_path" ] || ! [ -O "$candidate_path" ]; then
       error "Refusing to retire the OpenShell gateway from an untrusted macOS user service: ${candidate_path}"
     fi
@@ -3307,13 +3310,12 @@ stop_macos_openshell_gateway_user_service() {
       error "Refusing to retire an OpenShell gateway from a macOS user service with an untrusted executable: ${candidate_program:-<empty>}"
     fi
 
-    candidate_domain="gui/$(id -u)/${candidate_label}"
-    candidate_service="$(launchctl print "$candidate_domain" 2>/dev/null)" || continue
     candidate_active_program="$(printf '%s\n' "$candidate_service" | sed -n 's/^[[:space:]]*program = //p' | head -1)"
     [ "$candidate_active_program" = "$expected_program" ] \
       || error "Refusing to retire an OpenShell gateway from an active macOS user service with an untrusted executable: ${candidate_active_program:-<empty>}"
-    [ -z "$service_domain" ] \
-      || error "Refusing to retire an OpenShell gateway because multiple trusted Homebrew user services are active."
+    if [ -n "$service_domain" ]; then
+      error "Refusing to retire an OpenShell gateway because multiple trusted Homebrew user services are active: ${service_domain} and ${candidate_domain}. Inspect both with 'launchctl print ${service_domain}' and 'launchctl print ${candidate_domain}', stop the obsolete service, then rerun the installer."
+    fi
     service_domain="$candidate_domain"
   done
   [ -n "$service_domain" ] || return 1

--- a/src/lib/onboard/docker-driver-gateway-service-homebrew.test.ts
+++ b/src/lib/onboard/docker-driver-gateway-service-homebrew.test.ts
@@ -210,4 +210,16 @@ describe("OpenShell Homebrew service boundary", () => {
       ]),
     ).toBeNull();
   });
+
+  it("accepts one active canonical record beside an inactive legacy record (#11111)", () => {
+    expect(
+      queryHomebrewService([
+        serviceRecord({ service_name: "sh.brew.openshell" }),
+        serviceRecord({ pid: 4343, running: false }),
+      ]),
+    ).toEqual({
+      pid: 4242,
+      executablePath: "/opt/homebrew/opt/openshell/bin/openshell-gateway",
+    });
+  });
 });

--- a/src/lib/onboard/docker-driver-gateway-service-homebrew.test.ts
+++ b/src/lib/onboard/docker-driver-gateway-service-homebrew.test.ts
@@ -4,6 +4,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  getTrustedActiveOpenShellGatewayUserServiceIdentity,
   hasOpenShellGatewayUserService,
   OPENSHELL_GATEWAY_HOMEBREW_FORMULA_SHA256,
   type SpawnSyncLikeResult,
@@ -21,6 +22,46 @@ function officialFormulaInfo(): SpawnSyncLikeResult {
     "",
     JSON.stringify({ formulae: [{ name: "openshell", tap: "nvidia/openshell" }] }),
   );
+}
+
+interface HomebrewServiceRecord {
+  loaded: boolean;
+  name: string;
+  pid: number;
+  running: boolean;
+  service_name: string;
+}
+
+function serviceRecord(overrides: Partial<HomebrewServiceRecord> = {}): HomebrewServiceRecord {
+  return {
+    loaded: true,
+    name: "openshell",
+    pid: 4242,
+    running: true,
+    service_name: "homebrew.mxcl.openshell",
+    ...overrides,
+  };
+}
+
+function queryHomebrewService(records: HomebrewServiceRecord[]) {
+  const formulaPrefix = "/opt/homebrew/opt/openshell";
+  const gatewayBin = `${formulaPrefix}/bin/openshell-gateway`;
+  const spawnSyncImpl = vi.fn((_command: string, args: string[]) => {
+    const responses = {
+      info: officialFormulaInfo(),
+      services: spawnResult(0, "", JSON.stringify(records)),
+      "--prefix": spawnResult(0, "", formulaPrefix),
+    };
+    return responses[args[0] as keyof typeof responses] ?? spawnResult();
+  });
+
+  return getTrustedActiveOpenShellGatewayUserServiceIdentity({
+    commandExists: (command) => command === "brew",
+    existsSync: (candidate) => candidate === gatewayBin,
+    homebrewFormulaOperation: (args) => spawnSyncImpl("brew", args),
+    platform: "darwin",
+    spawnSyncImpl,
+  });
 }
 
 describe("OpenShell Homebrew service boundary", () => {
@@ -143,5 +184,30 @@ describe("OpenShell Homebrew service boundary", () => {
         platform: "darwin",
       }),
     ).toBe(false);
+  });
+
+  it.each(["homebrew.mxcl.openshell", "sh.brew.openshell"])(
+    "accepts the active official service label %s (#11111)",
+    (serviceName) => {
+      expect(queryHomebrewService([serviceRecord({ service_name: serviceName })])).toEqual({
+        pid: 4242,
+        executablePath: "/opt/homebrew/opt/openshell/bin/openshell-gateway",
+      });
+    },
+  );
+
+  it("rejects a service label that extends the canonical label (#11111)", () => {
+    expect(
+      queryHomebrewService([serviceRecord({ service_name: "sh.brew.openshell.attacker" })]),
+    ).toBeNull();
+  });
+
+  it("rejects canonical and legacy service records with different active PIDs (#11111)", () => {
+    expect(
+      queryHomebrewService([
+        serviceRecord(),
+        serviceRecord({ pid: 4343, service_name: "sh.brew.openshell" }),
+      ]),
+    ).toBeNull();
   });
 });

--- a/src/lib/onboard/docker-driver-gateway-service.ts
+++ b/src/lib/onboard/docker-driver-gateway-service.ts
@@ -992,17 +992,14 @@ export function getTrustedActiveOpenShellGatewayUserServiceIdentity(
         (candidate) =>
           candidate.name === service.serviceName &&
           candidate.service_name !== undefined &&
-          trustedServiceNames.has(candidate.service_name),
+          trustedServiceNames.has(candidate.service_name) &&
+          candidate.running === true &&
+          candidate.loaded === true,
       );
       if (matchingRecords.length !== 1) return null;
       const [record] = matchingRecords;
       const pid =
-        record?.running === true &&
-        record.loaded === true &&
-        Number.isSafeInteger(record.pid) &&
-        Number(record.pid) > 0
-          ? Number(record.pid)
-          : null;
+        Number.isSafeInteger(record?.pid) && Number(record.pid) > 0 ? Number(record.pid) : null;
       if (pid === null) return null;
       return {
         pid,

--- a/src/lib/onboard/docker-driver-gateway-service.ts
+++ b/src/lib/onboard/docker-driver-gateway-service.ts
@@ -984,11 +984,18 @@ export function getTrustedActiveOpenShellGatewayUserServiceIdentity(
         running?: boolean;
         service_name?: string;
       }>;
-      const record = records.find(
+      const trustedServiceNames = new Set([
+        `homebrew.mxcl.${service.serviceName}`,
+        `sh.brew.${service.serviceName}`,
+      ]);
+      const matchingRecords = records.filter(
         (candidate) =>
           candidate.name === service.serviceName &&
-          candidate.service_name === `homebrew.mxcl.${service.serviceName}`,
+          candidate.service_name !== undefined &&
+          trustedServiceNames.has(candidate.service_name),
       );
+      if (matchingRecords.length !== 1) return null;
+      const [record] = matchingRecords;
       const pid =
         record?.running === true &&
         record.loaded === true &&

--- a/src/lib/readiness/gateway-production.test.ts
+++ b/src/lib/readiness/gateway-production.test.ts
@@ -243,6 +243,96 @@ describe("managed gateway port readiness (#7411)", () => {
     ).toBe(false);
   });
 
+  it("recognizes a Homebrew 6 packaged-service listener in readiness (#11111)", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    vi.spyOn(process, "arch", "get").mockReturnValue("arm64");
+    const formulaPrefix = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-readiness-homebrew-"));
+    const formulaBin = path.join(formulaPrefix, "bin");
+    const openshellBin = path.join(formulaBin, "openshell");
+    const gatewayBin = path.join(formulaBin, "openshell-gateway");
+    fs.mkdirSync(formulaBin);
+    fs.writeFileSync(openshellBin, "");
+    fs.writeFileSync(gatewayBin, "");
+    const listener = net.createServer();
+    await new Promise<void>((resolve, reject) => {
+      listener.once("error", reject);
+      listener.listen(0, "127.0.0.1", resolve);
+    });
+    const gatewayPort = (listener.address() as AddressInfo).port;
+    const gatewayName = "nemoclaw-readiness-test";
+    const status = `Server Status\n\nGateway: ${gatewayName}\nStatus: Connected`;
+    const info = `Gateway Info\n\nGateway: ${gatewayName}\nGateway endpoint: https://127.0.0.1:${gatewayPort}`;
+    const resultByInvocation = new Map([
+      [
+        ["sh", "-c", 'command -v "$1"', "--", "openshell"].join("\0"),
+        commandResult(openshellBin, 0),
+      ],
+      [
+        ["sh", "-c", 'command -v "$1" >/dev/null 2>&1', "sh", "brew"].join("\0"),
+        commandResult("", 0),
+      ],
+      [[openshellBin, "status", "-g", gatewayName].join("\0"), commandResult(status, 0)],
+      [[openshellBin, "gateway", "info", "-g", gatewayName].join("\0"), commandResult(info, 0)],
+      [[openshellBin, "gateway", "info"].join("\0"), commandResult(info, 0)],
+      [[openshellBin, "--version"].join("\0"), commandResult("openshell 0.0.106", 0)],
+      [
+        ["lsof", "-ti", `:${gatewayPort}`, "-sTCP:LISTEN"].join("\0"),
+        commandResult(`${process.pid}\n`, 0),
+      ],
+      [["ps", "-p", String(process.pid), "-o", "args="].join("\0"), commandResult()],
+      [
+        ["/usr/sbin/lsof", "-a", "-p", String(process.pid), "-d", "txt", "-Fn"].join("\0"),
+        commandResult(`p${process.pid}\nftxt\nn${gatewayBin}\n`, 0),
+      ],
+      [["brew", "list", "--formula", "openshell"].join("\0"), commandResult("", 0)],
+      [
+        ["brew", "info", "--json=v2", "openshell"].join("\0"),
+        commandResult(
+          JSON.stringify({ formulae: [{ name: "openshell", tap: "nvidia/openshell" }] }),
+          0,
+        ),
+      ],
+      [
+        ["brew", "services", "info", "openshell", "--json"].join("\0"),
+        commandResult(
+          JSON.stringify([
+            {
+              loaded: true,
+              name: "openshell",
+              pid: process.pid,
+              running: true,
+              service_name: "sh.brew.openshell",
+            },
+          ]),
+          0,
+        ),
+      ],
+      [["brew", "--prefix", "openshell"].join("\0"), commandResult(formulaPrefix, 0)],
+    ]);
+    subprocess.spawnSync.mockImplementation((command: string, args: readonly string[] = []) => {
+      const brewIndex = args.indexOf("brew");
+      const invocation =
+        command === "bash" ? ["brew", ...args.slice(brewIndex + 1)] : [command, ...args];
+      return resultByInvocation.get(invocation.join("\0")) ?? commandResult();
+    });
+
+    try {
+      const deps = createProductionGatewayReadinessDependencies({
+        gatewayName: () => gatewayName,
+        gatewayPort: () => gatewayPort,
+        observeVersionCompatibility: () => "compatible",
+      });
+
+      await expect(deps.observeManagedGateway(managedOwner(gatewayPort))).resolves.toMatchObject({
+        reuseState: "healthy",
+        portConflictState: "none",
+      });
+    } finally {
+      await new Promise<void>((resolve) => listener.close(() => resolve()));
+      fs.rmSync(formulaPrefix, { force: true, recursive: true });
+    }
+  });
+
   it("rejects a listener when Linux process samples change (#8755)", () => {
     const trusted = "/opt/openshell/bin/openshell-gateway";
 

--- a/test/install/install-openshell-macos-upgrade.test.ts
+++ b/test/install/install-openshell-macos-upgrade.test.ts
@@ -316,6 +316,8 @@ printf 'openshell=%s\ngateway=%s\npath=%s\n' "$NEMOCLAW_OPENSHELL_BIN" "$NEMOCLA
 
 function runDarwinGatewayServiceStop(
   options: {
+    additionalServiceLabel?: string;
+    serviceLabel?: string;
     trustedActiveProgram?: boolean;
     trustedLabel?: boolean;
     trustedProgram?: boolean;
@@ -325,7 +327,10 @@ function runDarwinGatewayServiceStop(
   const home = path.join(tmp, "home");
   const bin = path.join(tmp, "bin");
   const brewPrefix = path.join(tmp, "homebrew");
-  const serviceLabel = "homebrew.mxcl.openshell";
+  const serviceLabel = options.serviceLabel ?? "homebrew.mxcl.openshell";
+  const serviceLabels = [serviceLabel, options.additionalServiceLabel].filter(
+    (candidate): candidate is string => candidate !== undefined,
+  );
   const servicePath = path.join(home, "Library", "LaunchAgents", `${serviceLabel}.plist`);
   const serviceProgram = path.join(
     brewPrefix,
@@ -339,7 +344,9 @@ function runDarwinGatewayServiceStop(
   fs.mkdirSync(path.dirname(servicePath), { recursive: true });
   fs.mkdirSync(path.dirname(serviceProgram), { recursive: true });
   fs.mkdirSync(bin, { recursive: true });
-  fs.writeFileSync(servicePath, "test plist\n");
+  for (const label of serviceLabels) {
+    fs.writeFileSync(path.join(home, "Library", "LaunchAgents", `${label}.plist`), "test plist\n");
+  }
   fs.writeFileSync(active, "active\n");
   writeExecutable(serviceProgram, "#!/usr/bin/env bash\nexit 0\n");
   writeExecutable(path.join(bin, "uname"), "#!/usr/bin/env bash\nprintf 'Darwin\\n'\n");
@@ -353,7 +360,9 @@ function runDarwinGatewayServiceStop(
     path.join(bin, "plutil"),
     `#!/usr/bin/env bash
 case "\${2:-}" in
-  Label) printf '%s\n' '${options.trustedLabel === false ? "other.service" : serviceLabel}' ;;
+  Label)
+    ${options.trustedLabel === false ? "printf '%s\\n' 'other.service'" : 'basename "\${6:-}" .plist'}
+    ;;
   ProgramArguments.0) printf '%s\n' '${
     options.trustedProgram === false ? path.join(tmp, "foreign-gateway") : serviceProgram
   }' ;;
@@ -579,16 +588,29 @@ describe("install.sh macOS OpenShell upgrade recovery", () => {
     expect(symlinked.result.stderr).toContain("untrusted PID file");
   });
 
-  it("stops only the active trusted OpenShell Homebrew user service (#10369)", () => {
-    const { result, launchctlLog } = runDarwinGatewayServiceStop();
-    const serviceDomain = `gui/${process.getuid?.()}/homebrew.mxcl.openshell`;
+  it.each(["homebrew.mxcl.openshell", "sh.brew.openshell"])(
+    "stops only the active trusted OpenShell Homebrew user service with label %s (#11111)",
+    (serviceLabel) => {
+      const { result, launchctlLog } = runDarwinGatewayServiceStop({ serviceLabel });
+      const serviceDomain = `gui/${process.getuid?.()}/${serviceLabel}`;
 
-    expect(result.status, result.stdout + result.stderr).toBe(0);
-    expect(launchctlLog.trim().split(/\r?\n/)).toEqual([
-      `print ${serviceDomain}`,
-      `bootout ${serviceDomain}`,
-      `print ${serviceDomain}`,
-    ]);
+      expect(result.status, result.stdout + result.stderr).toBe(0);
+      expect(launchctlLog.trim().split(/\r?\n/)).toEqual([
+        `print ${serviceDomain}`,
+        `bootout ${serviceDomain}`,
+        `print ${serviceDomain}`,
+      ]);
+    },
+  );
+
+  it("refuses to stop ambiguous active OpenShell Homebrew user services (#11111)", () => {
+    const { result, launchctlLog } = runDarwinGatewayServiceStop({
+      additionalServiceLabel: "sh.brew.openshell",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("multiple trusted Homebrew user services are active");
+    expect(launchctlLog).not.toContain("bootout");
   });
 
   it("refuses to stop a Homebrew user service with an unexpected label (#10369)", () => {

--- a/test/install/install-openshell-macos-upgrade.test.ts
+++ b/test/install/install-openshell-macos-upgrade.test.ts
@@ -323,6 +323,7 @@ function runDarwinGatewayServiceStop(
     trustedActiveProgram?: boolean;
     trustedLabel?: boolean;
     trustedProgram?: boolean;
+    waitingServiceLabel?: string;
   } = {},
 ) {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-darwin-gateway-service-stop-"));
@@ -390,6 +391,10 @@ case "\${1:-}" in
       *) exit 1 ;;
     esac
     [ -f '${active}' ] || exit 1
+    case "\${2:-}" in
+      'gui/${process.getuid?.()}/${options.waitingServiceLabel ?? "no-waiting-service"}') printf 'state = waiting\n' ;;
+      *) printf 'state = running\n' ;;
+    esac
     printf 'program = %s\\n' '${
       options.trustedActiveProgram === false
         ? path.join(tmp, "active-foreign-gateway")
@@ -638,25 +643,29 @@ describe("install.sh macOS OpenShell upgrade recovery", () => {
     expect(launchctlLog).not.toContain("bootout");
   });
 
-  it("ignores an inactive stale plist before stopping the active Homebrew 6 service (#11111)", () => {
-    const currentLabel = "sh.brew.openshell";
-    const legacyLabel = "homebrew.mxcl.openshell";
-    const currentDomain = `gui/${process.getuid?.()}/${currentLabel}`;
-    const { result, launchctlLog } = runDarwinGatewayServiceStop({
-      additionalServiceLabel: legacyLabel,
-      inactiveServiceLabel: legacyLabel,
-      serviceLabel: currentLabel,
-      symlinkedServiceLabel: legacyLabel,
-    });
+  it.each(["inactive", "waiting"] as const)(
+    "ignores a stale legacy plist when that service is %s (#11111)",
+    (legacyState) => {
+      const currentLabel = "sh.brew.openshell";
+      const legacyLabel = "homebrew.mxcl.openshell";
+      const currentDomain = `gui/${process.getuid?.()}/${currentLabel}`;
+      const { result, launchctlLog } = runDarwinGatewayServiceStop({
+        additionalServiceLabel: legacyLabel,
+        inactiveServiceLabel: legacyState === "inactive" ? legacyLabel : undefined,
+        serviceLabel: currentLabel,
+        symlinkedServiceLabel: legacyLabel,
+        waitingServiceLabel: legacyState === "waiting" ? legacyLabel : undefined,
+      });
 
-    expect(result.status, result.stdout + result.stderr).toBe(0);
-    expect(launchctlLog.trim().split(/\r?\n/)).toEqual([
-      `print ${currentDomain}`,
-      `print gui/${process.getuid?.()}/${legacyLabel}`,
-      `bootout ${currentDomain}`,
-      `print ${currentDomain}`,
-    ]);
-  });
+      expect(result.status, result.stdout + result.stderr).toBe(0);
+      expect(launchctlLog.trim().split(/\r?\n/)).toEqual([
+        `print ${currentDomain}`,
+        `print gui/${process.getuid?.()}/${legacyLabel}`,
+        `bootout ${currentDomain}`,
+        `print ${currentDomain}`,
+      ]);
+    },
+  );
 
   it("refuses to stop a Homebrew user service with an unexpected label (#10369)", () => {
     const { result, launchctlLog } = runDarwinGatewayServiceStop({ trustedLabel: false });

--- a/test/install/install-openshell-macos-upgrade.test.ts
+++ b/test/install/install-openshell-macos-upgrade.test.ts
@@ -317,7 +317,9 @@ printf 'openshell=%s\ngateway=%s\npath=%s\n' "$NEMOCLAW_OPENSHELL_BIN" "$NEMOCLA
 function runDarwinGatewayServiceStop(
   options: {
     additionalServiceLabel?: string;
+    inactiveServiceLabel?: string;
     serviceLabel?: string;
+    symlinkedServiceLabel?: string;
     trustedActiveProgram?: boolean;
     trustedLabel?: boolean;
     trustedProgram?: boolean;
@@ -331,6 +333,11 @@ function runDarwinGatewayServiceStop(
   const serviceLabels = [serviceLabel, options.additionalServiceLabel].filter(
     (candidate): candidate is string => candidate !== undefined,
   );
+  const activeServicePattern =
+    serviceLabels
+      .filter((label) => label !== options.inactiveServiceLabel)
+      .map((label) => `'gui/${process.getuid?.()}/${label}'`)
+      .join(" | ") || "'no-active-service'";
   const servicePath = path.join(home, "Library", "LaunchAgents", `${serviceLabel}.plist`);
   const serviceProgram = path.join(
     brewPrefix,
@@ -345,7 +352,10 @@ function runDarwinGatewayServiceStop(
   fs.mkdirSync(path.dirname(serviceProgram), { recursive: true });
   fs.mkdirSync(bin, { recursive: true });
   for (const label of serviceLabels) {
-    fs.writeFileSync(path.join(home, "Library", "LaunchAgents", `${label}.plist`), "test plist\n");
+    const candidatePath = path.join(home, "Library", "LaunchAgents", `${label}.plist`);
+    label === options.symlinkedServiceLabel
+      ? fs.symlinkSync(serviceProgram, candidatePath)
+      : fs.writeFileSync(candidatePath, "test plist\n");
   }
   fs.writeFileSync(active, "active\n");
   writeExecutable(serviceProgram, "#!/usr/bin/env bash\nexit 0\n");
@@ -375,6 +385,10 @@ esac
 printf '%s\n' "$*" >>'${launchctlLog}'
 case "\${1:-}" in
   print)
+    case "\${2:-}" in
+      ${activeServicePattern}) ;;
+      *) exit 1 ;;
+    esac
     [ -f '${active}' ] || exit 1
     printf 'program = %s\\n' '${
       options.trustedActiveProgram === false
@@ -593,10 +607,18 @@ describe("install.sh macOS OpenShell upgrade recovery", () => {
     (serviceLabel) => {
       const { result, launchctlLog } = runDarwinGatewayServiceStop({ serviceLabel });
       const serviceDomain = `gui/${process.getuid?.()}/${serviceLabel}`;
+      const otherServiceLabel =
+        serviceLabel === "sh.brew.openshell" ? "homebrew.mxcl.openshell" : "sh.brew.openshell";
 
       expect(result.status, result.stdout + result.stderr).toBe(0);
       expect(launchctlLog.trim().split(/\r?\n/)).toEqual([
+        ...(serviceLabel === "sh.brew.openshell"
+          ? []
+          : [`print gui/${process.getuid?.()}/${otherServiceLabel}`]),
         `print ${serviceDomain}`,
+        ...(serviceLabel === "sh.brew.openshell"
+          ? [`print gui/${process.getuid?.()}/${otherServiceLabel}`]
+          : []),
         `bootout ${serviceDomain}`,
         `print ${serviceDomain}`,
       ]);
@@ -610,7 +632,30 @@ describe("install.sh macOS OpenShell upgrade recovery", () => {
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain("multiple trusted Homebrew user services are active");
+    expect(result.stderr).toContain(`gui/${process.getuid?.()}/sh.brew.openshell`);
+    expect(result.stderr).toContain(`gui/${process.getuid?.()}/homebrew.mxcl.openshell`);
+    expect(result.stderr).toContain("stop the obsolete service, then rerun the installer");
     expect(launchctlLog).not.toContain("bootout");
+  });
+
+  it("ignores an inactive stale plist before stopping the active Homebrew 6 service (#11111)", () => {
+    const currentLabel = "sh.brew.openshell";
+    const legacyLabel = "homebrew.mxcl.openshell";
+    const currentDomain = `gui/${process.getuid?.()}/${currentLabel}`;
+    const { result, launchctlLog } = runDarwinGatewayServiceStop({
+      additionalServiceLabel: legacyLabel,
+      inactiveServiceLabel: legacyLabel,
+      serviceLabel: currentLabel,
+      symlinkedServiceLabel: legacyLabel,
+    });
+
+    expect(result.status, result.stdout + result.stderr).toBe(0);
+    expect(launchctlLog.trim().split(/\r?\n/)).toEqual([
+      `print ${currentDomain}`,
+      `print gui/${process.getuid?.()}/${legacyLabel}`,
+      `bootout ${currentDomain}`,
+      `print ${currentDomain}`,
+    ]);
   });
 
   it("refuses to stop a Homebrew user service with an unexpected label (#10369)", () => {
@@ -618,7 +663,7 @@ describe("install.sh macOS OpenShell upgrade recovery", () => {
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain("macOS user service with an unexpected label");
-    expect(launchctlLog).toBe("");
+    expect(launchctlLog).not.toContain("bootout");
   });
 
   it("refuses to stop a Homebrew user service with an unexpected executable (#10369)", () => {
@@ -626,7 +671,7 @@ describe("install.sh macOS OpenShell upgrade recovery", () => {
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain("macOS user service with an untrusted executable");
-    expect(launchctlLog).toBe("");
+    expect(launchctlLog).not.toContain("bootout");
   });
 
   it("refuses to stop a trusted plist when the active launchd job has a foreign executable (#10369)", () => {
@@ -634,9 +679,8 @@ describe("install.sh macOS OpenShell upgrade recovery", () => {
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain("active macOS user service with an untrusted executable");
-    expect(launchctlLog.trim().split(/\r?\n/)).toEqual([
-      `print gui/${process.getuid?.()}/homebrew.mxcl.openshell`,
-    ]);
+    expect(launchctlLog).toContain(`print gui/${process.getuid?.()}/homebrew.mxcl.openshell`);
+    expect(launchctlLog).not.toContain("bootout");
   });
 
   it("selects Homebrew binaries after a verified formula install (#10386)", () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

NemoClaw now recognizes the canonical Homebrew 6 `sh.brew.openshell` service label and the legacy `homebrew.mxcl.openshell` label. Fresh macOS onboarding no longer rejects its managed gateway as a foreign port owner, and the trusted installer recovery path recognizes either label.

## Reason

Homebrew 6 changed the canonical launchd label, but NemoClaw required the legacy label in both service observation and the macOS installer fallback.

### Related issues

Fixes #11111

## Changes

- Accept exactly the canonical and legacy OpenShell Homebrew service labels.
- Select exactly one loaded, running service record; ignore an inactive migration record and reject two active records.
- Require launchd `state = running` before validating or selecting a service.
- Ignore absent, inactive, or waiting stale plists so they cannot block the active service.
- Retain plist ownership, label, executable, and active-program validation for every running service.
- Name both domains and the recovery sequence when two trusted services are running.
- Prove the canonical label through the production readiness collector and its port-owner classification.
- Keep the wrapper performance and freshness-window work from #11112 out of this change.

## Verification

- `npx vitest run --project cli src/lib/onboard/docker-driver-gateway-service-homebrew.test.ts src/lib/onboard/docker-driver-gateway-service.test.ts` — 78 tests passed.
- `npx vitest run --project cli src/lib/readiness/gateway-production.test.ts` — 57 tests passed.
- `npx vitest run --project integration test/install/install-openshell-macos-upgrade.test.ts` — 25 tests passed.
- `npx vitest run --project integration test/automation/pull-requests/growth-guardrails.test.ts` — 45 tests passed.
- `npm run typecheck:cli` — passed.
- `npm run checks:repository` — passed.
- `npx prek run shellcheck --files scripts/install.sh` — passed.
- `npm run validate:pr` — passed against canonical main `66c5fdfe98cbb783bd80938adf209e34ad5e8bdc`.
- Live macOS proof on Homebrew 6.0.21: Homebrew returned running service `sh.brew.openshell` with PID 73765; the PR resolver returned PID 73765 and `/opt/homebrew/opt/openshell/bin/openshell-gateway`.
- Live launchd/plist proof: `state = running`; the active and plist programs matched the executable trusted Homebrew wrapper; the plist was user-owned and non-symlinked. The live service was not stopped or restarted.
- Exact-head ordinary CI, CodeQL and security scans, installer checks, all CLI shards, both OpenClaw MCP discovery passes, and nine Advisor specialists passed.
- [Exact-head all-agent activation attempt 2](https://github.com/NVIDIA/NemoClaw/actions/runs/34014630761) — passed at unchanged commit `d8a09750308d278a66e0360a1df968e7fc003d43`.
- GitHub marks all commits through `d8a09750308d278a66e0360a1df968e7fc003d43` as Verified.
- The diff contains no secrets, API keys, or credentials.

## Review notes

- CodeRabbit identified that inactive migration records were counted as ambiguous. Commit `6621cb1e` filters for loaded, running records before enforcing uniqueness and adds the inactive-legacy regression.
- Initial exact-commit CI found Bash nounset could read the uninitialized selected-service variable. Commit `6621cb1e` initializes it and retains the no-`bootout` ambiguity assertion.
- The repaired Advisor verification specialist requested direct readiness-consumer evidence. Commit `b785e8c5` supplies a canonical Homebrew 6 service record, matching listener PID and executable observations, then asserts healthy reuse and no port conflict.
- The next Advisor pass found that inactive stale plist metadata could block an active service and that the dual-active error lacked recovery details. Commit `ee2222ed` probes active domains first, validates only active candidates, names both ambiguous domains, and directs the operator to inspect them, stop the obsolete service, and rerun.
- CodeRabbit then distinguished a loaded `waiting` launchd job from a running service. Commit `d8a09750` requires `state = running` and extends the stale-plist regression across inactive and waiting service states.
- Final CodeRabbit review reported no new finding. All review threads are resolved. All nine final Advisor specialists reported no issue.
- The first exact-head all-agent activation attempt failed during Hermes agent setup after OpenClaw passed. PR #11071, the owning Hermes repair, is merged in this branch; the immediately prior PR commit passed the same lane; and this final delta is macOS-only. One explicitly authorized failed-job rerun passed at the unchanged exact head.
- Prior candidates exposed unrelated timing and process-harness failures in unchanged tests. Their files are byte-identical to current main, and later cycles passed them.
- The live Mac uses released OpenShell 0.0.101 while current main pins 0.0.106. The label proof therefore used the installed release-compatible trusted Homebrew wrapper with the PR resolver; it did not alter the service or Homebrew installation.
- #11112 remains the separate next change. This PR does not alter trusted-wrapper calls or observation freshness.

---

Signed-off-by: Aaron Erickson <aerickson@nvidia.com>
