### PR TITLE
perf(readiness): reduce Homebrew trust operations

### DIFF
--- a/src/lib/onboard/docker-driver-gateway-service-homebrew.test.ts
+++ b/src/lib/onboard/docker-driver-gateway-service-homebrew.test.ts
@@ -16,18 +16,33 @@ function spawnResult(status = 0, stderr = "", stdout = ""): SpawnSyncLikeResult 
   return { status, stderr, stdout };
 }
 
-function officialFormulaInfo(): SpawnSyncLikeResult {
+const FORMULA_PREFIX = "/opt/homebrew/opt/openshell";
+const GATEWAY_BIN = `${FORMULA_PREFIX}/bin/openshell-gateway`;
+const SERVICE_PROGRAM = `${FORMULA_PREFIX}/libexec/openshell-gateway-homebrew-service`;
+
+function officialFormulaInfo(
+  options: { installed?: unknown[]; serviceProgram?: unknown; tap?: string } = {},
+): SpawnSyncLikeResult {
   return spawnResult(
     0,
     "",
-    JSON.stringify({ formulae: [{ name: "openshell", tap: "nvidia/openshell" }] }),
+    JSON.stringify({
+      formulae: [
+        {
+          installed: options.installed ?? [{ version: "0.0.106" }],
+          name: "openshell",
+          service: { run: options.serviceProgram ?? SERVICE_PROGRAM },
+          tap: options.tap ?? "nvidia/openshell",
+        },
+      ],
+    }),
   );
 }
 
 interface HomebrewServiceRecord {
   loaded: boolean;
-  name: string;
   pid: number;
+  program: string;
   running: boolean;
   service_name: string;
 }
@@ -35,8 +50,8 @@ interface HomebrewServiceRecord {
 function serviceRecord(overrides: Partial<HomebrewServiceRecord> = {}): HomebrewServiceRecord {
   return {
     loaded: true,
-    name: "openshell",
     pid: 4242,
+    program: SERVICE_PROGRAM,
     running: true,
     service_name: "homebrew.mxcl.openshell",
     ...overrides,
@@ -44,20 +59,25 @@ function serviceRecord(overrides: Partial<HomebrewServiceRecord> = {}): Homebrew
 }
 
 function queryHomebrewService(records: HomebrewServiceRecord[]) {
-  const formulaPrefix = "/opt/homebrew/opt/openshell";
-  const gatewayBin = `${formulaPrefix}/bin/openshell-gateway`;
-  const spawnSyncImpl = vi.fn((_command: string, args: string[]) => {
-    const responses = {
-      info: officialFormulaInfo(),
-      services: spawnResult(0, "", JSON.stringify(records)),
-      "--prefix": spawnResult(0, "", formulaPrefix),
-    };
-    return responses[args[0] as keyof typeof responses] ?? spawnResult();
+  const spawnSyncImpl = vi.fn((command: string, args: string[]) => {
+    const label = args[1]?.split("/").at(-1);
+    const record = records.find((candidate) => candidate.service_name === label);
+    return command === "brew"
+      ? args[0] === "info"
+        ? officialFormulaInfo()
+        : spawnResult()
+      : !record?.loaded
+        ? spawnResult(113)
+        : spawnResult(
+            0,
+            "",
+            `\tstate = ${record.running ? "running" : "waiting"}\n\tprogram = ${record.program}\n\tpid = ${String(record.pid)}\n`,
+          );
   });
 
   return getTrustedActiveOpenShellGatewayUserServiceIdentity({
-    commandExists: (command) => command === "brew",
-    existsSync: (candidate) => candidate === gatewayBin,
+    commandExists: (command) => command === "brew" || command === "launchctl",
+    existsSync: (candidate) => candidate === GATEWAY_BIN,
     homebrewFormulaOperation: (args) => spawnSyncImpl("brew", args),
     platform: "darwin",
     spawnSyncImpl,
@@ -67,13 +87,7 @@ function queryHomebrewService(records: HomebrewServiceRecord[]) {
 describe("OpenShell Homebrew service boundary", () => {
   it("rejects a Homebrew formula outside the official tap (#6903)", () => {
     const operation = vi.fn((args: string[]) =>
-      args[0] === "info"
-        ? spawnResult(
-            0,
-            "",
-            JSON.stringify({ formulae: [{ name: "openshell", tap: "other/tap" }] }),
-          )
-        : spawnResult(),
+      args[0] === "info" ? officialFormulaInfo({ tap: "other/tap" }) : spawnResult(),
     );
 
     expect(() =>
@@ -83,6 +97,24 @@ describe("OpenShell Homebrew service boundary", () => {
         platform: "darwin",
       }),
     ).toThrow("must come from nvidia/openshell");
+  });
+
+  it.each([
+    ["is not installed", { installed: [] }, "pinned checksum and temporary trust contract"],
+    ["has a relative service command", { serviceProgram: "bin/gateway" }, "one absolute path"],
+    [
+      "has a different service command",
+      { serviceProgram: `${FORMULA_PREFIX}/bin/other` },
+      "expected gateway wrapper",
+    ],
+  ])("rejects an official formula that %s (#11112)", (_case, options, expected) => {
+    expect(() =>
+      hasOpenShellGatewayUserService({
+        commandExists: () => true,
+        homebrewFormulaOperation: () => officialFormulaInfo(options),
+        platform: "darwin",
+      }),
+    ).toThrow(expected);
   });
 
   it("uses the temporary formula trust boundary for inspection (#7707)", () => {
@@ -98,7 +130,6 @@ describe("OpenShell Homebrew service boundary", () => {
       }),
     ).toBe(true);
     expect(operation.mock.calls.map(([args]) => args)).toEqual([
-      ["list", "--formula", "openshell"],
       ["info", "--json=v2", "openshell"],
     ]);
   });
@@ -148,8 +179,8 @@ describe("OpenShell Homebrew service boundary", () => {
         OPENSHELL_GATEWAY_HOMEBREW_FORMULA_SHA256,
         "--",
         "brew",
-        "list",
-        "--formula",
+        "info",
+        "--json=v2",
         "openshell",
       ]),
       expect.any(Object),
@@ -199,6 +230,20 @@ describe("OpenShell Homebrew service boundary", () => {
   it("rejects a service label that extends the canonical label (#11111)", () => {
     expect(
       queryHomebrewService([serviceRecord({ service_name: "sh.brew.openshell.attacker" })]),
+    ).toBeNull();
+  });
+
+  it("rejects an active canonical service with a foreign program (#11112)", () => {
+    expect(
+      queryHomebrewService([
+        serviceRecord({ program: "/tmp/foreign-service", service_name: "sh.brew.openshell" }),
+      ]),
+    ).toBeNull();
+  });
+
+  it("rejects an active canonical service with a malformed PID (#11112)", () => {
+    expect(
+      queryHomebrewService([serviceRecord({ pid: Number.NaN, service_name: "sh.brew.openshell" })]),
     ).toBeNull();
   });
 

--- a/src/lib/onboard/docker-driver-gateway-service.test.ts
+++ b/src/lib/onboard/docker-driver-gateway-service.test.ts
@@ -59,36 +59,23 @@ function trustedShowOutput(
   ].join("\n");
 }
 
+const HOMEBREW_FORMULA_PREFIX = "/opt/homebrew/opt/openshell";
+const HOMEBREW_SERVICE_PROGRAM = `${HOMEBREW_FORMULA_PREFIX}/libexec/openshell-gateway-homebrew-service`;
+
 function officialFormulaInfo(): SpawnSyncLikeResult {
   return spawnResult(
     0,
     "",
-    JSON.stringify({ formulae: [{ name: "openshell", tap: "nvidia/openshell" }] }),
-  );
-}
-
-function officialRunningServiceInfo(
-  overrides: Partial<{
-    loaded: boolean;
-    name: string;
-    pid: number;
-    running: boolean;
-    service_name: string;
-  }> = {},
-): SpawnSyncLikeResult {
-  return spawnResult(
-    0,
-    "",
-    JSON.stringify([
-      {
-        loaded: true,
-        name: "openshell",
-        pid: 4242,
-        running: true,
-        service_name: "homebrew.mxcl.openshell",
-        ...overrides,
-      },
-    ]),
+    JSON.stringify({
+      formulae: [
+        {
+          installed: [{ version: "0.0.106" }],
+          name: "openshell",
+          service: { run: HOMEBREW_SERVICE_PROGRAM },
+          tap: "nvidia/openshell",
+        },
+      ],
+    }),
   );
 }
 
@@ -321,48 +308,6 @@ describe("docker-driver-gateway-service", () => {
     ).toBeNull();
   });
 
-  it("identifies the active official Homebrew gateway process (#6903)", () => {
-    const formulaPrefix = "/opt/homebrew/opt/openshell";
-    const gatewayBin = `${formulaPrefix}/bin/openshell-gateway`;
-    const spawnSyncImpl = vi.fn((_command: string, args: string[]) => {
-      const responses = {
-        info: officialFormulaInfo(),
-        services: officialRunningServiceInfo(),
-        "--prefix": spawnResult(0, "", formulaPrefix),
-      };
-      return responses[args[0] as keyof typeof responses] ?? spawnResult();
-    });
-
-    expect(
-      getTrustedActiveOpenShellGatewayUserServiceIdentity({
-        commandExists: (command) => command === "brew",
-        existsSync: (candidate) => candidate === gatewayBin,
-        homebrewFormulaOperation: trustedBrew(spawnSyncImpl),
-        platform: "darwin",
-        spawnSyncImpl,
-      }),
-    ).toEqual({ pid: 4242, executablePath: gatewayBin });
-    expect(spawnSyncImpl).toHaveBeenCalledWith("brew", ["services", "info", "openshell", "--json"]);
-  });
-
-  it.each([
-    ["inactive", officialRunningServiceInfo({ running: false })],
-    ["foreign", officialRunningServiceInfo({ service_name: "other.openshell" })],
-    ["malformed", spawnResult(0, "", "not-json")],
-  ])("does not trust a %s Homebrew gateway process (#6903)", (_case, serviceInfo) => {
-    const brew = vi.fn((_command: string, args: string[]) =>
-      args[0] === "info" ? officialFormulaInfo() : serviceInfo,
-    );
-    expect(
-      getTrustedActiveOpenShellGatewayUserServicePid({
-        commandExists: () => true,
-        homebrewFormulaOperation: trustedBrew(brew),
-        platform: "darwin",
-        spawnSyncImpl: brew,
-      }),
-    ).toBeNull();
-  });
-
   it("removes a marked NemoClaw unit before activating an upstream systemd unit (#6903)", () => {
     const events: string[] = [];
     const removed: string[] = [];
@@ -435,7 +380,6 @@ describe("docker-driver-gateway-service", () => {
       started: true,
     });
     expect(events).toEqual([
-      "list --formula openshell",
       "info --json=v2 openshell",
       "validate-port",
       "prepare-env",

--- a/src/lib/onboard/docker-driver-gateway-service.ts
+++ b/src/lib/onboard/docker-driver-gateway-service.ts
@@ -38,7 +38,7 @@ export interface OpenShellGatewayUserServiceOptions {
   commandExists?: (command: string) => boolean;
   env?: NodeJS.ProcessEnv;
   existsSync?: (filePath: string) => boolean;
-  /** Test seam for the checksum-verified, temporary formula trust boundary. */
+  /** Runner for the checksum-verified, temporary formula trust boundary. */
   homebrewFormulaOperation?: (args: string[]) => SpawnSyncLikeResult;
   /** Test seam: read the version output of the package-managed gateway binary. */
   getUpstreamGatewayVersion?: (binaryPath: string) => string | null;
@@ -450,15 +450,8 @@ function homebrewFormulaOperationScript(): string {
   return path.resolve(__dirname, "../../../scripts/install-openshell.sh");
 }
 
-function runTrustedHomebrewFormulaOperation(
-  args: string[],
-  opts: Required<Pick<OpenShellGatewayUserServiceOptions, "env" | "spawnSyncImpl">> &
-    Pick<OpenShellGatewayUserServiceOptions, "homebrewFormulaOperation">,
-): CommandResult {
-  if (opts.homebrewFormulaOperation) {
-    return commandResult(opts.homebrewFormulaOperation(args));
-  }
-  return runCommand(
+function homebrewFormulaOperationCommand(args: string[]): [string, string[]] {
+  return [
     "bash",
     [
       homebrewFormulaOperationScript(),
@@ -468,8 +461,41 @@ function runTrustedHomebrewFormulaOperation(
       "brew",
       ...args,
     ],
-    opts,
-  );
+  ];
+}
+
+export function createOpenShellHomebrewFormulaOperation(
+  opts: Pick<OpenShellGatewayUserServiceOptions, "env" | "spawnSyncImpl"> = {},
+): NonNullable<OpenShellGatewayUserServiceOptions["homebrewFormulaOperation"]> {
+  const env = opts.env ?? process.env;
+  const spawnSyncImpl = opts.spawnSyncImpl ?? spawnSync;
+  return (args) => {
+    try {
+      const [command, commandArgs] = homebrewFormulaOperationCommand(args);
+      return spawnSyncImpl(command, commandArgs, {
+        encoding: "utf-8",
+        env,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch (error) {
+      return {
+        error: error instanceof Error ? error : new Error(formatError(error)),
+        status: null,
+      };
+    }
+  };
+}
+
+function runTrustedHomebrewFormulaOperation(
+  args: string[],
+  opts: Required<Pick<OpenShellGatewayUserServiceOptions, "env" | "spawnSyncImpl">> &
+    Pick<OpenShellGatewayUserServiceOptions, "homebrewFormulaOperation">,
+): CommandResult {
+  if (opts.homebrewFormulaOperation) {
+    return commandResult(opts.homebrewFormulaOperation(args));
+  }
+  const [command, commandArgs] = homebrewFormulaOperationCommand(args);
+  return runCommand(command, commandArgs, opts);
 }
 
 const HOMEBREW_FORMULA_REPAIR_GUIDANCE =

--- a/src/lib/onboard/docker-driver-gateway-service.ts
+++ b/src/lib/onboard/docker-driver-gateway-service.ts
@@ -151,6 +151,7 @@ export interface PackageManagedDockerDriverGatewayOptions {
 }
 
 interface OpenShellGatewayUserServiceTarget {
+  homebrewServiceProgram?: string;
   logCommand: string;
   manager: "homebrew" | "systemd";
   serviceName: string;
@@ -576,43 +577,46 @@ function hasUpstreamOpenShellGatewayUserService(
   return getOpenShellGatewayUserServicePaths().some(existsSync);
 }
 
-function hasOfficialHomebrewFormula(
+interface OfficialHomebrewFormulaPaths {
+  gatewayBinary: string;
+  serviceProgram: string;
+}
+
+function resolveOfficialHomebrewFormulaPaths(
   opts: Pick<
     OpenShellGatewayUserServiceOptions,
     "commandExists" | "env" | "homebrewFormulaOperation" | "platform" | "spawnSyncImpl"
   >,
-): boolean {
-  if ((opts.platform ?? process.platform) !== "darwin") return false;
+): OfficialHomebrewFormulaPaths | null {
+  if ((opts.platform ?? process.platform) !== "darwin") return null;
   const env = opts.env ?? process.env;
   const commandExists = opts.commandExists ?? ((command) => defaultCommandExists(command, env));
-  if (!commandExists("brew")) return false;
+  if (!commandExists("brew")) return null;
   const spawnSyncImpl = opts.spawnSyncImpl ?? spawnSync;
   const operationOptions = {
     env,
     homebrewFormulaOperation: opts.homebrewFormulaOperation,
     spawnSyncImpl,
   };
-  const listed = runTrustedHomebrewFormulaOperation(
-    ["list", "--formula", OPENSHELL_GATEWAY_HOMEBREW_SERVICE],
-    operationOptions,
-  );
-  if (!listed.ok) {
-    if (listed.status === OPENSHELL_HOMEBREW_FORMULA_ABSENT) return false;
-    if (listed.status === OPENSHELL_HOMEBREW_OPERATION_FAILED) {
-      throw new OpenShellGatewayServiceTrustError(HOMEBREW_FORMULA_REPAIR_GUIDANCE);
-    }
-    throwHomebrewFormulaOperationFailure("installation inspection", listed);
-  }
   const info = runTrustedHomebrewFormulaOperation(
     ["info", "--json=v2", OPENSHELL_GATEWAY_HOMEBREW_SERVICE],
     operationOptions,
   );
   if (!info.ok) {
+    if (info.status === OPENSHELL_HOMEBREW_FORMULA_ABSENT) return null;
+    if (info.status === OPENSHELL_HOMEBREW_OPERATION_FAILED) {
+      throw new OpenShellGatewayServiceTrustError(HOMEBREW_FORMULA_REPAIR_GUIDANCE);
+    }
     throwHomebrewFormulaOperationFailure("formula identity inspection", info);
   }
   try {
     const parsed = JSON.parse(info.stdout ?? "") as {
-      formulae?: Array<{ name?: string; tap?: string }>;
+      formulae?: Array<{
+        installed?: unknown[];
+        name?: string;
+        service?: { run?: unknown };
+        tap?: string;
+      }>;
     };
     const formula = parsed.formulae?.find(
       (candidate) => candidate.name === OPENSHELL_GATEWAY_HOMEBREW_SERVICE,
@@ -622,6 +626,29 @@ function hasOfficialHomebrewFormula(
         `OpenShell Homebrew formula must come from ${OPENSHELL_GATEWAY_HOMEBREW_TAP}`,
       );
     }
+    if (!Array.isArray(formula.installed) || formula.installed.length === 0) {
+      throw new OpenShellGatewayServiceTrustError(HOMEBREW_FORMULA_REPAIR_GUIDANCE);
+    }
+    const serviceProgram = formula.service?.run;
+    if (typeof serviceProgram !== "string" || !path.isAbsolute(serviceProgram)) {
+      throw new OpenShellGatewayServiceTrustError(
+        "OpenShell Homebrew formula service command is not one absolute path",
+      );
+    }
+    const normalizedProgram = path.normalize(serviceProgram);
+    const formulaPrefix = path.dirname(path.dirname(normalizedProgram));
+    if (
+      normalizedProgram !==
+      path.join(formulaPrefix, "libexec", "openshell-gateway-homebrew-service")
+    ) {
+      throw new OpenShellGatewayServiceTrustError(
+        "OpenShell Homebrew formula service command is not the expected gateway wrapper",
+      );
+    }
+    return {
+      gatewayBinary: path.join(formulaPrefix, "bin", "openshell-gateway"),
+      serviceProgram: normalizedProgram,
+    };
   } catch (error) {
     if (error instanceof SyntaxError) {
       throw new OpenShellGatewayServiceTrustError(
@@ -630,7 +657,6 @@ function hasOfficialHomebrewFormula(
     }
     throw error;
   }
-  return true;
 }
 
 function resolveOpenShellGatewayUserService(
@@ -638,13 +664,15 @@ function resolveOpenShellGatewayUserService(
 ): OpenShellGatewayUserServiceTarget | null {
   const platform = opts.platform ?? process.platform;
   if (platform === "darwin") {
-    return hasOfficialHomebrewFormula(opts)
+    const formula = resolveOfficialHomebrewFormulaPaths(opts);
+    return formula
       ? {
+          homebrewServiceProgram: formula.serviceProgram,
           logCommand: getHomebrewGatewayLogCommand(),
           manager: "homebrew",
           serviceName: OPENSHELL_GATEWAY_HOMEBREW_SERVICE,
           statusCommand: `brew services info ${OPENSHELL_GATEWAY_HOMEBREW_SERVICE}`,
-          trustedBinaryPaths: [],
+          trustedBinaryPaths: [formula.gatewayBinary],
           trustedUnitPaths: [],
         }
       : null;
@@ -960,19 +988,39 @@ export interface TrustedActiveOpenShellGatewayUserServiceIdentity {
   executablePath: string | null;
 }
 
-function resolveOfficialHomebrewGatewayBinary(
-  opts: Required<Pick<OpenShellGatewayUserServiceOptions, "env" | "existsSync" | "spawnSyncImpl">> &
-    Pick<OpenShellGatewayUserServiceOptions, "homebrewFormulaOperation">,
-): string | null {
-  const prefix = runTrustedHomebrewFormulaOperation(
-    ["--prefix", OPENSHELL_GATEWAY_HOMEBREW_SERVICE],
-    opts,
-  );
-  if (!prefix.ok) return null;
-  const value = prefix.stdout?.trim() ?? "";
-  if (!path.isAbsolute(value)) return null;
-  const gatewayBinary = path.normalize(path.join(value, "bin", "openshell-gateway"));
-  return opts.existsSync(gatewayBinary) ? gatewayBinary : null;
+const OPENSHELL_HOMEBREW_SERVICE_LABELS = [
+  `sh.brew.${OPENSHELL_GATEWAY_HOMEBREW_SERVICE}`,
+  `homebrew.mxcl.${OPENSHELL_GATEWAY_HOMEBREW_SERVICE}`,
+] as const;
+
+function launchctlPrintValue(output: string, key: string): string | null {
+  const prefix = `\t${key} = `;
+  const line = output.split(/\r?\n/).find((candidate) => candidate.startsWith(prefix));
+  return line?.slice(prefix.length).trim() || null;
+}
+
+function getActiveHomebrewGatewayServiceIdentity(
+  service: OpenShellGatewayUserServiceTarget,
+  opts: Required<Pick<OpenShellGatewayUserServiceOptions, "env" | "existsSync" | "spawnSyncImpl">>,
+): TrustedActiveOpenShellGatewayUserServiceIdentity | null {
+  const uid = process.getuid?.();
+  const executablePath = service.trustedBinaryPaths[0] ?? null;
+  const expectedProgram = service.homebrewServiceProgram ?? null;
+  if (!Number.isSafeInteger(uid) || uid === undefined || !executablePath || !expectedProgram) {
+    return null;
+  }
+  if (!opts.existsSync(executablePath)) return null;
+
+  const identities: TrustedActiveOpenShellGatewayUserServiceIdentity[] = [];
+  for (const label of OPENSHELL_HOMEBREW_SERVICE_LABELS) {
+    const result = runCommand("launchctl", ["print", `gui/${String(uid)}/${label}`], opts);
+    if (!result.ok || launchctlPrintValue(result.stdout ?? "", "state") !== "running") continue;
+    const program = launchctlPrintValue(result.stdout ?? "", "program");
+    const pid = Number(launchctlPrintValue(result.stdout ?? "", "pid"));
+    if (program !== expectedProgram || !Number.isSafeInteger(pid) || pid <= 0) return null;
+    identities.push({ executablePath, pid });
+  }
+  return identities.length === 1 ? identities[0] : null;
 }
 
 export function getTrustedActiveOpenShellGatewayUserServiceIdentity(
@@ -992,53 +1040,12 @@ export function getTrustedActiveOpenShellGatewayUserServiceIdentity(
   }
   if (!service) return null;
   if (service.manager === "homebrew") {
-    if (!commandExists("brew")) return null;
-    const result = runTrustedHomebrewFormulaOperation(
-      ["services", "info", service.serviceName, "--json"],
-      {
-        env,
-        homebrewFormulaOperation: opts.homebrewFormulaOperation,
-        spawnSyncImpl,
-      },
-    );
-    if (!result.ok) return null;
-    try {
-      const records = JSON.parse(result.stdout ?? "") as Array<{
-        loaded?: boolean;
-        name?: string;
-        pid?: number;
-        running?: boolean;
-        service_name?: string;
-      }>;
-      const trustedServiceNames = new Set([
-        `homebrew.mxcl.${service.serviceName}`,
-        `sh.brew.${service.serviceName}`,
-      ]);
-      const matchingRecords = records.filter(
-        (candidate) =>
-          candidate.name === service.serviceName &&
-          candidate.service_name !== undefined &&
-          trustedServiceNames.has(candidate.service_name) &&
-          candidate.running === true &&
-          candidate.loaded === true,
-      );
-      if (matchingRecords.length !== 1) return null;
-      const [record] = matchingRecords;
-      const pid =
-        Number.isSafeInteger(record?.pid) && Number(record.pid) > 0 ? Number(record.pid) : null;
-      if (pid === null) return null;
-      return {
-        pid,
-        executablePath: resolveOfficialHomebrewGatewayBinary({
-          env,
-          existsSync: opts.existsSync ?? fs.existsSync,
-          homebrewFormulaOperation: opts.homebrewFormulaOperation,
-          spawnSyncImpl,
-        }),
-      };
-    } catch {
-      return null;
-    }
+    if (!commandExists("launchctl")) return null;
+    return getActiveHomebrewGatewayServiceIdentity(service, {
+      env,
+      existsSync: opts.existsSync ?? fs.existsSync,
+      spawnSyncImpl,
+    });
   }
   if (!commandExists("systemctl")) return null;
   const result = runSystemctlUser(

--- a/src/lib/readiness/gateway-production.test.ts
+++ b/src/lib/readiness/gateway-production.test.ts
@@ -251,6 +251,11 @@ describe("managed gateway port readiness (#7411)", () => {
     const formulaBin = path.join(formulaPrefix, "bin");
     const openshellBin = path.join(formulaBin, "openshell");
     const gatewayBin = path.join(formulaBin, "openshell-gateway");
+    const serviceProgram = path.join(
+      formulaPrefix,
+      "libexec",
+      "openshell-gateway-homebrew-service",
+    );
     fs.mkdirSync(formulaBin);
     fs.writeFileSync(openshellBin, "");
     fs.writeFileSync(gatewayBin, "");
@@ -272,6 +277,10 @@ describe("managed gateway port readiness (#7411)", () => {
         ["sh", "-c", 'command -v "$1" >/dev/null 2>&1', "sh", "brew"].join("\0"),
         commandResult("", 0),
       ],
+      [
+        ["sh", "-c", 'command -v "$1" >/dev/null 2>&1', "sh", "launchctl"].join("\0"),
+        commandResult("", 0),
+      ],
       [[openshellBin, "status", "-g", gatewayName].join("\0"), commandResult(status, 0)],
       [[openshellBin, "gateway", "info", "-g", gatewayName].join("\0"), commandResult(info, 0)],
       [[openshellBin, "gateway", "info"].join("\0"), commandResult(info, 0)],
@@ -285,30 +294,35 @@ describe("managed gateway port readiness (#7411)", () => {
         ["/usr/sbin/lsof", "-a", "-p", String(process.pid), "-d", "txt", "-Fn"].join("\0"),
         commandResult(`p${process.pid}\nftxt\nn${gatewayBin}\n`, 0),
       ],
-      [["brew", "list", "--formula", "openshell"].join("\0"), commandResult("", 0)],
       [
         ["brew", "info", "--json=v2", "openshell"].join("\0"),
         commandResult(
-          JSON.stringify({ formulae: [{ name: "openshell", tap: "nvidia/openshell" }] }),
+          JSON.stringify({
+            formulae: [
+              {
+                installed: [{ version: "0.0.106" }],
+                name: "openshell",
+                service: { run: serviceProgram },
+                tap: "nvidia/openshell",
+              },
+            ],
+          }),
           0,
         ),
       ],
       [
-        ["brew", "services", "info", "openshell", "--json"].join("\0"),
+        ["launchctl", "print", `gui/${String(process.getuid?.())}/sh.brew.openshell`].join("\0"),
         commandResult(
-          JSON.stringify([
-            {
-              loaded: true,
-              name: "openshell",
-              pid: process.pid,
-              running: true,
-              service_name: "sh.brew.openshell",
-            },
-          ]),
+          `\tstate = running\n\tprogram = ${serviceProgram}\n\tpid = ${process.pid}\n`,
           0,
         ),
       ],
-      [["brew", "--prefix", "openshell"].join("\0"), commandResult(formulaPrefix, 0)],
+      [
+        ["launchctl", "print", `gui/${String(process.getuid?.())}/homebrew.mxcl.openshell`].join(
+          "\0",
+        ),
+        commandResult(),
+      ],
     ]);
     subprocess.spawnSync.mockImplementation((command: string, args: readonly string[] = []) => {
       const brewIndex = args.indexOf("brew");
@@ -337,16 +351,23 @@ describe("managed gateway port readiness (#7411)", () => {
             const brewIndex = args.indexOf("brew");
             return args.slice(brewIndex + 1);
           });
-      const expectedFormulaCalls = [
-        ["list", "--formula", "openshell"],
-        ["info", "--json=v2", "openshell"],
-        ["services", "info", "openshell", "--json"],
-        ["services", "info", "openshell", "--json"],
-      ];
+      const expectedFormulaCalls = [["info", "--json=v2", "openshell"]];
       expect(formulaCalls()).toEqual(expectedFormulaCalls);
+      const launchctlCalls = () =>
+        subprocess.spawnSync.mock.calls
+          .filter(([command]) => command === "launchctl")
+          .map(([, args]) => args);
+      const expectedLaunchctlCalls = [
+        ["print", `gui/${String(process.getuid?.())}/sh.brew.openshell`],
+        ["print", `gui/${String(process.getuid?.())}/homebrew.mxcl.openshell`],
+        ["print", `gui/${String(process.getuid?.())}/sh.brew.openshell`],
+        ["print", `gui/${String(process.getuid?.())}/homebrew.mxcl.openshell`],
+      ];
+      expect(launchctlCalls()).toEqual(expectedLaunchctlCalls);
 
       await collectGatewayObservations(deps);
       expect(formulaCalls()).toEqual([...expectedFormulaCalls, ...expectedFormulaCalls]);
+      expect(launchctlCalls()).toEqual([...expectedLaunchctlCalls, ...expectedLaunchctlCalls]);
     } finally {
       await new Promise<void>((resolve) => listener.close(() => resolve()));
       fs.rmSync(formulaPrefix, { force: true, recursive: true });

--- a/src/lib/readiness/gateway-production.test.ts
+++ b/src/lib/readiness/gateway-production.test.ts
@@ -244,7 +244,7 @@ describe("managed gateway port readiness (#7411)", () => {
     ).toBe(false);
   });
 
-  it("recognizes a Homebrew 6 listener without repeated static formula probes (#11111, #11112)", async () => {
+  it("resets Homebrew formula evidence after successful and failed observations (#11111, #11112)", async () => {
     vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
     vi.spyOn(process, "arch", "get").mockReturnValue("arm64");
     const formulaPrefix = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-readiness-homebrew-"));
@@ -324,11 +324,20 @@ describe("managed gateway port readiness (#7411)", () => {
         commandResult(),
       ],
     ]);
+    let failManagedObservation = false;
+    let failingExecutableSamples = 0;
+    const failObservation = (): never => {
+      throw new Error("synthetic managed observation failure");
+    };
     subprocess.spawnSync.mockImplementation((command: string, args: readonly string[] = []) => {
       const brewIndex = args.indexOf("brew");
       const invocation =
         command === "bash" ? ["brew", ...args.slice(brewIndex + 1)] : [command, ...args];
-      return resultByInvocation.get(invocation.join("\0")) ?? commandResult();
+      return failManagedObservation &&
+        command === "/usr/sbin/lsof" &&
+        ++failingExecutableSamples === 3
+        ? failObservation()
+        : (resultByInvocation.get(invocation.join("\0")) ?? commandResult());
     });
 
     try {
@@ -365,9 +374,28 @@ describe("managed gateway port readiness (#7411)", () => {
       ];
       expect(launchctlCalls()).toEqual(expectedLaunchctlCalls);
 
-      await collectGatewayObservations(deps);
+      failManagedObservation = true;
+      await expect(collectGatewayObservations(deps)).resolves.toMatchObject({
+        failure: "Managed gateway observations could not be collected safely.",
+      });
       expect(formulaCalls()).toEqual([...expectedFormulaCalls, ...expectedFormulaCalls]);
-      expect(launchctlCalls()).toEqual([...expectedLaunchctlCalls, ...expectedLaunchctlCalls]);
+      expect(launchctlCalls()).toEqual([
+        ...expectedLaunchctlCalls,
+        ...expectedLaunchctlCalls.slice(0, 2),
+      ]);
+
+      failManagedObservation = false;
+      await collectGatewayObservations(deps);
+      expect(formulaCalls()).toEqual([
+        ...expectedFormulaCalls,
+        ...expectedFormulaCalls,
+        ...expectedFormulaCalls,
+      ]);
+      expect(launchctlCalls()).toEqual([
+        ...expectedLaunchctlCalls,
+        ...expectedLaunchctlCalls.slice(0, 2),
+        ...expectedLaunchctlCalls,
+      ]);
     } finally {
       await new Promise<void>((resolve) => listener.close(() => resolve()));
       fs.rmSync(formulaPrefix, { force: true, recursive: true });

--- a/src/lib/readiness/gateway-production.test.ts
+++ b/src/lib/readiness/gateway-production.test.ts
@@ -11,6 +11,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { isDockerDriverGatewayProcessIdentity } from "../onboard/docker-driver-gateway-process-identity";
 import type { GatewayOwner } from "../onboard/gateway-ownership";
 import { resetTraceForTests, TRACE_FILE_ENV } from "../trace";
+import { collectGatewayObservations } from "./gateway";
 
 const subprocess = vi.hoisted(() => ({
   spawnSync: vi.fn(),
@@ -243,7 +244,7 @@ describe("managed gateway port readiness (#7411)", () => {
     ).toBe(false);
   });
 
-  it("recognizes a Homebrew 6 packaged-service listener in readiness (#11111)", async () => {
+  it("recognizes a Homebrew 6 listener without repeated static formula probes (#11111, #11112)", async () => {
     vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
     vi.spyOn(process, "arch", "get").mockReturnValue("arm64");
     const formulaPrefix = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-readiness-homebrew-"));
@@ -323,10 +324,29 @@ describe("managed gateway port readiness (#7411)", () => {
         observeVersionCompatibility: () => "compatible",
       });
 
-      await expect(deps.observeManagedGateway(managedOwner(gatewayPort))).resolves.toMatchObject({
-        reuseState: "healthy",
-        portConflictState: "none",
+      await expect(collectGatewayObservations(deps)).resolves.toMatchObject({
+        observations: {
+          reuseState: "healthy",
+          portConflictState: "none",
+        },
       });
+      const formulaCalls = () =>
+        subprocess.spawnSync.mock.calls
+          .filter(([command]) => command === "bash")
+          .map(([, args]) => {
+            const brewIndex = args.indexOf("brew");
+            return args.slice(brewIndex + 1);
+          });
+      const expectedFormulaCalls = [
+        ["list", "--formula", "openshell"],
+        ["info", "--json=v2", "openshell"],
+        ["services", "info", "openshell", "--json"],
+        ["services", "info", "openshell", "--json"],
+      ];
+      expect(formulaCalls()).toEqual(expectedFormulaCalls);
+
+      await collectGatewayObservations(deps);
+      expect(formulaCalls()).toEqual([...expectedFormulaCalls, ...expectedFormulaCalls]);
     } finally {
       await new Promise<void>((resolve) => listener.close(() => resolve()));
       fs.rmSync(formulaPrefix, { force: true, recursive: true });

--- a/src/lib/readiness/gateway-production.ts
+++ b/src/lib/readiness/gateway-production.ts
@@ -592,15 +592,9 @@ export function createProductionGatewayReadinessDependencies(
     string,
     ReturnType<typeof homebrewFormulaOperation>
   >();
-  // Cache only static formula evidence for this observation. Service status
-  // remains uncached so the two PID samples still detect replacement.
-  const cacheableHomebrewFormulaOperations = new Set([
-    ["list", "--formula", OPENSHELL_GATEWAY_HOMEBREW_SERVICE].join("\0"),
-    ["info", "--json=v2", OPENSHELL_GATEWAY_HOMEBREW_SERVICE].join("\0"),
-    ["--prefix", OPENSHELL_GATEWAY_HOMEBREW_SERVICE].join("\0"),
-  ]);
-  const directHomebrewPrefixOperation = [
-    "--prefix",
+  const homebrewFormulaInfoOperation = [
+    "info",
+    "--json=v2",
     OPENSHELL_GATEWAY_HOMEBREW_SERVICE,
   ].join("\0");
 
@@ -612,23 +606,8 @@ export function createProductionGatewayReadinessDependencies(
     const key = args.join("\0");
     const cached = cachedHomebrewFormulaOperations.get(key);
     if (cached) return cached;
-    let result: ReturnType<typeof homebrewFormulaOperation>;
-    if (key === directHomebrewPrefixOperation) {
-      try {
-        // `brew --prefix` reads installed-keg metadata without loading formula
-        // Ruby. Formula identity and service evaluation stay wrapped.
-        result = spawnSync("brew", args, {
-          encoding: "utf-8",
-          env: probeEnv,
-          stdio: ["ignore", "pipe", "pipe"],
-        });
-      } catch (error) {
-        result = { error: error instanceof Error ? error : new Error(String(error)), status: null };
-      }
-    } else {
-      result = homebrewFormulaOperation(args);
-    }
-    if (result.status === 0 && cacheableHomebrewFormulaOperations.has(key)) {
+    const result = homebrewFormulaOperation(args);
+    if (result.status === 0 && key === homebrewFormulaInfoOperation) {
       cachedHomebrewFormulaOperations.set(key, result);
     }
     return result;

--- a/src/lib/readiness/gateway-production.ts
+++ b/src/lib/readiness/gateway-production.ts
@@ -588,10 +588,7 @@ export function createProductionGatewayReadinessDependencies(
   const trustedVersionBinaryByPid = new Map<number, string>();
   const trustedTargetBoundPids = new Set<number>();
   const homebrewFormulaOperation = createOpenShellHomebrewFormulaOperation({ env: probeEnv });
-  const cachedHomebrewFormulaOperations = new Map<
-    string,
-    ReturnType<typeof homebrewFormulaOperation>
-  >();
+  let cachedHomebrewFormulaInfo: ReturnType<typeof homebrewFormulaOperation> | null = null;
   const homebrewFormulaInfoOperation = [
     "info",
     "--json=v2",
@@ -599,16 +596,17 @@ export function createProductionGatewayReadinessDependencies(
   ].join("\0");
 
   function resetGatewayServiceObservation(): void {
-    cachedHomebrewFormulaOperations.clear();
+    cachedHomebrewFormulaInfo = null;
   }
 
   function runObservedHomebrewFormulaOperation(args: string[]) {
     const key = args.join("\0");
-    const cached = cachedHomebrewFormulaOperations.get(key);
-    if (cached) return cached;
+    if (key === homebrewFormulaInfoOperation && cachedHomebrewFormulaInfo) {
+      return cachedHomebrewFormulaInfo;
+    }
     const result = homebrewFormulaOperation(args);
     if (result.status === 0 && key === homebrewFormulaInfoOperation) {
-      cachedHomebrewFormulaOperations.set(key, result);
+      cachedHomebrewFormulaInfo = result;
     }
     return result;
   }

--- a/src/lib/readiness/gateway-production.ts
+++ b/src/lib/readiness/gateway-production.ts
@@ -35,8 +35,10 @@ import {
 } from "../onboard/docker-driver-gateway-process-identity";
 import { resolveDockerDriverGatewayName } from "../onboard/docker-driver-gateway-runtime";
 import {
+  createOpenShellHomebrewFormulaOperation,
   getTrustedActiveOpenShellGatewayUserServiceIdentity,
   hasOpenShellGatewayUserService,
+  OPENSHELL_GATEWAY_HOMEBREW_SERVICE,
 } from "../onboard/docker-driver-gateway-service";
 import { createGatewayHostRuntime } from "../onboard/gateway-host-runtime";
 import { loadGatewayManagementDeclaration } from "../onboard/gateway-management";
@@ -585,6 +587,52 @@ export function createProductionGatewayReadinessDependencies(
   const trustedGatewayBin = resolveTrustedGatewayBinary(openshellBin);
   const trustedVersionBinaryByPid = new Map<number, string>();
   const trustedTargetBoundPids = new Set<number>();
+  const homebrewFormulaOperation = createOpenShellHomebrewFormulaOperation({ env: probeEnv });
+  const cachedHomebrewFormulaOperations = new Map<
+    string,
+    ReturnType<typeof homebrewFormulaOperation>
+  >();
+  // Cache only static formula evidence for this observation. Service status
+  // remains uncached so the two PID samples still detect replacement.
+  const cacheableHomebrewFormulaOperations = new Set([
+    ["list", "--formula", OPENSHELL_GATEWAY_HOMEBREW_SERVICE].join("\0"),
+    ["info", "--json=v2", OPENSHELL_GATEWAY_HOMEBREW_SERVICE].join("\0"),
+    ["--prefix", OPENSHELL_GATEWAY_HOMEBREW_SERVICE].join("\0"),
+  ]);
+  const directHomebrewPrefixOperation = [
+    "--prefix",
+    OPENSHELL_GATEWAY_HOMEBREW_SERVICE,
+  ].join("\0");
+
+  function resetGatewayServiceObservation(): void {
+    cachedHomebrewFormulaOperations.clear();
+  }
+
+  function runObservedHomebrewFormulaOperation(args: string[]) {
+    const key = args.join("\0");
+    const cached = cachedHomebrewFormulaOperations.get(key);
+    if (cached) return cached;
+    let result: ReturnType<typeof homebrewFormulaOperation>;
+    if (key === directHomebrewPrefixOperation) {
+      try {
+        // `brew --prefix` reads installed-keg metadata without loading formula
+        // Ruby. Formula identity and service evaluation stay wrapped.
+        result = spawnSync("brew", args, {
+          encoding: "utf-8",
+          env: probeEnv,
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+      } catch (error) {
+        result = { error: error instanceof Error ? error : new Error(String(error)), status: null };
+      }
+    } else {
+      result = homebrewFormulaOperation(args);
+    }
+    if (result.status === 0 && cacheableHomebrewFormulaOperations.has(key)) {
+      cachedHomebrewFormulaOperations.set(key, result);
+    }
+    return result;
+  }
 
   function observeDirectGatewayBinary(pid: number): string | null {
     if ((process.platform !== "linux" && process.platform !== "darwin") || !trustedGatewayBin) {
@@ -655,6 +703,7 @@ export function createProductionGatewayReadinessDependencies(
     if (process.platform !== "linux" && process.platform !== "darwin") return null;
     const serviceBefore = getTrustedActiveOpenShellGatewayUserServiceIdentity({
       env: probeEnv,
+      homebrewFormulaOperation: runObservedHomebrewFormulaOperation,
       suppressUnsupportedVersionWarning: true,
     });
     if (serviceBefore?.pid !== pid || !serviceBefore.executablePath) return null;
@@ -665,6 +714,7 @@ export function createProductionGatewayReadinessDependencies(
         : readDarwinProcessExecutable(pid, probeEnv);
     const serviceAfter = getTrustedActiveOpenShellGatewayUserServiceIdentity({
       env: probeEnv,
+      homebrewFormulaOperation: runObservedHomebrewFormulaOperation,
       suppressUnsupportedVersionWarning: true,
     });
     // Bracket the complete service-identity probe so PID reuse or re-exec
@@ -726,6 +776,7 @@ export function createProductionGatewayReadinessDependencies(
     hasOpenShellGatewayUserService: () =>
       hasOpenShellGatewayUserService({
         env: probeEnv,
+        homebrewFormulaOperation: runObservedHomebrewFormulaOperation,
         suppressUnsupportedVersionWarning: true,
       }),
     loadGatewayManagementDeclaration,
@@ -738,7 +789,7 @@ export function createProductionGatewayReadinessDependencies(
     supervisorProbeEnv: probeEnv,
   });
 
-  async function observeManagedGateway(): Promise<ManagedGatewayObservations> {
+  async function collectManagedGatewayObservations(): Promise<ManagedGatewayObservations> {
     const { endpointBinding, reuseState } = observeReuseState(
       gatewayName,
       gatewayPort,
@@ -839,9 +890,26 @@ export function createProductionGatewayReadinessDependencies(
     };
   }
 
+  async function observeManagedGateway(): Promise<ManagedGatewayObservations> {
+    try {
+      return await collectManagedGatewayObservations();
+    } finally {
+      resetGatewayServiceObservation();
+    }
+  }
+
   return {
-    resolveOwner: options.resolveOwner ?? runtime.getGatewayOwner,
-    probeAttachment: options.probeAttachment ?? runtime.probeGatewayAttachment,
+    resolveOwner: () => {
+      resetGatewayServiceObservation();
+      return (options.resolveOwner ?? runtime.getGatewayOwner)();
+    },
+    probeAttachment: async (owner) => {
+      try {
+        return await (options.probeAttachment ?? runtime.probeGatewayAttachment)(owner);
+      } finally {
+        resetGatewayServiceObservation();
+      }
+    },
     observeManagedGateway,
   };
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

macOS gateway readiness now grants temporary Homebrew formula trust once per observation. The live observation sequence fell from 10 trust-wrapper calls and 119.95 seconds to 1 trust-wrapper call and 9.46 seconds on the reproducing Mac, below the 30-second freshness window.

## Reason

Each trusted wrapper call grants and removes formula trust. Repeating identical formula reads and using Homebrew formula evaluation for both service samples made a healthy gateway observation stale before onboarding could use it.

### Related issues

Fixes #11112

## Changes

- Expose the existing checksum-verified Homebrew operation runner so readiness can cache one successful formula identity result for one observation.
- Use wrapped `brew info --json=v2` as the single source for installed-keg state, official tap identity, and the exact formula-defined service and gateway paths.
- Sample both supported launchd labels twice with `launchctl print`. Require one running job, its exact formula-defined program, one positive PID, and the expected gateway binary.
- Clear formula evidence after every managed or external observation.
- Extend the Homebrew 6 readiness and service regressions for cache lifetime, repeated launchd samples, missing installations, malformed formula service paths, foreign programs, malformed PIDs, and ambiguous labels.

## Verification

- `npm exec vitest -- run --project cli src/lib/readiness/gateway-production.test.ts src/lib/onboard/docker-driver-gateway-service-homebrew.test.ts src/lib/onboard/docker-driver-gateway-service.test.ts src/lib/onboard/homebrew-formula-operation.test.ts` — 145 tests passed.
- `npm run typecheck:cli` — passed.
- `npm run checks:repository` — passed.
- `npm run validate:pr` — passed against `origin/main` at `0e5f18654524c2fe00292f18227dfb1a03cded2e`.
- Live macOS comparison through the shipped temporary-trust wrapper — the pre-fix 10-call sequence took 119.95 seconds; the candidate one-trust observation with two launchd and executable samples took 9.46 seconds. The Homebrew 6 `sh.brew.openshell` service stayed running with the same PID and formula-defined program.
- `npm run test:changed` — 4,262 tests passed and 15 unrelated ambient-host tests failed. The failures require Linux Podman tools, inspect live host ports, or encounter the installed OpenShell 0.0.101 formula while this branch pins 0.0.106; none exercise the changed readiness cache.
- The diff contains no secrets, API keys, or credentials.

## Review notes

The checksum-verified wrapper remains the only source of formula identity and executable paths. The cache lasts for one observation. Both live service/PID samples and both executable samples remain uncached, so service replacement, formula path drift, foreign launchd programs, and ambiguous active labels fail closed.

The `docker-driver-*` module names are historical. This change selects no compute runtime and adds no Docker command. Managed Docker and the managed/portable OpenShell Podman driver on macOS share this Homebrew gateway readiness path, so both receive the fix. The separate native Podman provider uses the Linux systemd path and never invokes the Homebrew cache. External and other supervised gateways use the attachment path and clear the cache without consuming it.

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved macOS Homebrew gateway detection and startup validation.
  - Prevented uninstalled or incorrectly configured Homebrew formulas from being treated as valid.
  - Strengthened verification of gateway service identity, executable paths, and running process IDs.
  - Improved handling of malformed service metadata and command failures.

- **Reliability**
  - Readiness checks now refresh Homebrew and macOS service information after both successful and failed gateway observations.
  - Added safer failure reporting and recovery during gateway startup checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->