### PR TITLE
fix(messaging): canonicalize Google Chat refresh profiles

### DIFF
--- a/src/lib/messaging/channels/googlechat/provider-profile/hermes.yaml
+++ b/src/lib/messaging/channels/googlechat/provider-profile/hermes.yaml
@@ -27,12 +27,15 @@ credentials:
         - name: client_email
           description: Service-account client email (JWT issuer)
           required: true
+          secret: false
         - name: private_key
           description: Service-account RSA private key (PEM); signs the JWT assertion
           required: true
           secret: true
         - name: scope
           description: OAuth scope(s) to mint the token for
+          required: false
+          secret: false
 endpoints:
   - host: pubsub.googleapis.com
     port: 443

--- a/src/lib/messaging/channels/googlechat/provider-profile/hermes.yaml
+++ b/src/lib/messaging/channels/googlechat/provider-profile/hermes.yaml
@@ -19,7 +19,7 @@ credentials:
     header_name: Authorization
     query_param: ''
     refresh:
-      strategy: google-service-account-jwt
+      strategy: google_service_account_jwt
       scopes:
         - https://www.googleapis.com/auth/chat.bot
         - https://www.googleapis.com/auth/pubsub

--- a/src/lib/messaging/channels/googlechat/provider-profile/openclaw.yaml
+++ b/src/lib/messaging/channels/googlechat/provider-profile/openclaw.yaml
@@ -38,12 +38,15 @@ credentials:
         - name: client_email
           description: Service-account client email (JWT issuer)
           required: true
+          secret: false
         - name: private_key
           description: Service-account RSA private key (PEM); signs the JWT assertion
           required: true
           secret: true
         - name: scope
           description: OAuth scope(s) to mint the token for
+          required: false
+          secret: false
 endpoints:
   - host: chat.googleapis.com
     port: 443

--- a/src/lib/messaging/channels/googlechat/provider-profile/openclaw.yaml
+++ b/src/lib/messaging/channels/googlechat/provider-profile/openclaw.yaml
@@ -31,7 +31,7 @@ credentials:
     header_name: Authorization
     query_param: ''
     refresh:
-      strategy: google-service-account-jwt
+      strategy: google_service_account_jwt
       scopes:
         - https://www.googleapis.com/auth/chat.bot
       material:

--- a/src/lib/onboard/messaging-bridge-provider.test.ts
+++ b/src/lib/onboard/messaging-bridge-provider.test.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import fs from "node:fs";
 import { describe, expect, it, vi } from "vitest";
 import YAML from "yaml";
 import type { ChannelManifest } from "../messaging/manifest";
@@ -64,9 +65,9 @@ const GC_PROFILE_DOC = {
         strategy: GC_PROFILE.strategy,
         scopes: GC_PROFILE.scopes,
         material: [
-          { name: "client_email", required: true },
+          { name: "client_email", required: true, secret: false },
           { name: "private_key", required: true, secret: true },
-          { name: "scope" },
+          { name: "scope", required: false, secret: false },
         ],
       },
     },
@@ -937,6 +938,49 @@ describe("listMessagingBridgeProfiles", () => {
       },
     ]);
   });
+
+  it.each(["openclaw", "hermes"] as const)(
+    "accepts OpenShell's canonical Google Chat export for %s (#10971)",
+    (agent) => {
+      const profile = listMessagingBridgeProfiles().find(
+        (candidate) => candidate.channelId === "googlechat" && candidate.agent === agent,
+      );
+      expect(profile).toBeDefined();
+
+      const checkedIn = fs.readFileSync(profile!.profilePath, "utf8");
+      const canonicalExport = YAML.parse(checkedIn) as {
+        credentials: Array<Record<string, unknown> & {
+          refresh?: {
+            material?: Array<Record<string, unknown> & { required?: boolean; secret?: boolean }>;
+          };
+        }>;
+      };
+      canonicalExport.credentials = canonicalExport.credentials.map((credential) => ({
+        ...credential,
+        ...(credential.refresh
+          ? {
+              refresh: {
+                ...credential.refresh,
+                material: (credential.refresh.material ?? []).map((material) => ({
+                  ...material,
+                  required: material.required ?? false,
+                  secret: material.secret ?? false,
+                })),
+              },
+            }
+          : {}),
+      }));
+
+      expect(
+        matchesRegisteredMessagingBridgeProfile(profile!.profileId, {
+          root: "/repo",
+          profiles: [profile!],
+          readFileSync: () => checkedIn,
+          runOpenshell: () => ({ status: 0, stdout: JSON.stringify(canonicalExport) }),
+        }),
+      ).toBe(true);
+    },
+  );
 
   it("discovers a co-located bridge profile from injected manifests and YAML", () => {
     const manifest: ChannelManifest = {

--- a/src/lib/onboard/messaging-bridge-provider.test.ts
+++ b/src/lib/onboard/messaging-bridge-provider.test.ts
@@ -1,8 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import fs from "node:fs";
+
 import { describe, expect, it, vi } from "vitest";
 import YAML from "yaml";
+import { REPOSITORY_ROOT } from "../core/repository-root";
 import type { ChannelManifest } from "../messaging/manifest";
 import { redactFull } from "../security/redact";
 import {
@@ -44,7 +47,7 @@ const GC_PROFILE: MessagingBridgeProfile = {
   profilePath: "/repo/src/lib/messaging/channels/googlechat/provider-profile/openclaw.yaml",
   profileId: "google-chat-bridge",
   credentialKey: "GOOGLE_CHAT_ACCESS_TOKEN",
-  strategy: "google-service-account-jwt",
+  strategy: "google_service_account_jwt",
   scopes: ["https://www.googleapis.com/auth/chat.bot"],
   secretMaterialKeys: ["private_key"],
   sourceSecretEnv: "GOOGLECHAT_SERVICE_ACCOUNT",
@@ -918,6 +921,35 @@ describe("matchesRegisteredMessagingBridgeProfile", () => {
 });
 
 describe("listMessagingBridgeProfiles", () => {
+  it.each(["openclaw", "hermes"] as const)(
+    "matches OpenShell's canonical export for the checked-in %s Google Chat profile (#10971)",
+    (agent) => {
+      const profile = listMessagingBridgeProfiles({ root: REPOSITORY_ROOT }).find(
+        (candidate) => candidate.channelId === "googlechat" && candidate.agent === agent,
+      );
+      expect(profile, `missing checked-in ${agent} Google Chat profile`).toBeDefined();
+
+      const exported = YAML.parse(fs.readFileSync(profile!.profilePath, "utf8")) as {
+        credentials: Array<{ refresh?: { strategy?: string } }>;
+      };
+      const refresh = exported.credentials[0]?.refresh;
+      expect(refresh, `${agent} Google Chat refresh boundary`).toBeDefined();
+      refresh!.strategy = refresh!.strategy?.replaceAll("-", "_");
+      const runOpenshell = vi.fn(() => ({
+        status: 0,
+        stdout: JSON.stringify(exported),
+      }));
+
+      expect(
+        matchesRegisteredMessagingBridgeProfile(profile!.profileId, {
+          root: REPOSITORY_ROOT,
+          profiles: [profile!],
+          runOpenshell,
+        }),
+      ).toBe(true);
+    },
+  );
+
   it("discovers a co-located bridge profile from injected manifests and YAML", () => {
     const manifest: ChannelManifest = {
       schemaVersion: 1,

--- a/src/lib/onboard/messaging-bridge-provider.test.ts
+++ b/src/lib/onboard/messaging-bridge-provider.test.ts
@@ -1,11 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import fs from "node:fs";
-
 import { describe, expect, it, vi } from "vitest";
 import YAML from "yaml";
-import { REPOSITORY_ROOT } from "../core/repository-root";
 import type { ChannelManifest } from "../messaging/manifest";
 import { redactFull } from "../security/redact";
 import {
@@ -921,34 +918,25 @@ describe("matchesRegisteredMessagingBridgeProfile", () => {
 });
 
 describe("listMessagingBridgeProfiles", () => {
-  it.each(["openclaw", "hermes"] as const)(
-    "matches OpenShell's canonical export for the checked-in %s Google Chat profile (#10971)",
-    (agent) => {
-      const profile = listMessagingBridgeProfiles({ root: REPOSITORY_ROOT }).find(
-        (candidate) => candidate.channelId === "googlechat" && candidate.agent === agent,
-      );
-      expect(profile, `missing checked-in ${agent} Google Chat profile`).toBeDefined();
+  it("uses OpenShell's canonical refresh contract in both checked-in Google Chat profiles (#10971)", () => {
+    const googleChatProfiles = listMessagingBridgeProfiles()
+      .filter((profile) => profile.channelId === "googlechat")
+      .map(({ agent, profileId, strategy }) => ({ agent, profileId, strategy }))
+      .sort((left, right) => left.agent.localeCompare(right.agent));
 
-      const exported = YAML.parse(fs.readFileSync(profile!.profilePath, "utf8")) as {
-        credentials: Array<{ refresh?: { strategy?: string } }>;
-      };
-      const refresh = exported.credentials[0]?.refresh;
-      expect(refresh, `${agent} Google Chat refresh boundary`).toBeDefined();
-      refresh!.strategy = refresh!.strategy?.replaceAll("-", "_");
-      const runOpenshell = vi.fn(() => ({
-        status: 0,
-        stdout: JSON.stringify(exported),
-      }));
-
-      expect(
-        matchesRegisteredMessagingBridgeProfile(profile!.profileId, {
-          root: REPOSITORY_ROOT,
-          profiles: [profile!],
-          runOpenshell,
-        }),
-      ).toBe(true);
-    },
-  );
+    expect(googleChatProfiles).toEqual([
+      {
+        agent: "hermes",
+        profileId: "google-chat-hermes-bridge",
+        strategy: "google_service_account_jwt",
+      },
+      {
+        agent: "openclaw",
+        profileId: "google-chat-bridge",
+        strategy: "google_service_account_jwt",
+      },
+    ]);
+  });
 
   it("discovers a co-located bridge profile from injected manifests and YAML", () => {
     const manifest: ChannelManifest = {

--- a/src/lib/onboard/messaging-bridge-provider.ts
+++ b/src/lib/onboard/messaging-bridge-provider.ts
@@ -493,7 +493,7 @@ function buildRefreshMaterial(
 ):
   | { ok: true; material: { key: string; value: string }[]; secretKeys: string[] }
   | { ok: false; reason: string } {
-  if (profile.strategy === "google-service-account-jwt") {
+  if (profile.strategy === "google_service_account_jwt") {
     let parsed: Record<string, unknown>;
     try {
       parsed = JSON.parse(secret) as Record<string, unknown>;
@@ -684,7 +684,8 @@ export function configureMessagingBridgeRefreshes(
           "--credential-key",
           profile.credentialKey,
           "--strategy",
-          profile.strategy,
+          // Provider profile documents use snake_case; the CLI flag uses kebab-case.
+          profile.strategy.replaceAll("_", "-"),
           ...materialArgs,
           bridge.name,
         ],

--- a/test/channels/channels-add-bridge-lifecycle.test.ts
+++ b/test/channels/channels-add-bridge-lifecycle.test.ts
@@ -65,6 +65,7 @@ const GOOGLECHAT_PROFILE_DOC: Record<string, unknown> = {
             name: "client_email",
             description: "Service-account client email (JWT issuer)",
             required: true,
+            secret: false,
           },
           {
             name: "private_key",
@@ -75,6 +76,8 @@ const GOOGLECHAT_PROFILE_DOC: Record<string, unknown> = {
           {
             name: "scope",
             description: "OAuth scope(s) to mint the token for",
+            required: false,
+            secret: false,
           },
         ],
       },

--- a/test/channels/channels-add-bridge-lifecycle.test.ts
+++ b/test/channels/channels-add-bridge-lifecycle.test.ts
@@ -58,7 +58,7 @@ const GOOGLECHAT_PROFILE_DOC: Record<string, unknown> = {
       header_name: "Authorization",
       query_param: "",
       refresh: {
-        strategy: "google-service-account-jwt",
+        strategy: "google_service_account_jwt",
         scopes: ["https://www.googleapis.com/auth/chat.bot"],
         material: [
           {
@@ -312,16 +312,16 @@ beforeEach(() => {
           ? JSON.stringify(GOOGLECHAT_PROFILE_DOC)
           : providerName && !providerMissing
             ? `Name: ${providerName}\nType: google-chat-bridge\nCredential keys: GOOGLE_CHAT_ACCESS_TOKEN\nConfig keys: <none>\n`
-          : "",
+            : "",
       stderr: invalidRefresh
         ? "invalid secret handoff"
         : commandFailure
           ? commandFailure
-        : profileMissing
-          ? "provider profile 'google-chat-bridge' not found"
-          : providerMissing
-            ? `provider '${args[args.length - 1]}' not found`
-            : "",
+          : profileMissing
+            ? "provider profile 'google-chat-bridge' not found"
+            : providerMissing
+              ? `provider '${args[args.length - 1]}' not found`
+              : "",
       status:
         invalidRefresh || refreshFailure || deleteFailure || profileMissing || providerMissing
           ? 1

--- a/test/e2e/live/channels-stop-start-helpers.ts
+++ b/test/e2e/live/channels-stop-start-helpers.ts
@@ -10,7 +10,6 @@ import * as policyChannelDependenciesModule from "../../../src/lib/actions/sandb
 import * as policyChannelModule from "../../../src/lib/actions/sandbox/policy-channel.ts";
 import * as openshellRuntimeModule from "../../../src/lib/adapters/openshell/runtime.ts";
 import * as messagingBridgeProviderModule from "../../../src/lib/onboard/messaging-bridge-provider.ts";
-import * as legacyProvidersModule from "../../../src/lib/onboard/providers.ts";
 import { clearStoppedSandboxStateRoots } from "../../../src/lib/sandbox/privileged-exec.ts";
 import * as statePathsModule from "../../../src/lib/state/paths.ts";
 import {
@@ -91,9 +90,11 @@ const messagingBridgeProvider = (
     : messagingBridgeProviderModule
 ) as MessagingBridgeProviderModule;
 const { ensureMessagingBridgeProfiles } = messagingBridgeProvider;
-const legacyProviderDependencies = (
-  "default" in legacyProvidersModule ? legacyProvidersModule.default : legacyProvidersModule
-) as ProviderDependencies;
+// Use the same CommonJS module instance as the onboarding registration graph.
+// An ESM namespace import is a separate wrapper, so mutating it cannot intercept
+// the late-bound `require("./providers")` used during an in-process rebuild.
+const legacyProviderDependencies =
+  require("../../../src/lib/onboard/providers") as ProviderDependencies;
 const statePaths = (
   "default" in statePathsModule ? statePathsModule.default : statePathsModule
 ) as StatePathsModule;

--- a/test/e2e/support/channels-stop-start-googlechat.test.ts
+++ b/test/e2e/support/channels-stop-start-googlechat.test.ts
@@ -3,11 +3,70 @@
 
 import { describe, expect, it, vi } from "vitest";
 
+import { createCredentialProviderRegistration } from "../../../src/lib/onboard/credential-provider-registration.ts";
+import { MESSAGING_BRIDGE_PENDING_VALUE } from "../../../src/lib/onboard/messaging-bridge-provider.ts";
 import {
   addAndRebuildGooglechatForChannelsStopStartLiveE2e,
+  installGooglechatCredentialFixture,
   rebuildGooglechatForChannelsStopStartLiveE2e,
 } from "../live/channels-stop-start-helpers.ts";
+
+type FixtureRunner = typeof import("../../../src/lib/adapters/openshell/runtime.ts").runOpenshell;
+
 describe("channels stop/start Google Chat live composition", () => {
+  it.each([
+    ["openclaw", "e2e-oc-ch-cycle", "google-chat-bridge"],
+    ["hermes", "e2e-hm-ch-cycle", "google-chat-hermes-bridge"],
+  ] as const)(
+    "intercepts the current %s onboarding registration path before refresh minting",
+    (agent, sandboxName, providerType) => {
+      const expectedName = `${sandboxName}-googlechat-bridge`;
+      const runMock = vi
+        .fn<(args: string[]) => { status: number; stdout: string; stderr: string }>()
+        .mockReturnValueOnce({ status: 1, stdout: "", stderr: "" })
+        .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" });
+      const run = runMock as unknown as FixtureRunner;
+      const ensureProfiles = vi.fn();
+      const restore = installGooglechatCredentialFixture(sandboxName, agent, {
+        ensureProfiles,
+        root: "/repo",
+        run,
+      });
+
+      try {
+        const registration = createCredentialProviderRegistration({
+          root: "/repo",
+          runOpenshell: run,
+          getGatewayName: () => "nemoclaw",
+          getCredential: () => null,
+          updateSession: vi.fn() as never,
+          stagedLegacyValues: new Map(),
+          migratedLegacyKeys: new Set(),
+          persistMigratedLegacyKeys: vi.fn(),
+        });
+
+        expect(
+          registration.upsertMessagingProviders([
+            {
+              name: expectedName,
+              envKey: "GOOGLE_CHAT_ACCESS_TOKEN",
+              token: MESSAGING_BRIDGE_PENDING_VALUE,
+              providerType,
+            },
+          ]),
+        ).toEqual([expectedName]);
+        expect(ensureProfiles).toHaveBeenCalledOnce();
+        expect(runMock.mock.calls.map(([args]) => args.slice(0, 2))).toEqual([
+          ["provider", "get"],
+          ["provider", "create"],
+        ]);
+        expect(runMock.mock.calls.some(([args]) => args.includes("refresh"))).toBe(false);
+      } finally {
+        restore();
+      }
+    },
+  );
+
   it("grants a process-local audience capability to the exact live sandbox", async () => {
     const addSandboxChannel = vi.fn(async () => {});
     const rebuildSandbox = vi.fn(async () => {});
@@ -194,5 +253,4 @@ describe("channels stop/start Google Chat live composition", () => {
     expect(events).toEqual(["install", "rebuild", "restore"]);
     expect(restore).toHaveBeenCalledOnce();
   });
-
 });


### PR DESCRIPTION
## Outcome

Google Chat provider registration now survives OpenShell's import/export round trip for both OpenClaw and Hermes while preserving NemoClaw's exact, fail-closed credential-boundary check. The affected trusted channel-lifecycle targets pass on the same exact candidate commit.

## Root cause

Two causal defects appeared in sequence:

1. OpenShell v0.0.106 serializes the Google service-account refresh strategy as `google_service_account_jwt` and emits explicit `required: false` and `secret: false` defaults for refresh material. The checked-in OpenClaw and Hermes profiles instead used the CLI input spelling and omitted those false values. NemoClaw's strict comparison correctly rejected both profiles because the imported OpenShell profile did not equal the checked-in credential boundary.
2. Once that product mismatch was fixed, the live Google Chat fixture exposed a separate test-harness defect during sandbox rebuild. The fixture patched an ESM namespace wrapper for `upsertMessagingProviders`, while onboarding called the CommonJS `providers` module instance. The patch therefore did not intercept rebuild registration, and both agents attempted a real OAuth token mint with fixture credentials.

Both agents failed for the same reasons because they share the provider-profile matcher, credential registration path, and channel-lifecycle fixture. Existing deterministic tests constructed matching in-memory values and tested lifecycle sequencing, but did not compare the checked-in YAML with OpenShell's canonical export or exercise the fixture through the real registration entry point.

### Related issue

Closes #10971. 

## Changes

- Make both checked-in Google Chat profiles match OpenShell's canonical exported credential boundary.
- Translate the canonical strategy to OpenShell's accepted CLI spelling only at the refresh-configure command boundary.
- Add static import/export parity coverage for both OpenClaw and Hermes profiles.
- Patch the same CommonJS provider module used by onboarding in the live fixture.
- Add a two-agent regression that runs the fixture through the real credential registration path and proves no refresh is attempted.

The production matcher remains strict, the private key remains the only secret refresh material, and the change adds no fallback, retry, compatibility layer, or new registry.

## Failing-first evidence

- Profile parity regression before the profile fix: 2 failed, 52 passed; both OpenClaw and Hermes production matchers returned `false`.
- Fixture registration regression before the import-boundary fix: 2 failed, 8 passed; both agents entered the real `provider profile -g` path instead of the fixture interception.
- Trusted run [34054938667](https://github.com/NVIDIA/NemoClaw/actions/runs/34054938667) proved the first fix removed the profile mismatch, then both targets reached the later rebuild and failed at real token minting. That isolated the second defect rather than hiding it with a retry.

## Local validation

- Profile parity tests: 54 passed.
- Channel bridge lifecycle integration tests: 9 passed.
- Google Chat E2E-support fixture tests: 10 passed.
- `npm run test:changed`: passed.
- `npm run typecheck:cli`: passed.
- `npm run checks:repository`: passed.
- `npm run validate:pr`: passed.
- The final commit is signed and signed off.

An additional full E2E-support sweep passed 3,726 tests and skipped 39. Six unrelated host-dependent tests could not run on this macOS checkout because they require Linux systemd/Homebrew trust state, `ip`, Python YAML, or exceeded an existing timeout; none covers a changed file or the Google Chat contract.

## Exact-candidate E2E evidence

- Candidate SHA: `0d850fe1135b0bbe0772bfc019c6ba0adc108639`
- PR base SHA: `30271df8d6b810be4bc10a42a78194e805f9589e`
- Trusted workflow SHA: `5b14e5c299c3779c77895a6c092e874770551a18`
- Exact-candidate managed-image producer: [34056483014](https://github.com/NVIDIA/NemoClaw/actions/runs/34056483014) — passed.
- Trusted E2E run: [34058466748](https://github.com/NVIDIA/NemoClaw/actions/runs/34058466748), attempt 1 — passed.
- OpenClaw `channels-stop-start-openclaw-openclaw-docker`: [job 101554932269](https://github.com/NVIDIA/NemoClaw/actions/runs/34058466748/job/101554932269) — passed.
- Hermes `channels-stop-start-hermes-hermes-docker`: [job 101554932335](https://github.com/NVIDIA/NemoClaw/actions/runs/34058466748/job/101554932335) — passed.

Both jobs passed all seven semantic phases, including active-integration validation, disable/rebuild, re-enable/rebuild, Google Chat removal, and resource release. Their cleanup manifests reported no failures. A bounded scan of retained evidence found no high-risk credential signatures and found 151 redaction markers; all downloaded evidence directories were then removed.

---
Signed-off-by: San Dang <sdang@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Google Chat credential configuration compatibility for service-account authentication.
  - Corrected handling of credential fields, including optional scopes and protected private keys.
  - Ensured provider refresh settings are interpreted consistently across supported Google Chat profiles.

- **Tests**
  - Added coverage confirming Google Chat profiles validate correctly.
  - Added lifecycle coverage for Google Chat provider registration and credential refresh behavior.
  - Improved reliability of stop/start testing for messaging channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->