### PR TITLE
fix(onboard): validate Homebrew formula JSON shape

### DIFF
--- a/src/lib/onboard/docker-driver-gateway-service-homebrew.test.ts
+++ b/src/lib/onboard/docker-driver-gateway-service-homebrew.test.ts
@@ -7,6 +7,7 @@ import {
   getTrustedActiveOpenShellGatewayUserServiceIdentity,
   hasOpenShellGatewayUserService,
   OPENSHELL_GATEWAY_HOMEBREW_FORMULA_SHA256,
+  OpenShellGatewayServiceTrustError,
   type SpawnSyncLikeResult,
   startOpenShellGatewayUserService,
   startPackageManagedDockerDriverGateway,
@@ -85,6 +86,23 @@ function queryHomebrewService(records: HomebrewServiceRecord[]) {
 }
 
 describe("OpenShell Homebrew service boundary", () => {
+  it.each([
+    ["a null document", "null"],
+    ["no formula list", "{}"],
+    ["a non-array formula list", '{"formulae":{}}'],
+    ["a null formula entry", '{"formulae":[null]}'],
+  ])("rejects valid JSON with %s (#11129)", (_case, stdout) => {
+    const detectService = () =>
+      hasOpenShellGatewayUserService({
+        commandExists: () => true,
+        homebrewFormulaOperation: () => spawnResult(0, "", stdout),
+        platform: "darwin",
+      });
+
+    expect(detectService).toThrow(OpenShellGatewayServiceTrustError);
+    expect(detectService).toThrow("formula identity check returned invalid data");
+  });
+
   it("rejects a Homebrew formula outside the official tap (#6903)", () => {
     const operation = vi.fn((args: string[]) =>
       args[0] === "info" ? officialFormulaInfo({ tap: "other/tap" }) : spawnResult(),

--- a/src/lib/onboard/docker-driver-gateway-service-homebrew.test.ts
+++ b/src/lib/onboard/docker-driver-gateway-service-homebrew.test.ts
@@ -91,7 +91,9 @@ describe("OpenShell Homebrew service boundary", () => {
     ["a Boolean document", "true"],
     ["no formula list", "{}"],
     ["a non-array formula list", '{"formulae":{}}'],
+    ["no requested formula", '{"formulae":[]}'],
     ["a null formula entry", '{"formulae":[null]}'],
+    ["a Boolean formula entry", '{"formulae":[true]}'],
   ])("rejects valid JSON with %s (#11129)", (_case, stdout) => {
     const detectService = () =>
       hasOpenShellGatewayUserService({

--- a/src/lib/onboard/docker-driver-gateway-service-homebrew.test.ts
+++ b/src/lib/onboard/docker-driver-gateway-service-homebrew.test.ts
@@ -88,6 +88,7 @@ function queryHomebrewService(records: HomebrewServiceRecord[]) {
 describe("OpenShell Homebrew service boundary", () => {
   it.each([
     ["a null document", "null"],
+    ["a Boolean document", "true"],
     ["no formula list", "{}"],
     ["a non-array formula list", '{"formulae":{}}'],
     ["a null formula entry", '{"formulae":[null]}'],

--- a/src/lib/onboard/docker-driver-gateway-service.ts
+++ b/src/lib/onboard/docker-driver-gateway-service.ts
@@ -635,7 +635,12 @@ function resolveOfficialHomebrewFormulaPaths(
     const formula = formulae.find(
       (candidate) => candidate.name === OPENSHELL_GATEWAY_HOMEBREW_SERVICE,
     );
-    if (formula?.tap !== OPENSHELL_GATEWAY_HOMEBREW_TAP) {
+    if (!formula) {
+      throw new OpenShellGatewayServiceTrustError(
+        "OpenShell Homebrew formula identity check returned invalid data",
+      );
+    }
+    if (formula.tap !== OPENSHELL_GATEWAY_HOMEBREW_TAP) {
       throw new OpenShellGatewayServiceTrustError(
         `OpenShell Homebrew formula must come from ${OPENSHELL_GATEWAY_HOMEBREW_TAP}`,
       );

--- a/src/lib/onboard/docker-driver-gateway-service.ts
+++ b/src/lib/onboard/docker-driver-gateway-service.ts
@@ -610,15 +610,29 @@ function resolveOfficialHomebrewFormulaPaths(
     throwHomebrewFormulaOperationFailure("formula identity inspection", info);
   }
   try {
-    const parsed = JSON.parse(info.stdout ?? "") as {
-      formulae?: Array<{
-        installed?: unknown[];
-        name?: string;
-        service?: { run?: unknown };
-        tap?: string;
-      }>;
-    };
-    const formula = parsed.formulae?.find(
+    const parsed: unknown = JSON.parse(info.stdout ?? "");
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      Array.isArray(parsed) ||
+      !("formulae" in parsed) ||
+      !Array.isArray(parsed.formulae) ||
+      parsed.formulae.some(
+        (candidate) =>
+          typeof candidate !== "object" || candidate === null || Array.isArray(candidate),
+      )
+    ) {
+      throw new OpenShellGatewayServiceTrustError(
+        "OpenShell Homebrew formula identity check returned invalid data",
+      );
+    }
+    const formulae = parsed.formulae as Array<{
+      installed?: unknown[];
+      name?: string;
+      service?: { run?: unknown };
+      tap?: string;
+    }>;
+    const formula = formulae.find(
       (candidate) => candidate.name === OPENSHELL_GATEWAY_HOMEBREW_SERVICE,
     );
     if (formula?.tap !== OPENSHELL_GATEWAY_HOMEBREW_TAP) {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

NemoClaw now rejects malformed-but-valid Homebrew formula JSON with `OpenShellGatewayServiceTrustError`. Service detection no longer exposes an internal property-access `TypeError` for these inputs.

## Reason

The Homebrew formula resolver parsed trusted JSON but assumed the result was a non-null object with an array of object entries.

### Related issues

Fixes #11129.

## Changes

- Validate the parsed formula document, formula list, and formula entries before reading their fields.
- Preserve the existing formula identity, installation, and service-command checks for valid data.
- Cover seven malformed JSON shapes and require the typed error plus the stable diagnostic.

## Verification

- Focused Homebrew service tests — 26 passed.
- `npm run build:cli && npm run typecheck:cli` — passed.
- `npm run test:titles:check` — passed.
- `npm run validate:pr` — passed.
- Normal pre-commit, commit-message, and pre-push hooks — passed.
- Private Claude and Codex trust-boundary review — passed with no unresolved findings.
- GitHub marks the published commits as Verified; the latest signed commit is `a7a57c91ce8d7dc56f40040a900572047478b72b`.
- The diff contains no secrets, API keys, or credentials.

## Review notes

The broader `npm run test:changed` run passed 4,273 tests and failed nine unrelated host-fixture tests. The failures require Linux `ip`, clean shared `/tmp` gateway fixtures, or compatible host Python and Hermes fixtures. The focused Homebrew suite passes.

Claude found that the first regression table asserted only the error class. The final test also requires the malformed-data diagnostic for every row. Both private reviewers approved the amended commit.

PR Review Advisor found that the table lacked a valid primitive document. The follow-up commit adds a Boolean document, and the focused suite plus both private reviewers pass on the updated head.

The refreshed Advisor found a missing-formula diagnostic gap and missing primitive-entry proof. The final commit routes a missing requested formula through the invalid-data error and adds empty-list and Boolean-entry regression rows.

### Documentation Writer Review

PASS — an independent Codex documentation writer reviewed the committed change. No documentation update is required because existing Homebrew troubleshooting guidance owns this failure class.

<!-- documentation-writer-review-head: a7a57c91ce8d7dc56f40040a900572047478b72b -->
<!-- documentation-writer-review-agents-blob: dd3528f6e332f7f09f4841555c2ed11cb2139fb9 -->

---
<!-- DCO sign-off is required in this PR description. Every commit must appear as Verified in GitHub. -->
Signed-off-by: harjoth <harjoth.khara@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation of Homebrew formula identity responses.
  - Malformed, missing, or structurally invalid formula data now produces a clear trust error instead of being reported as a tap mismatch.
  - Valid formula responses continue to be checked against the expected tap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->