### PR TITLE
fix(inference): allow N1x compaction concurrency

### DIFF
--- a/docs/changelog/2026-09-01.mdx
+++ b/docs/changelog/2026-09-01.mdx
@@ -40,5 +40,7 @@ It also broadens Deferred N1x detection and gives N1x managed vLLM a dedicated s
 - DGX Station Express host preparation now ignores NemoClaw and OpenShell agent processes owned by another user for non-root and `sudo` controllers. It still blocks the controller agent processes and keeps direct-root agent checks, vLLM conflicts, and Docker conflicts host-wide.
   Related change: [PR #10689](https://github.com/NVIDIA/NemoClaw/pull/10689).
 - Deferred N1x preview detection now accepts NVIDIA display-class GPUs without requiring one PCI device ID and recognizes OEM DGX Spark FastOS identity.
-  N1x managed vLLM uses a dedicated Qwen3.6 35B NVFP4 serving profile with a physically exercised memory, context, concurrency, and batching envelope; N1x remains Deferred pending complete Express end-to-end validation.
+  v0.0.118 introduced a dedicated N1x Qwen3.6 35B NVFP4 serving profile with its original memory, context, concurrency, and batching envelope physically exercised.
+  For the current limits and validation status, refer to [Set Up vLLM](/user-guide/openclaw/inference/local-inference/set-up-vllm#use-n1x-express).
+  N1x remains Deferred pending complete Express end-to-end validation.
   Related changes: [PR #10099](https://github.com/NVIDIA/NemoClaw/pull/10099), [PR #10721](https://github.com/NVIDIA/NemoClaw/pull/10721), and [PR #10625](https://github.com/NVIDIA/NemoClaw/pull/10625).

--- a/docs/inference/set-up-vllm.mdx
+++ b/docs/inference/set-up-vllm.mdx
@@ -360,7 +360,8 @@ When you start managed vLLM outside the installer express flow, NemoClaw uses th
 
 For the managed one-host DGX Spark and N1x `nvidia/Qwen3.6-35B-A3B-NVFP4` profiles, NemoClaw enables async scheduling and does not enable multi-token prediction (MTP) speculative decoding.
 The DGX Spark profile retains `--gpu-memory-utilization 0.4`, a `262144`-token context window, `4` concurrent sequences, and an `8192`-token batch limit.
-The Deferred N1x profile uses `--gpu-memory-utilization 0.6`, a `32768`-token context window, `1` concurrent sequence, and a `4096`-token batch limit.
+The Deferred N1x profile uses `--gpu-memory-utilization 0.6`, a `32768`-token context window, `2` concurrent sequences, and a `4096`-token batch limit.
+The two-sequence limit permits vLLM to schedule a compaction summary while an agent response uses the other sequence.
 Both profiles retain chunked prefill, prefix caching, and their registered parsers and acceleration backends.
 
 NVIDIA Nemotron 3.5 Lightning is an additional explicit-only single-DGX Spark profile and does not change the Qwen default.
@@ -459,8 +460,8 @@ A full uninstall removes it only after managed-runtime cleanup succeeds and no s
 On an N1x host that matches the required identity, the Deferred Express preview selects one-host managed vLLM with `nvidia/Qwen3.6-35B-A3B-NVFP4`.
 The installer uses the existing managed-vLLM image, download, container, receipt, recovery, and uninstall lifecycle.
 The installer applies the existing CUDA and Container Device Interface (CDI) readiness checks before it downloads the image or model.
-The N1x serving limits above have reached the ready vLLM endpoint on one physical host.
-That result covers managed-vLLM startup only; the full Express onboarding E2E remains pending.
+The N1x memory, context, and batch limits above have reached the ready vLLM endpoint on one physical host.
+Physical validation of compaction with the two-sequence limit and the full Express onboarding E2E remain pending.
 
 NemoClaw requires all of this N1x identity evidence:
 
@@ -680,7 +681,7 @@ The following override disables async scheduling and lowers the context window, 
 ```bash
 NEMOCLAW_PROVIDER=install-vllm \
   NEMOCLAW_VLLM_MODEL=qwen3.6-35b-a3b-nvfp4 \
-  NEMOCLAW_VLLM_EXTRA_ARGS_JSON='["--no-async-scheduling","--max-model-len","32768","--max-num-seqs","1","--max-num-batched-tokens","4096"]' \
+  NEMOCLAW_VLLM_EXTRA_ARGS_JSON='["--no-async-scheduling","--max-model-len","32768","--max-num-seqs","2","--max-num-batched-tokens","4096"]' \
   $$nemoclaw onboard --non-interactive
 ```
 

--- a/docs/inference/set-up-vllm.mdx
+++ b/docs/inference/set-up-vllm.mdx
@@ -463,6 +463,36 @@ The installer applies the existing CUDA and Container Device Interface (CDI) rea
 The N1x memory, context, and batch limits above have reached the ready vLLM endpoint on one physical host.
 Physical validation of compaction with the two-sequence limit and the full Express onboarding E2E remain pending.
 
+#### Upgrade an Existing N1x Managed vLLM Runtime
+
+An existing `nemoclaw-vllm` container retains its original command after a NemoClaw update or sandbox rebuild.
+A container created by v0.0.119 therefore retains `--max-num-seqs 1` until you replace the managed runtime.
+
+Before replacement, follow [Handle a Running vLLM Server](#handle-a-running-vllm-server) to inspect every gateway environment and confirm that no other sandbox or distributed deployment uses the server.
+Stop only the exact verified managed container ID.
+If another sandbox can use the server, schedule coordinated downtime instead of continuing.
+
+Rebuild the affected sandbox with explicit managed-vLLM intent.
+
+```bash
+NEMOCLAW_PROVIDER=install-vllm \
+  $$nemoclaw my-assistant rebuild --yes
+```
+
+NemoClaw verifies the stopped container ownership, replaces that container with the current N1x recipe, and then continues the transactional sandbox rebuild.
+If managed-vLLM startup fails, the existing sandbox remains registered, but its stopped host inference server can remain unavailable.
+Correct the reported startup problem, then repeat the same rebuild command.
+
+Verify that the replacement container uses the two-sequence limit.
+
+```bash
+docker container inspect \
+  --format '{{json .Config.Cmd}}' \
+  nemoclaw-vllm
+```
+
+Accept the result when the command contains `--max-num-seqs 2`.
+
 NemoClaw requires all of this N1x identity evidence:
 
 - The host runs Linux on `arm64`.

--- a/docs/inference/set-up-vllm.mdx
+++ b/docs/inference/set-up-vllm.mdx
@@ -465,7 +465,7 @@ Physical validation of compaction with the two-sequence limit and the full Expre
 
 #### Upgrade an Existing N1x Managed vLLM Runtime
 
-An existing `nemoclaw-vllm` container retains its original command after a NemoClaw update or sandbox rebuild.
+An existing `nemoclaw-vllm` container retains its original command after a NemoClaw update or ordinary sandbox rebuild.
 A container created by v0.0.119 therefore retains `--max-num-seqs 1` until you replace the managed runtime.
 
 Before replacement, follow [Handle a Running vLLM Server](#handle-a-running-vllm-server) to inspect every gateway environment and confirm that no other sandbox or distributed deployment uses the server.

--- a/docs/inference/set-up-vllm.mdx
+++ b/docs/inference/set-up-vllm.mdx
@@ -466,7 +466,7 @@ Physical validation of compaction with the two-sequence limit and the full Expre
 #### Upgrade an Existing N1x Managed vLLM Runtime
 
 An existing `nemoclaw-vllm` container retains its original command after a NemoClaw update or ordinary sandbox rebuild.
-A container created by v0.0.119 therefore retains `--max-num-seqs 1` until you replace the managed runtime.
+Replace an affected N1x managed container when its command contains `--max-num-seqs 1`.
 
 Before replacement, follow [Handle a Running vLLM Server](#handle-a-running-vllm-server) to inspect every gateway environment and confirm that no other sandbox or distributed deployment uses the server.
 Stop only the exact verified managed container ID.

--- a/managed-inference/recipes/vllm.qwen3-6-35b-a3b-nvfp4.n1x-single.v1.yaml
+++ b/managed-inference/recipes/vllm.qwen3-6-35b-a3b-nvfp4.n1x-single.v1.yaml
@@ -62,7 +62,7 @@ spec:
       - name: --moe-backend
         value: marlin
       - name: --max-num-seqs
-        value: 1
+        value: 2
       - name: --max-num-batched-tokens
         value: 4096
       - name: --enable-chunked-prefill

--- a/src/lib/actions/sandbox/rebuild-flow-target-session.test.ts
+++ b/src/lib/actions/sandbox/rebuild-flow-target-session.test.ts
@@ -14,15 +14,18 @@ describe("rebuildSandbox flow: target session", () => {
   it("isolates ambient onboard-selection env during recreate, then restores it (#5735)", async () => {
     const restoreEnv = snapshotEnv([
       "NEMOCLAW_AGENT",
+      "NEMOCLAW_PROVIDER",
       "NEMOCLAW_PROVIDER_KEY",
       "NVIDIA_INFERENCE_API_KEY",
     ]);
     process.env.NEMOCLAW_AGENT = "langchain-deepagents-code";
+    process.env.NEMOCLAW_PROVIDER = "install-vllm";
     process.env.NEMOCLAW_PROVIDER_KEY = "sk-bogus-installer-key";
     process.env.NVIDIA_INFERENCE_API_KEY = "hosted-source-key";
 
     let envSeenInsideOnboard: {
       agent: string | undefined;
+      provider: string | undefined;
       providerKey: string | undefined;
       hostedSourceKey: string | undefined;
     } | null = null;
@@ -33,6 +36,7 @@ describe("rebuildSandbox flow: target session", () => {
         onboard: () => {
           envSeenInsideOnboard = {
             agent: process.env.NEMOCLAW_AGENT,
+            provider: process.env.NEMOCLAW_PROVIDER,
             providerKey: process.env.NEMOCLAW_PROVIDER_KEY,
             hostedSourceKey: process.env.NVIDIA_INFERENCE_API_KEY,
           };
@@ -45,14 +49,57 @@ describe("rebuildSandbox flow: target session", () => {
 
       expect(envSeenInsideOnboard).toEqual({
         agent: undefined,
+        provider: undefined,
         providerKey: undefined,
         hostedSourceKey: "hosted-source-key",
       });
       const logged = harness.logSpy.mock.calls.map((call) => String(call[0])).join("\n");
       expect(logged).toContain("Ignoring ambient NEMOCLAW_AGENT='langchain-deepagents-code'");
       expect(process.env.NEMOCLAW_AGENT).toBe("langchain-deepagents-code");
+      expect(process.env.NEMOCLAW_PROVIDER).toBe("install-vllm");
       expect(process.env.NEMOCLAW_PROVIDER_KEY).toBe("sk-bogus-installer-key");
       expect(process.env.NVIDIA_INFERENCE_API_KEY).toBe("hosted-source-key");
+    } finally {
+      restoreEnv();
+    }
+  });
+
+  it("carries only qualified N1x managed-vLLM replacement intent into recreate (#10955)", async () => {
+    const restoreEnv = snapshotEnv(["NEMOCLAW_PROVIDER"]);
+    process.env.NEMOCLAW_PROVIDER = "install-vllm";
+    let seen: { provider: string | undefined; replacement: boolean } | null = null;
+
+    try {
+      const harness = createRebuildFlowHarness({
+        applyPreset: () => true,
+        sandboxEntry: {
+          provider: "vllm-local",
+          model: "nvidia/Qwen3.6-35B-A3B-NVFP4",
+          endpointUrl: null,
+          endpointSource: null,
+          openshellDriver: "docker",
+          hostLocalInferenceReceipt: null,
+          nimContainer: null,
+        },
+        onboard: (_session, options) => {
+          seen = {
+            provider: process.env.NEMOCLAW_PROVIDER,
+            replacement: options.reinstallDeferredN1xManagedVllm === true,
+          };
+        },
+      });
+      harness.session.provider = "vllm-local";
+      harness.session.model = "nvidia/Qwen3.6-35B-A3B-NVFP4";
+      harness.session.endpointUrl = null;
+      harness.session.credentialEnv = null;
+      harness.session.preferredInferenceApi = "openai-completions";
+
+      await expect(
+        harness.rebuildSandbox("alpha", ["--yes"], { throwOnError: true }),
+      ).resolves.toBeUndefined();
+
+      expect(seen).toEqual({ provider: "install-vllm", replacement: true });
+      expect(process.env.NEMOCLAW_PROVIDER).toBe("install-vllm");
     } finally {
       restoreEnv();
     }

--- a/src/lib/actions/sandbox/rebuild-gpu-opt-out.ts
+++ b/src/lib/actions/sandbox/rebuild-gpu-opt-out.ts
@@ -132,6 +132,8 @@ export type RebuildRecreateOnboardOpts = {
   providerRecoveryReceipt?: ProviderRecoveryReceipt;
   /** Recorded provider intent admitted only by the N1x readiness exception. */
   allowDeferredN1xManagedVllm?: true;
+  /** Explicit request to replace an eligible Deferred N1x managed-vLLM runtime. */
+  reinstallDeferredN1xManagedVllm?: true;
   /** Target-scoped authority admitted by the authoritative rebuild preflight. */
   rebuildGatewayAuthority?: CheckpointGatewayAuthority;
   preparedImageRebuild?: PreparedImageRebuildHandoff;

--- a/src/lib/actions/sandbox/rebuild-preflight-target-phase-orchestration.test.ts
+++ b/src/lib/actions/sandbox/rebuild-preflight-target-phase-orchestration.test.ts
@@ -239,7 +239,10 @@ describe("prepareRebuildTargetPreflights", () => {
     const readinessOptions = await prepareN1xTarget(null, null, undefined, undefined, null, false);
 
     expect(readinessOptions).toEqual(
-      expect.objectContaining({ allowDeferredN1xManagedVllm: true }),
+      expect.objectContaining({
+        allowDeferredN1xManagedVllm: true,
+        reinstallDeferredN1xManagedVllm: true,
+      }),
     );
   });
 

--- a/src/lib/actions/sandbox/rebuild-preflight-target-phase.ts
+++ b/src/lib/actions/sandbox/rebuild-preflight-target-phase.ts
@@ -270,11 +270,7 @@ export async function prepareRebuildTargetPreflights(args: {
   recreateOptions.observabilityRequestedExplicitly = requestedObservabilityEnabled !== undefined;
   stageRecordedDeferredN1xIntent(recreateOptions, sandboxEntry, resumeConfig);
   if (
-    !hasValidDeferredN1xManagedVllmReplacementAuthority(
-      recreateOptions,
-      sandboxEntry,
-      resumeConfig,
-    )
+    !hasValidDeferredN1xManagedVllmReplacementAuthority(recreateOptions, sandboxEntry, resumeConfig)
   ) {
     return bail("Deferred N1x managed-vLLM replacement authority is invalid.");
   }

--- a/src/lib/actions/sandbox/rebuild-preflight-target-phase.ts
+++ b/src/lib/actions/sandbox/rebuild-preflight-target-phase.ts
@@ -55,6 +55,7 @@ import {
 } from "./rebuild-preflight-guards";
 import { disposePreparedBuildContext } from "./rebuild-prepared-image-context";
 import {
+  hasValidDeferredN1xManagedVllmReplacementAuthority,
   hydrateMessagingConfigForRebuild,
   preflightAuthoritativeOnboardRuntime,
   preflightRebuildTargetRuntime,
@@ -268,6 +269,15 @@ export async function prepareRebuildTargetPreflights(args: {
     requestedObservabilityEnabled ?? recreateOptions.observabilityEnabled;
   recreateOptions.observabilityRequestedExplicitly = requestedObservabilityEnabled !== undefined;
   stageRecordedDeferredN1xIntent(recreateOptions, sandboxEntry, resumeConfig);
+  if (
+    !hasValidDeferredN1xManagedVllmReplacementAuthority(
+      recreateOptions,
+      sandboxEntry,
+      resumeConfig,
+    )
+  ) {
+    return bail("Deferred N1x managed-vLLM replacement authority is invalid.");
+  }
   if (
     !stageRebuildHermesDashboardConfig(
       rebuildAgent,

--- a/src/lib/actions/sandbox/rebuild-recreate-journal.test.ts
+++ b/src/lib/actions/sandbox/rebuild-recreate-journal.test.ts
@@ -140,6 +140,7 @@ describe("rebuild replacement target fingerprint", () => {
     { recreateProvider: "compatible-endpoint" },
     { recreateModel: "model-b" },
     { recreatePreferredInferenceApi: "anthropic" },
+    { reinstallDeferredN1xManagedVllm: true },
   ] as const)("changes when a recorded replacement input changes [case %#]", (drift) => {
     expect(fingerprintRebuildRecreateTargetIntent({ ...recreateOptions, ...drift })).not.toBe(
       fingerprintRebuildRecreateTargetIntent(recreateOptions),

--- a/src/lib/actions/sandbox/rebuild-recreate-journal.ts
+++ b/src/lib/actions/sandbox/rebuild-recreate-journal.ts
@@ -558,6 +558,7 @@ export function fingerprintRebuildRecreateTargetIntent(
     | "toolDisclosure"
     | "dcodeAutoApprovalMode"
     | "observabilityEnabled"
+    | "reinstallDeferredN1xManagedVllm"
   >,
 ): string {
   const hostMounts = (options.hostMounts ?? []).map(
@@ -590,6 +591,9 @@ export function fingerprintRebuildRecreateTargetIntent(
     toolDisclosure: options.toolDisclosure,
     dcodeAutoApprovalMode: options.dcodeAutoApprovalMode,
     observabilityEnabled: options.observabilityEnabled,
+    ...(options.reinstallDeferredN1xManagedVllm === true
+      ? { reinstallDeferredN1xManagedVllm: true }
+      : {}),
   });
 }
 

--- a/src/lib/actions/sandbox/rebuild-recreate-phase.ts
+++ b/src/lib/actions/sandbox/rebuild-recreate-phase.ts
@@ -4,6 +4,7 @@
 import { CLI_NAME } from "../../cli/branding";
 import { RD as _RD, R } from "../../cli/terminal-style";
 import { normalizeProcessExitCode } from "../../core/process-exit";
+import { isN1xManagedVllmProviderModel } from "../../domain/sandbox/n1x-managed-vllm-rebuild";
 import { MessagingSetupApplier, type SandboxMessagingPlan } from "../../messaging";
 import { markLastStartedStepFailed } from "../../onboard/exit-step-failure";
 import { gatewayOwnerFromCheckpoint } from "../../onboard/gateway-authority-checkpoint";
@@ -241,6 +242,18 @@ export async function runRebuildRecreatePhase(input: RebuildRecreatePhaseInput):
   let onboardFailed = false;
   let onboardExitCode = 1;
   const restoreAmbientRecreateEnv = isolateAmbientRecreateEnv();
+  if (recreateOptions.reinstallDeferredN1xManagedVllm === true) {
+    if (
+      recreateOptions.allowDeferredN1xManagedVllm !== true ||
+      !isN1xManagedVllmProviderModel(resumeConfig.provider, resumeConfig.model) ||
+      sb.openshellDriver !== "docker" ||
+      Boolean(sb.nimContainer)
+    ) {
+      restoreAmbientRecreateEnv();
+      return bail("Deferred N1x managed-vLLM replacement authority is invalid.");
+    }
+    process.env.NEMOCLAW_PROVIDER = "install-vllm";
+  }
   const previousSandboxName = process.env.NEMOCLAW_SANDBOX_NAME;
   const previousRecreateWithoutBackup = process.env.NEMOCLAW_RECREATE_WITHOUT_BACKUP;
   const previousRestoreLatestBackup = process.env.NEMOCLAW_RESTORE_LATEST_BACKUP_ON_RECREATE;

--- a/src/lib/actions/sandbox/rebuild-recreate-phase.ts
+++ b/src/lib/actions/sandbox/rebuild-recreate-phase.ts
@@ -4,6 +4,7 @@
 import { CLI_NAME } from "../../cli/branding";
 import { RD as _RD, R } from "../../cli/terminal-style";
 import { normalizeProcessExitCode } from "../../core/process-exit";
+import { hasValidDeferredN1xManagedVllmReplacementAuthority } from "../../domain/sandbox/n1x-managed-vllm-rebuild";
 import { MessagingSetupApplier, type SandboxMessagingPlan } from "../../messaging";
 import { markLastStartedStepFailed } from "../../onboard/exit-step-failure";
 import { gatewayOwnerFromCheckpoint } from "../../onboard/gateway-authority-checkpoint";
@@ -38,7 +39,6 @@ import { rebuildOnboardDependencies } from "./rebuild-onboard-dependencies";
 import type { RebuildRecreateJournal } from "./rebuild-recreate-journal";
 import type { RebuildRegistryRollback } from "./rebuild-registry-rollback";
 import type { RebuildResumeConfig } from "./rebuild-resume-config";
-import { hasValidDeferredN1xManagedVllmReplacementAuthority } from "./rebuild-target-staging";
 
 export interface RebuildRecreatePhaseInput {
   sandboxName: string;

--- a/src/lib/actions/sandbox/rebuild-recreate-phase.ts
+++ b/src/lib/actions/sandbox/rebuild-recreate-phase.ts
@@ -4,7 +4,6 @@
 import { CLI_NAME } from "../../cli/branding";
 import { RD as _RD, R } from "../../cli/terminal-style";
 import { normalizeProcessExitCode } from "../../core/process-exit";
-import { isN1xManagedVllmProviderModel } from "../../domain/sandbox/n1x-managed-vllm-rebuild";
 import { MessagingSetupApplier, type SandboxMessagingPlan } from "../../messaging";
 import { markLastStartedStepFailed } from "../../onboard/exit-step-failure";
 import { gatewayOwnerFromCheckpoint } from "../../onboard/gateway-authority-checkpoint";
@@ -39,6 +38,7 @@ import { rebuildOnboardDependencies } from "./rebuild-onboard-dependencies";
 import type { RebuildRecreateJournal } from "./rebuild-recreate-journal";
 import type { RebuildRegistryRollback } from "./rebuild-registry-rollback";
 import type { RebuildResumeConfig } from "./rebuild-resume-config";
+import { hasValidDeferredN1xManagedVllmReplacementAuthority } from "./rebuild-target-staging";
 
 export interface RebuildRecreatePhaseInput {
   sandboxName: string;
@@ -242,16 +242,12 @@ export async function runRebuildRecreatePhase(input: RebuildRecreatePhaseInput):
   let onboardFailed = false;
   let onboardExitCode = 1;
   const restoreAmbientRecreateEnv = isolateAmbientRecreateEnv();
-  if (recreateOptions.reinstallDeferredN1xManagedVllm === true) {
-    if (
-      recreateOptions.allowDeferredN1xManagedVllm !== true ||
-      !isN1xManagedVllmProviderModel(resumeConfig.provider, resumeConfig.model) ||
-      sb.openshellDriver !== "docker" ||
-      Boolean(sb.nimContainer)
-    ) {
-      restoreAmbientRecreateEnv();
-      return bail("Deferred N1x managed-vLLM replacement authority is invalid.");
-    }
+  const replacementAuthorityValid = hasValidDeferredN1xManagedVllmReplacementAuthority(
+    recreateOptions,
+    sb,
+    resumeConfig,
+  );
+  if (replacementAuthorityValid && recreateOptions.reinstallDeferredN1xManagedVllm === true) {
     process.env.NEMOCLAW_PROVIDER = "install-vllm";
   }
   const previousSandboxName = process.env.NEMOCLAW_SANDBOX_NAME;
@@ -284,6 +280,9 @@ export async function runRebuildRecreatePhase(input: RebuildRecreatePhaseInput):
   const savedExitCode = process.exitCode;
   process.exitCode = undefined;
   try {
+    if (!replacementAuthorityValid) {
+      throw new Error("Deferred N1x managed-vLLM replacement authority is invalid.");
+    }
     await rebuildOnboardDependencies.onboard({
       ...recreateOptions,
       ...(recreateJournal.runtimeSelection

--- a/src/lib/actions/sandbox/rebuild-target-preflight.ts
+++ b/src/lib/actions/sandbox/rebuild-target-preflight.ts
@@ -13,6 +13,7 @@ export {
   preflightRebuildTargetRuntime,
 } from "./rebuild-target-runtime";
 export {
+  hasValidDeferredN1xManagedVllmReplacementAuthority,
   hydrateMessagingConfigForRebuild,
   prepareRebuildRecreateOptions,
   stageRebuildHermesDashboardConfig,

--- a/src/lib/actions/sandbox/rebuild-target-preflight.ts
+++ b/src/lib/actions/sandbox/rebuild-target-preflight.ts
@@ -7,13 +7,13 @@
  * staging remain independently reviewable.
  */
 export { printRebuildPreflightFailure } from "./rebuild-preflight-error";
+export { hasValidDeferredN1xManagedVllmReplacementAuthority } from "../../domain/sandbox/n1x-managed-vllm-rebuild";
 export { prepareRebuildTargetConfig, type RebuildTargetConfig } from "./rebuild-target-config";
 export {
   preflightAuthoritativeOnboardRuntime,
   preflightRebuildTargetRuntime,
 } from "./rebuild-target-runtime";
 export {
-  hasValidDeferredN1xManagedVllmReplacementAuthority,
   hydrateMessagingConfigForRebuild,
   prepareRebuildRecreateOptions,
   stageRebuildHermesDashboardConfig,

--- a/src/lib/actions/sandbox/rebuild-target-staging.ts
+++ b/src/lib/actions/sandbox/rebuild-target-staging.ts
@@ -100,7 +100,10 @@ export function stageRebuildHermesDashboardConfig(
 
 /** Stage a validated recorded N1x provider decision for authoritative rebuild readiness. */
 export function stageRecordedDeferredN1xIntent(
-  recreateOptions: Pick<RebuildRecreateOnboardOpts, "allowDeferredN1xManagedVllm">,
+  recreateOptions: Pick<
+    RebuildRecreateOnboardOpts,
+    "allowDeferredN1xManagedVllm" | "reinstallDeferredN1xManagedVllm"
+  >,
   sandboxEntry: Pick<
     RebuildSandboxEntry,
     | "provider"
@@ -120,6 +123,8 @@ export function stageRecordedDeferredN1xIntent(
   },
   env: Readonly<Record<string, string | undefined>> = process.env,
 ): void {
+  const explicitPreviewIntent =
+    String(env.NEMOCLAW_PROVIDER ?? "").trim() === "install-vllm";
   const selectionMatchesRecord =
     rebuildSelection.provider === sandboxEntry.provider &&
     rebuildSelection.model === sandboxEntry.model;
@@ -144,12 +149,14 @@ export function stageRecordedDeferredN1xIntent(
       rebuildSelection,
       parseHostLocalInferenceReceipt,
       {
-        explicitPreviewIntent:
-          String(env.NEMOCLAW_PROVIDER ?? "").trim() === "install-vllm",
+        explicitPreviewIntent,
       },
     );
   if (recordedStandardProviderIsEligible || recordedManagedVllmIsEligible) {
     recreateOptions.allowDeferredN1xManagedVllm = true;
+  }
+  if (recordedManagedVllmIsEligible && explicitPreviewIntent) {
+    recreateOptions.reinstallDeferredN1xManagedVllm = true;
   }
 }
 

--- a/src/lib/actions/sandbox/rebuild-target-staging.ts
+++ b/src/lib/actions/sandbox/rebuild-target-staging.ts
@@ -160,6 +160,24 @@ export function stageRecordedDeferredN1xIntent(
   }
 }
 
+/** Recheck the staged N1x replacement authority before destructive boundaries. */
+export function hasValidDeferredN1xManagedVllmReplacementAuthority(
+  recreateOptions: Pick<
+    RebuildRecreateOnboardOpts,
+    "allowDeferredN1xManagedVllm" | "reinstallDeferredN1xManagedVllm"
+  >,
+  sandboxEntry: Pick<RebuildSandboxEntry, "openshellDriver" | "nimContainer">,
+  rebuildSelection: { provider: string; model: string },
+): boolean {
+  return (
+    recreateOptions.reinstallDeferredN1xManagedVllm !== true ||
+    (recreateOptions.allowDeferredN1xManagedVllm === true &&
+      isN1xManagedVllmProviderModel(rebuildSelection.provider, rebuildSelection.model) &&
+      sandboxEntry.openshellDriver === "docker" &&
+      !sandboxEntry.nimContainer)
+  );
+}
+
 export function hydrateMessagingConfigForRebuild(
   sandboxName: string,
   log: (msg: string) => void,

--- a/src/lib/actions/sandbox/rebuild-target-staging.ts
+++ b/src/lib/actions/sandbox/rebuild-target-staging.ts
@@ -123,8 +123,7 @@ export function stageRecordedDeferredN1xIntent(
   },
   env: Readonly<Record<string, string | undefined>> = process.env,
 ): void {
-  const explicitPreviewIntent =
-    String(env.NEMOCLAW_PROVIDER ?? "").trim() === "install-vllm";
+  const explicitPreviewIntent = String(env.NEMOCLAW_PROVIDER ?? "").trim() === "install-vllm";
   const selectionMatchesRecord =
     rebuildSelection.provider === sandboxEntry.provider &&
     rebuildSelection.model === sandboxEntry.model;
@@ -158,24 +157,6 @@ export function stageRecordedDeferredN1xIntent(
   if (recordedManagedVllmIsEligible && explicitPreviewIntent) {
     recreateOptions.reinstallDeferredN1xManagedVllm = true;
   }
-}
-
-/** Recheck the staged N1x replacement authority before destructive boundaries. */
-export function hasValidDeferredN1xManagedVllmReplacementAuthority(
-  recreateOptions: Pick<
-    RebuildRecreateOnboardOpts,
-    "allowDeferredN1xManagedVllm" | "reinstallDeferredN1xManagedVllm"
-  >,
-  sandboxEntry: Pick<RebuildSandboxEntry, "openshellDriver" | "nimContainer">,
-  rebuildSelection: { provider: string; model: string },
-): boolean {
-  return (
-    recreateOptions.reinstallDeferredN1xManagedVllm !== true ||
-    (recreateOptions.allowDeferredN1xManagedVllm === true &&
-      isN1xManagedVllmProviderModel(rebuildSelection.provider, rebuildSelection.model) &&
-      sandboxEntry.openshellDriver === "docker" &&
-      !sandboxEntry.nimContainer)
-  );
 }
 
 export function hydrateMessagingConfigForRebuild(

--- a/src/lib/domain/sandbox/n1x-managed-vllm-rebuild.ts
+++ b/src/lib/domain/sandbox/n1x-managed-vllm-rebuild.ts
@@ -14,6 +14,24 @@ export function isN1xManagedVllmProviderModel(
   return provider === N1X_EXPRESS_PROVIDER && model === N1X_EXPRESS_MODEL;
 }
 
+/** Recheck the staged N1x replacement authority before destructive boundaries. */
+export function hasValidDeferredN1xManagedVllmReplacementAuthority(
+  recreateOptions: {
+    allowDeferredN1xManagedVllm?: boolean;
+    reinstallDeferredN1xManagedVllm?: boolean;
+  },
+  sandboxEntry: { openshellDriver?: string | null; nimContainer?: unknown },
+  rebuildSelection: { provider: string; model: string },
+): boolean {
+  return (
+    recreateOptions.reinstallDeferredN1xManagedVllm !== true ||
+    (recreateOptions.allowDeferredN1xManagedVllm === true &&
+      isN1xManagedVllmProviderModel(rebuildSelection.provider, rebuildSelection.model) &&
+      sandboxEntry.openshellDriver === "docker" &&
+      !sandboxEntry.nimContainer)
+  );
+}
+
 export interface DeferredN1xManagedVllmAcceptanceRoute {
   provider?: string | null;
   model?: string | null;

--- a/src/lib/inference/vllm-models.test.ts
+++ b/src/lib/inference/vllm-models.test.ts
@@ -589,7 +589,7 @@ describe("vllm model registry", () => {
     expect(qwen35b!.gated).toBe(false);
   });
 
-  it("permits reply and compaction concurrency within the N1x serving envelope (#10955)", () => {
+  it("configures two sequences within the N1x serving envelope (#10955)", () => {
     const qwen35b = VLLM_MODELS.find((model) => model.envValue === "qwen3.6-35b-a3b-nvfp4");
     const n1xProfile = detectVllmProfile({ platform: "n1x", type: "nvidia" })!;
     const n1xModel = resolveVllmModelRuntime(n1xProfile, qwen35b!, "arm64").model;

--- a/src/lib/inference/vllm-models.test.ts
+++ b/src/lib/inference/vllm-models.test.ts
@@ -589,7 +589,7 @@ describe("vllm model registry", () => {
     expect(qwen35b!.gated).toBe(false);
   });
 
-  it("uses the physically exercised N1x serving envelope (#10552)", () => {
+  it("permits reply and compaction concurrency within the N1x serving envelope (#10955)", () => {
     const qwen35b = VLLM_MODELS.find((model) => model.envValue === "qwen3.6-35b-a3b-nvfp4");
     const n1xProfile = detectVllmProfile({ platform: "n1x", type: "nvidia" })!;
     const n1xModel = resolveVllmModelRuntime(n1xProfile, qwen35b!, "arm64").model;
@@ -597,7 +597,7 @@ describe("vllm model registry", () => {
 
     expect(command).toContain("--gpu-memory-utilization 0.6");
     expect(command).toContain("--max-model-len 32768");
-    expect(command).toContain("--max-num-seqs 1");
+    expect(command).toContain("--max-num-seqs 2");
     expect(command).toContain("--max-num-batched-tokens 4096");
     expect(command).not.toContain("--gpu-memory-utilization 0.4");
     expect(command).not.toContain("--max-model-len 262144");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

The Deferred N1x managed-vLLM recipe now permits two sequences per scheduler iteration, so a compaction summary can make progress while an agent response occupies the other sequence.
The fixed GPU-memory utilization, context window, token-batch limit, image, parsers, and every non-N1x recipe remain unchanged.

## Reason

The N1x recipe currently sets `--max-num-seqs 1`.
An active response therefore occupies the only schedulable sequence, and OpenClaw's concurrent compaction request waits until its 120-second safeguard timeout.
This leaves automatic and manual compaction unusable after several turns.

### Related issues

Fixes #10955

## Changes

- Change only the N1x Qwen3.6 managed-vLLM recipe from `--max-num-seqs 1` to `2`.
- Retain the existing `0.6` GPU-memory utilization, 32,768-token context window, and 4,096-token batch limit.
- Update the existing recipe-consumer test and N1x serving documentation without adding another test layer.
- Preserve the v0.0.118 changelog as a historical statement and direct readers to the current N1x limits and validation status.
- Document the ownership-checked replacement procedure that moves an affected existing managed container to the current recipe.
- Carry an explicit replacement decision through rebuild environment isolation only after the existing N1x route eligibility check accepts `install-vllm`.
- Bind that decision to the rebuild target fingerprint and recheck the provider, model, Docker driver, and NIM exclusion before inner onboarding.
- Validate replacement authority before deletion and route any defense-in-depth mismatch through the existing rebuild recovery path.

## Verification

- Pre-fix `npx vitest run --project cli src/lib/inference/vllm-models.test.ts` — failed the new N1x expectation with `--max-num-seqs 1`; the other 130 tests passed.
- `npm run catalog:check` — passed.
- `npx vitest run --project cli src/lib/inference/vllm*.test.ts` — 24 files and 635 tests passed.
- `npx vitest run --project cli src/lib/inference/vllm-models.test.ts src/lib/inference/serving/resolver.test.ts` — 191 tests passed.
- `npx vitest run --project integration test/inference/managed/managed-inference-catalog-compiler.test.ts` — 19 tests passed.
- `npx vitest run --project package-contract test/package-contract/managed-inference-catalog.test.ts` — 2 tests passed.
- `npx vitest run --project cli src/lib/inference/vllm-models.test.ts src/lib/inference/vllm-serving-port.test.ts src/lib/inference/vllm.test.ts src/lib/onboard/setup-nim-flow-vllm-resume.test.ts` — 4 files and 222 tests passed.
- `npx vitest run --project cli src/lib/actions/sandbox/rebuild-preflight-target-phase-orchestration.test.ts src/lib/actions/sandbox/rebuild-flow-target-session.test.ts src/lib/actions/sandbox/rebuild-recreate-journal.test.ts src/lib/actions/sandbox/rebuild-env-isolation.test.ts` — 4 files and 95 tests passed.
- `npx vitest run --project cli src/lib/actions/sandbox/rebuild-target-staging.test.ts src/lib/actions/sandbox/rebuild-target-runtime.test.ts src/lib/onboard/authoritative-rebuild-target.test.ts` — 3 files and 42 tests passed.
- `npm run build:cli` — passed.
- `npm run typecheck:cli` — passed.
- `npm run lint -- --no-fix` — passed.
- `npm run docs` — passed with zero errors and five existing warnings.
- `npm run test-size:check` — 45 tests passed.
- `npm run validate:pr` — passed against canonical `main` at `0fa5e247a1`.
- The diff contains no secrets, API keys, or credentials.

## Review notes

This changes a Deferred N1x serving recipe.
Before merge, physical N1x validation must exercise the latest PR commit with a long agent response plus automatic and manual compaction.
The run must show successful compaction, a healthy vLLM endpoint, no out-of-memory or NVIDIA kernel errors, and stable agent responses under the two-sequence limit.
No physical N1x run was available during local implementation.
The first advisor cycle found that the v0.0.118 changelog described the old concurrency envelope in the present tense.
Commit `ec64c016dd` corrected that claim without changing runtime behavior.
The second advisor cycle found that existing containers retain their original Docker command and that the test title overstated deterministic evidence.
Commit `13aa4eb61b` documents the existing ownership-checked replacement path for v0.0.119 users and narrows the test title to command configuration.
The third advisor cycle found that rebuild environment isolation removed the documented `install-vllm` input before inner onboarding.
Commit `528e8a3f25` adds a constrained, fingerprinted replacement handoff for an eligible N1x route while preserving ambient provider isolation for every other rebuild.
CodeRabbit then identified that the recreate-boundary defense check returned directly after deletion.
Commit `9c5ceafc8b` applies the shared predicate before deletion and routes a later mismatch through the existing registry, session, backup, and retry recovery path.
The remaining CodeRabbit requests to duplicate the existing negative matrix through the public harness and persist one-time replacement authority were declined because they add no distinct evidence and would weaken explicit operator intent.
The final operability advisor noted that the replacement wording named only v0.0.119 even though the original one-sequence recipe also shipped in v0.0.118.
Commit `e6b90270e1` makes the procedure version-neutral and keyed to the observable `--max-num-seqs 1` command.
The final verification advisor proposed proving replacement from an owned, running legacy container, but that state is intentionally rejected by the existing port-conflict guard; the documented procedure requires stopping the exact verified managed container first.
For that supported stopped-container path, existing owner tests already prove `install-vllm` dispatch, inspected-ID-only managed-container replacement, fail-closed foreign or ambiguous ownership, and the N1x `--max-num-seqs 2` launch command.
The rebuild flow test adds only the previously missing qualified intent handoff into that established path; duplicating all downstream owners in its harness would add mocked integration breadth without physical N1x evidence.
CodeRabbit then identified that the pure replacement-authority predicate belonged in the existing N1x domain module rather than the action layer.
Commit `9bee79bca1` moves that decision owner without changing behavior or adding tests; the existing preflight facade preserves the action dependency budget.

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - N1x managed vLLM serving now supports two concurrent sequences for the Qwen3.6 35B NVFP4 profile.
  - Sandbox rebuilds can explicitly replace eligible deferred managed-vLLM runtimes when requested.

- **Bug Fixes**
  - Added validation to prevent managed-vLLM replacement when the selected sandbox, provider, model, or container state is not eligible.

- **Documentation**
  - Updated setup guidance with upgrade steps, validation status, rebuild instructions, and two-sequence configuration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->