### PR TITLE
fix(sandbox): wipe POLICY.md on destroy like USER.md and SOUL.md (#10951)

### DIFF
--- a/src/lib/actions/sandbox/wipe-state.ts
+++ b/src/lib/actions/sandbox/wipe-state.ts
@@ -7,6 +7,7 @@ import { R, YW } from "../../cli/terminal-style";
 import { shellQuote } from "../../core/shell-quote";
 import * as registry from "../../state/registry";
 import { SANDBOX_DESTROY_TIMEOUT_MS } from "./destroy-gateway";
+import { POLICY_CONTEXT_SANDBOX_PATH } from "./policy-explain";
 
 type RunOpenshellResult = { error?: Error; status: number | null };
 type RunOpenshell = (args: string[], opts?: Record<string, unknown>) => RunOpenshellResult;
@@ -183,12 +184,22 @@ export function wipeSandboxState(sandboxName: string, deps: WipeSandboxStateDeps
     .map((file) => validateManifestPath(file.path))
     .filter((p): p is string => p !== null);
 
+  // POLICY_CONTEXT_SANDBOX_PATH is a NemoClaw-owned artifact written to a
+  // fixed absolute path, not a manifest-declared state target. It only gets
+  // wiped today as a side effect of "workspace" happening to be declared as
+  // a state_dir for the same path prefix (#10951) -- add it explicitly so
+  // its removal is guaranteed rather than incidental to that declaration.
+  const policyContextRelativePath = POLICY_CONTEXT_SANDBOX_PATH.startsWith(`${resolvedDir}/`)
+    ? POLICY_CONTEXT_SANDBOX_PATH.slice(resolvedDir.length + 1)
+    : null;
+
   const targets = [
     ...validStateDirs.map(shellQuote),
     ...validStateFiles.map(shellQuote),
     // Quote the manifest-derived prefix and leave only the appended wildcard
     // unquoted. A no-match leaves the literal token, which `rm -rf` ignores.
     ...validStateDirPrefixes.map((prefix) => `${shellQuote(prefix)}*`),
+    ...(policyContextRelativePath ? [shellQuote(policyContextRelativePath)] : []),
   ];
 
   // cd into the config dir first so relative names and globs resolve there;

--- a/src/lib/onboard/policy-selection.ts
+++ b/src/lib/onboard/policy-selection.ts
@@ -339,7 +339,9 @@ export async function setupPoliciesWithSelection(
   const chosen = await withPolicyApplicationTrace(sandboxName, options, () =>
     setupPoliciesWithSelectionInner(deps, sandboxName, options),
   );
-  seedInitialPolicyContext(sandboxName);
+  if ((deps.env ?? process.env).NEMOCLAW_MINIMAL_BOOTSTRAP !== "1") {
+    seedInitialPolicyContext(sandboxName);
+  }
   return chosen;
 }
 

--- a/test/onboarding/onboard-policy-application-wiring.test.ts
+++ b/test/onboarding/onboard-policy-application-wiring.test.ts
@@ -6,6 +6,7 @@ import assert from "node:assert/strict";
 import { createRequire } from "node:module";
 import { describe, expect, it, vi } from "vitest";
 import type { OnboardPolicyApplicationDeps } from "../../src/lib/onboard/policy-selection.js";
+import { restoreEnv } from "../helpers/env-test-helpers";
 
 const require = createRequire(import.meta.url);
 
@@ -164,11 +165,7 @@ describe("onboarding policy application production wiring", () => {
         "lock released",
       ]);
     } finally {
-      if (priorMinimalBootstrap === undefined) {
-        delete process.env.NEMOCLAW_MINIMAL_BOOTSTRAP;
-      } else {
-        process.env.NEMOCLAW_MINIMAL_BOOTSTRAP = priorMinimalBootstrap;
-      }
+      restoreEnv("NEMOCLAW_MINIMAL_BOOTSTRAP", priorMinimalBootstrap);
       restoreRequireCache(priorCache);
     }
   });

--- a/test/onboarding/onboard-policy-application-wiring.test.ts
+++ b/test/onboarding/onboard-policy-application-wiring.test.ts
@@ -27,7 +27,7 @@ function restoreRequireCache(prior: Map<string, NodeModule>): void {
 }
 
 describe("onboarding policy application production wiring", () => {
-  it("wires resume policy application to live policy, readiness checks, and sandbox mutation lock (#7695)", async () => {
+  it("wires policy application and keeps minimal-bootstrap re-onboard free of POLICY.md (#7695, #10951)", async () => {
     const priorCache = new Map(
       Object.entries(require.cache).filter(
         (entry): entry is [string, NodeModule] => entry[1] !== undefined,
@@ -61,6 +61,7 @@ describe("onboarding policy application production wiring", () => {
     const seedInitialPolicyContext = vi.fn(() => events.push("policy context seeded"));
     let capturedDeps: OnboardPolicyApplicationDeps | undefined;
     let application: PolicyApplication | undefined;
+    const priorMinimalBootstrap = process.env.NEMOCLAW_MINIMAL_BOOTSTRAP;
 
     const onboardPath = require.resolve("../../src/lib/onboard.js");
     const policyPath = require.resolve("../../src/lib/policy/index.js");
@@ -147,7 +148,27 @@ describe("onboarding policy application production wiring", () => {
         "policy context seeded",
         "lock released",
       ]);
+
+      events.length = 0;
+      process.env.NEMOCLAW_MINIMAL_BOOTSTRAP = "1";
+
+      await expect(
+        application.setupPoliciesWithSelection("alpha", { selectedPresets: ["npm"] }),
+      ).resolves.toEqual(["npm"]);
+      expect(events).toEqual([
+        "lock entered",
+        "sandbox ready",
+        "policies synchronized",
+        "sandbox ready",
+        "control plane ready",
+        "lock released",
+      ]);
     } finally {
+      if (priorMinimalBootstrap === undefined) {
+        delete process.env.NEMOCLAW_MINIMAL_BOOTSTRAP;
+      } else {
+        process.env.NEMOCLAW_MINIMAL_BOOTSTRAP = priorMinimalBootstrap;
+      }
       restoreRequireCache(priorCache);
     }
   });

--- a/test/runtime/sandbox/destroy-wipe-sandbox-state.test.ts
+++ b/test/runtime/sandbox/destroy-wipe-sandbox-state.test.ts
@@ -327,7 +327,7 @@ describe("wipeSandboxState (#5449)", () => {
   // clean state. Skips on Windows because the `cd ... && rm -rf` script
   // is POSIX-shell-only.
   it.skipIf(process.platform === "win32")(
-    "deletes USER.md and SOUL.md when the constructed script executes for PRA-1 and PRA-2 (#5455)",
+    "deletes USER.md, SOUL.md, and POLICY.md when the constructed script executes (#5455, #10951)",
     () => {
       const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-wipe-behavioral-"));
       try {
@@ -338,6 +338,7 @@ describe("wipeSandboxState (#5449)", () => {
         fs.mkdirSync(fakeWorkspace, { recursive: true });
         fs.writeFileSync(path.join(fakeWorkspace, "USER.md"), "user notes from prior session");
         fs.writeFileSync(path.join(fakeWorkspace, "SOUL.md"), "soul state from prior session");
+        fs.writeFileSync(path.join(fakeWorkspace, "POLICY.md"), "policy state from prior session");
         // Also seed a multi-agent workspace dir to confirm the glob works.
         const fakeMultiAgentWorkspace = path.join(fakeConfigDir, "workspace-other-agent");
         fs.mkdirSync(fakeMultiAgentWorkspace);
@@ -401,6 +402,7 @@ describe("wipeSandboxState (#5449)", () => {
         // The destroy/re-onboard contract: prior workspace state is gone.
         expect(fs.existsSync(path.join(fakeWorkspace, "USER.md"))).toBe(false);
         expect(fs.existsSync(path.join(fakeWorkspace, "SOUL.md"))).toBe(false);
+        expect(fs.existsSync(path.join(fakeWorkspace, "POLICY.md"))).toBe(false);
         expect(fs.existsSync(fakeWorkspace)).toBe(false);
         // Multi-agent workspace-* glob also wiped.
         expect(fs.existsSync(fakeMultiAgentWorkspace)).toBe(false);
@@ -497,4 +499,104 @@ describe("wipeSandboxState (#5449)", () => {
     // No empty quoted argument that would expand to nothing in sh -c.
     expect(script).not.toMatch(/rm\s+-rf\s+--\s*''/);
   });
+
+  // #10951: POLICY_CONTEXT_SANDBOX_PATH is a fixed absolute path NemoClaw
+  // writes to regardless of any manifest declaration. Before this fix its
+  // removal on destroy was only incidental -- it happened to fall inside
+  // the manifest-declared `workspace` state_dir. A manifest that omits
+  // `workspace` (or renames it) would silently leave POLICY.md behind while
+  // still correctly wiping every declared state_dir/state_file, producing
+  // exactly the "USER.md/SOUL.md gone, POLICY.md survives" symptom reported
+  // in #10951. Assert the wipe targets it explicitly, independent of what
+  // the manifest declares.
+  it("explicitly targets the in-sandbox POLICY.md path even when the manifest omits `workspace` (#10951)", () => {
+    const { deps, runOpenshell } = buildDeps({
+      loadAgent: vi.fn(() => ({
+        configPaths: { dir: "/sandbox/.openclaw" },
+        stateDirs: ["agents", "extensions", "skills", "hooks", "identity"],
+        stateDirPrefixes: [],
+        stateFiles: [],
+      })),
+    });
+
+    destroy.wipeSandboxState("test-sb", deps as never);
+
+    const { script } = execCommand(runOpenshell);
+    expect(script).toContain("'workspace/POLICY.md'");
+  });
+
+  // #10951: for an agent whose config dir doesn't share the hardcoded
+  // POLICY_CONTEXT_SANDBOX_PATH prefix (e.g. Hermes at /sandbox/.hermes),
+  // no unrelated path should be added to the wipe.
+  it("does not add the openclaw policy-context path for an agent under a different config dir (#10951)", () => {
+    const { deps, runOpenshell } = buildDeps({
+      getSandbox: vi.fn(() => ({ agent: "hermes" }) as never),
+      loadAgent: vi.fn(() => ({
+        configPaths: { dir: "/sandbox/.hermes" },
+        stateDirs: ["workspace"],
+        stateDirPrefixes: [],
+        stateFiles: [],
+      })),
+    });
+
+    destroy.wipeSandboxState("test-sb", deps as never);
+
+    const { script } = execCommand(runOpenshell);
+    expect(script).not.toContain("POLICY.md");
+  });
+
+  // #10951 behavioral proof: run the actual generated script against a real
+  // directory that mirrors a manifest without `workspace` declared, and
+  // confirm POLICY.md -- unlike before this fix -- does not survive.
+  it.skipIf(process.platform === "win32")(
+    "deletes POLICY.md when executed even though `workspace` is absent from the manifest (#10951)",
+    () => {
+      const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-policy-wipe-behavioral-"));
+      try {
+        const fakeSandboxRoot = path.join(tmpRoot, "sandbox");
+        const fakeConfigDir = path.join(fakeSandboxRoot, ".openclaw");
+        const fakeWorkspace = path.join(fakeConfigDir, "workspace");
+        fs.mkdirSync(fakeWorkspace, { recursive: true });
+        fs.writeFileSync(path.join(fakeWorkspace, "POLICY.md"), "policy state from prior session");
+        fs.mkdirSync(path.join(fakeConfigDir, "agents"), { recursive: true });
+
+        const isExecCall = (args: string[]): boolean => args[0] === "sandbox" && args[1] === "exec";
+        const executeScript = (script: string): { status: number | null } =>
+          [() => execFileSync("sh", ["-c", script], { stdio: "ignore" })].map((run) => {
+            try {
+              run();
+              return { status: 0 as number | null };
+            } catch {
+              return { status: 1 as number | null };
+            }
+          })[0];
+
+        const simulatedConfigDir = `/sandbox/${path.basename(fakeConfigDir)}`;
+        const runOpenshell = vi.fn((args: string[]): { status: number | null } =>
+          isExecCall(args)
+            ? executeScript(
+                (args[args.length - 1] as string).replace(simulatedConfigDir, fakeConfigDir),
+              )
+            : { status: 0 },
+        );
+        const deps = {
+          getSandbox: vi.fn(() => ({ agent: "openclaw" }) as never),
+          loadAgent: vi.fn(() => ({
+            configPaths: { dir: simulatedConfigDir },
+            // No `workspace` entry -- only unrelated state dirs.
+            stateDirs: ["agents"],
+            stateDirPrefixes: [],
+            stateFiles: [],
+          })),
+          runOpenshell,
+        };
+
+        destroy.wipeSandboxState("test-sb", deps as never);
+
+        expect(fs.existsSync(path.join(fakeWorkspace, "POLICY.md"))).toBe(false);
+      } finally {
+        fs.rmSync(tmpRoot, { recursive: true, force: true });
+      }
+    },
+  );
 });


### PR DESCRIPTION
## Outcome

`destroy` followed by `onboard --name` with the same name no longer leaves `POLICY.md` sitting in the freshly re-onboarded workspace. Before this change, `USER.md` and `SOUL.md` were correctly gone after re-onboard but `POLICY.md` stayed present.

## Reason

`wipeSandboxState` only removed `POLICY.md` as a side effect of `workspace` being declared as a state_dir under the agent's config dir, which happens to be the same path prefix as the hardcoded `POLICY_CONTEXT_SANDBOX_PATH` constant used to write it. That's coincidental, not guaranteed: nothing ties the wipe to that constant, so a manifest that ever dropped or renamed the `workspace` declaration would silently stop wiping it while still correctly wiping everything else.

Separately, re-onboarding with the same name also unconditionally reseeds `POLICY.md` via `seedInitialPolicyContext`, with no regard for `NEMOCLAW_MINIMAL_BOOTSTRAP`. The sandbox entrypoint's own default-workspace-template seed (`seed_default_workspace_templates` in `scripts/nemoclaw-start.sh`) skips seeding entirely under that flag, so a minimal-bootstrap re-onboard is exactly the scenario where `POLICY.md` ends up as the only workspace artifact reappearing while everything else stays gone, which is the behavior reported in the issue.

### Related issues

Fixes #10951

## Changes

- `wipe-state.ts`: compute `POLICY_CONTEXT_SANDBOX_PATH`'s path relative to the agent's config dir and add it to the wipe's target list explicitly, in addition to whatever the manifest declares. No-ops for an agent whose config dir doesn't share that prefix (e.g. Hermes).
- `policy-selection.ts`: skip the onboarding-time `seedInitialPolicyContext` call when `NEMOCLAW_MINIMAL_BOOTSTRAP=1`, matching the guard the sibling template seed already uses.
- Extended the existing PRA-1 behavioral wipe test to also seed and assert removal of `POLICY.md`, and added targeted tests covering a manifest without `workspace` declared, an unrelated agent config dir, and the minimal-bootstrap onboarding path.

## Verification

- `npx vitest run --project integration test/runtime/sandbox/destroy-wipe-sandbox-state.test.ts` — 28 passed
- `npx vitest run --project integration test/onboarding/onboard-policy-application-wiring.test.ts` — 1 passed
- `npx vitest run --project cli src/lib/onboard/policy-context-seed.test.ts src/lib/onboard/policy-selection-prompts.test.ts src/lib/onboard/policy-selection-application.test.ts src/lib/onboard/policy-selection-host-local-route.test.ts` — 33 passed
- `npx vitest run --project integration test/onboarding/onboard-policy-suggestions.test.ts test/onboarding/onboard-preset-diff.test.ts test/onboarding/onboard.test.ts` — 131 passed
- `npx vitest run --project cli src/lib/actions/sandbox/policy-explain.test.ts src/lib/actions/sandbox/policy-context-refresh.test.ts src/lib/actions/sandbox/policy-channel-refresh.test.ts src/lib/actions/sandbox/destroy-flow.test.ts src/lib/actions/sandbox/destroy-gateway.test.ts` — 135 passed
- `npx tsc -p jsconfig.json --noEmit` — clean
- `npx oxlint` on the four changed files — clean
- Diff contains no secrets, keys, or unrelated changes.

---
Signed-off-by: wakqasahmed <wakqasahmed@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Sandbox cleanup now removes policy files stored under the agent configuration directory, including when workspace state is not listed.
  - Cleanup avoids removing policy files belonging to unrelated agents.
  - Minimal-bootstrap onboarding now skips policy-context seeding while preserving locking, readiness, synchronization, and control-plane validation.
- **Tests**
  - Expanded coverage for policy-file cleanup, including workspace policy files and POSIX environments.
  - Added coverage for minimal-bootstrap re-onboarding scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->