### PR TITLE
fix(cli): enforce clean exit code 0 on healthy sandbox status reports (#11064)

### DIFF
--- a/bin/nemoclaw.js
+++ b/bin/nemoclaw.js
@@ -8,6 +8,10 @@ if (invokedAs === "nemo-deepagents") {
   process.env.NEMOCLAW_AGENT = "langchain-deepagents-code";
   process.env.NEMOCLAW_INVOKED_AS = "nemo-deepagents";
 }
+if (invokedAs === "nemohermes") {
+  process.env.NEMOCLAW_AGENT = "hermes";
+  process.env.NEMOCLAW_INVOKED_AS = "nemohermes";
+}
 
 let topLevelLog = null;
 try {

--- a/src/commands/sandbox/oclif-command-adapters.test.ts
+++ b/src/commands/sandbox/oclif-command-adapters.test.ts
@@ -37,6 +37,8 @@ const mocks = vi.hoisted(() => {
     runSandboxDoctor: vi.fn().mockResolvedValue(undefined),
     showSandboxLogs: vi.fn(),
     showSandboxStatus: vi.fn().mockResolvedValue(undefined),
+    getSandboxStatusReport: vi.fn(),
+    isInferenceHealthFailing: vi.fn().mockReturnValue(false),
     addSandboxHostAlias: vi.fn(),
     listSandboxHostAliases: vi.fn(),
     removeSandboxHostAlias: vi.fn(),
@@ -66,6 +68,8 @@ vi.mock("../../lib/actions/sandbox/process-recovery", () => ({
 
 vi.mock("../../lib/actions/sandbox/status", () => ({
   showSandboxStatus: mocks.showSandboxStatus,
+  getSandboxStatusReport: mocks.getSandboxStatusReport,
+  isInferenceHealthFailing: mocks.isInferenceHealthFailing,
 }));
 
 vi.mock("../../lib/actions/sandbox/logs", () => ({
@@ -327,6 +331,37 @@ describe("sandbox oclif command adapters", () => {
     ).rejects.toThrow("schema-5 rejected");
     expect(mocks.configSet).not.toHaveBeenCalled();
     expect(mocks.configRotateToken).not.toHaveBeenCalled();
+  });
+
+  it("clears a stale non-zero process.exitCode on a successful status run (#11064)", async () => {
+    mocks.showSandboxStatus.mockResolvedValueOnce(undefined);
+    const previousExitCode = process.exitCode;
+    process.exitCode = 1;
+    try {
+      await SandboxStatusCommand.run(["alpha"], rootDir);
+      expect(process.exitCode).toBe(0);
+    } finally {
+      process.exitCode = previousExitCode;
+    }
+  });
+
+  it("sets process.exitCode = 0 on successful --json status run even when process.exitCode was dirty (#11064)", async () => {
+    mocks.getSandboxStatusReport.mockResolvedValueOnce({
+      found: true,
+      gatewayState: "present",
+      rpcIssue: null,
+      failureLayer: null,
+      inferenceHealth: { ok: true },
+      terminalRuntimeHealth: null,
+    });
+    const previousExitCode = process.exitCode;
+    process.exitCode = 1;
+    try {
+      await SandboxStatusCommand.run(["alpha", "--json"], rootDir);
+      expect(process.exitCode).toBe(0);
+    } finally {
+      process.exitCode = previousExitCode;
+    }
   });
 
   it("keeps sandbox inspection usage metadata on native oclif commands", () => {

--- a/src/commands/sandbox/status.ts
+++ b/src/commands/sandbox/status.ts
@@ -32,7 +32,7 @@ export default class SandboxStatusCommand extends NemoClawCommand {
     const { args } = await this.parse(SandboxStatusCommand);
     if (this.jsonEnabled()) {
       const report = await getSandboxStatusReport(args.sandboxName);
-      if (
+      const isFailed =
         !report.found ||
         ("portableLifecyclePhase" in report
           ? report.portableLifecyclePhase !== "active"
@@ -40,16 +40,24 @@ export default class SandboxStatusCommand extends NemoClawCommand {
             report.rpcIssue ||
             report.failureLayer ||
             isInferenceHealthFailing(report.inferenceHealth) ||
-            report.terminalRuntimeHealth?.kind === "degraded")
-      ) {
-        process.exitCode = 1;
-      }
+            report.terminalRuntimeHealth?.kind === "degraded");
+      this.setExitCode(isFailed ? 1 : 0);
       // #4310: route the machine-readable report through the centralized
       // redactForLog source of truth so health diagnostics (inferenceHealth
       // endpoint/detail/subprobes) cannot leak token-shaped values into
       // automation that persists CLI JSON output.
       return redactForLog(report);
     }
-    await showSandboxStatus(args.sandboxName);
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await showSandboxStatus(args.sandboxName);
+      this.setExitCode(process.exitCode ?? 0);
+    } catch (error) {
+      if (process.exitCode === undefined && priorExitCode !== undefined) {
+        process.exitCode = priorExitCode;
+      }
+      throw error;
+    }
   }
 }

--- a/test/cli/sandbox-status-text.test.ts
+++ b/test/cli/sandbox-status-text.test.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { execSync } from "node:child_process";
 import fs from "node:fs";
 import net from "node:net";
 import os from "node:os";
@@ -8,6 +9,7 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 import {
+  HERMES_CLI,
   healthyInferenceRouteStubLines,
   inferenceInvocationStubLines,
   runWithEnv,
@@ -588,4 +590,85 @@ describe("CLI sandbox status text output", () => {
       expect(parsed.dockerPaused).toBe(true);
     },
   );
+
+  it("sandbox <name> status exits 0 on a healthy Hermes sandbox invoked directly and via nemohermes (#11064)", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-sandbox-status-hermes-"));
+    const localBin = path.join(home, "bin");
+    fs.mkdirSync(localBin, { recursive: true });
+    writeSandboxRegistry(home, "hermes-station", {
+      agent: "hermes",
+      provider: "nvidia-prod",
+      model: "nvidia/nemotron-3-super-120b-a12b",
+      openshellDriver: "docker",
+      openshellVersion: "0.0.106",
+      policies: ["pypi"],
+    });
+    writeHealthyDockerStub(localBin);
+    fs.writeFileSync(
+      path.join(localBin, "openshell"),
+      [
+        "#!/usr/bin/env bash",
+        'if [ "$1" = "sandbox" ] && [ "$2" = "get" ] && { [ "$3" = "hermes-station" ] || [ "$5" = "hermes-station" ]; }; then',
+        "  echo 'Sandbox:'",
+        "  echo '  Name: hermes-station'",
+        "  echo '  Phase: Ready'",
+        "  exit 0",
+        "fi",
+        'if [ "$1" = "inference" ] && [ "$2" = "get" ]; then',
+        "  echo 'Gateway inference:'",
+        "  echo '  Provider: nvidia-prod'",
+        "  echo '  Model: nvidia/nemotron-3-super-120b-a12b'",
+        "  exit 0",
+        "fi",
+        'if [ "$1" = "status" ]; then',
+        "  echo 'Gateway: nemoclaw'",
+        "  echo 'Status: Connected'",
+        "  exit 0",
+        "fi",
+        'if [ "$1" = "gateway" ] && [ "$2" = "info" ]; then',
+        "  echo 'Gateway: nemoclaw'",
+        "  exit 0",
+        "fi",
+        ...healthyInferenceRouteStubLines(),
+        "exit 0",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    const r = runWithEnv("hermes-station status", {
+      HOME: home,
+      PATH: `${localBin}:${process.env.PATH || ""}`,
+    });
+
+    expect(r.code).toBe(0);
+    expect(r.out).toContain("Sandbox: hermes-station");
+    expect(r.out).toContain("Harness:  Hermes Agent (gateway)");
+    expect(r.out).toContain("Phase: Ready");
+
+    // Also assert clean exit 0 when invoked via nemohermes launcher
+    const hermesRun = execSync(`node "${HERMES_CLI}" hermes-station status`, {
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        HOME: home,
+        PATH: `${localBin}:${process.env.PATH || ""}`,
+        NEMOCLAW_AGENT: undefined,
+        NEMOCLAW_INVOKED_AS: undefined,
+        NEMOCLAW_HEALTH_POLL_COUNT: "1",
+        NEMOCLAW_HEALTH_POLL_INTERVAL: "0",
+      },
+    });
+    expect(hermesRun).toContain("Sandbox: hermes-station");
+    expect(hermesRun).toContain("Phase: Ready");
+    expect(hermesRun).toContain("Harness:  Hermes Agent (gateway)");
+
+    // Also assert exit 0 in --json mode
+    const jsonRun = runWithEnv("hermes-station status --json", {
+      HOME: home,
+      PATH: `${localBin}:${process.env.PATH || ""}`,
+    });
+    expect(jsonRun.code).toBe(0);
+    const parsedJson = JSON.parse(jsonRun.out);
+    expect(parsedJson.found).toBe(true);
+  });
 });


### PR DESCRIPTION
## Description

`SandboxStatusCommand` in `src/commands/sandbox/status.ts` previously only assigned `process.exitCode = 1` on status check failures, and left `process.exitCode` unset when the status report was fully healthy. In human-readable text mode, `showSandboxStatus(sandboxName)` also left `process.exitCode` untouched when all preflight, inference route, and serving process checks were healthy.

In dirty process environments (or when alias launchers complete), this allowed stale or leaked non-zero exit codes to persist, causing `nemohermes <name> status` (or `nemoclaw <name> status`) to exit with code 1 despite printing a completely healthy status report. Furthermore, `bin/nemohermes.js` previously required `dist/nemoclaw` directly without delegating to `bin/nemoclaw.js`, missing top-level exception handling, safe port diagnostics, and process lifecycle wrappers.

This change:
1. Enforces `this.setExitCode(0)` on healthy status runs in both `--json` and human-readable text formats, while properly preserving non-zero exit codes when preflight, route diagnostics, or managed runtime dependencies fail.
2. Clears any dirty non-zero `process.exitCode` before running `showSandboxStatus` so internal error-detection gates evaluate cleanly without false positives, restoring previous exit code state on uncaught errors.
3. Updates `bin/nemohermes.js` to delegate directly to `./nemoclaw`, ensuring the Hermes alias launcher benefits from top-level rejection handling and consistent lifecycle management.
4. Adds integration coverage in `test/cli/sandbox-status-text.test.ts` verifying exit 0 for healthy Hermes sandboxes both directly and via `nemohermes`, and unit tests in `src/commands/sandbox/oclif-command-adapters.test.ts` verifying exit code 0 enforcement across text and JSON formats even when prior process exit codes were dirty.

Fixes #11064

## Verification
- `npx vitest run test/cli/sandbox-status-text.test.ts` (9/9 pass)
- `npx vitest run test/cli/sandbox-status-json.test.ts` (18/18 pass)
- `npx vitest run src/commands/sandbox/oclif-command-adapters.test.ts` (14/14 pass)
- `npx vitest run test/nemohermes-alias.test.ts` (9/9 pass)
- `npx vitest run src/lib/actions/sandbox/status-flow.test.ts` (41/41 pass)
- Signed commit (`-S`) with SSH key and DCO sign-off (`-s`)

Signed-off-by: Ho Lim <subhoya@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for launching Hermes through the `nemohermes` command, including correct launcher identification.

- **Bug Fixes**
  - Sandbox status commands now accurately report success or failure through their exit codes.
  - Fixed stale exit codes affecting successful standard and JSON status checks.
  - Improved handling of degraded runtime health and status display failures.

- **Tests**
  - Added coverage for healthy sandbox status checks through direct and `nemohermes` command paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->