### PR TITLE
docs: fix custom policy troubleshooting link

### DIFF
--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -1788,7 +1788,7 @@ $$nemoclaw <name> logs --tail 50
 </AgentOnly>
 <AgentOnly variant="deepagents">
   If the host should be reachable, allow it with a built-in preset or apply a [reviewed custom
-  preset file](../network-policy/create-custom-policy-presets) from the host:
+  preset file](../network-policy/configure-policies/create-custom-policy-presets) from the host:
 </AgentOnly>
 
 ```bash


### PR DESCRIPTION
## Outcome
The Deep Agents troubleshooting link now opens the published Create Custom Policy Presets page instead of a missing route.

## Reason
The previous route omitted the Configure Policies navigation segment and returned HTTP 404.

### Related issues
Fixes #11202

## Changes
- Update the Deep Agents custom-preset troubleshooting link to the current nested route.

## Verification
- `npm run docs` — passed generated variant, route, link, MDX, and Fern validation.
- `npm run validate:pr` — passed the pre-commit, commit-message, and pre-push checks.
- Generated Deep Agents page inspection manual check — corrected route is present and the obsolete route is absent.
- Published route check — the corrected target returned HTTP 200; the previous target returned HTTP 404.
- Independent documentation writer review of commit `23c3a4311b16b899d8c2599d0998f654f9dc9bf1` — no findings.
- Secret review — the diff contains no secrets, API keys, or credentials.

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Deep Agents custom-policy preset documentation link to the current location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->