### PR TITLE
fix(hermes): remove spoof URL test source from images

### DIFF
--- a/agents/hermes/Dockerfile
+++ b/agents/hermes/Dockerfile
@@ -407,6 +407,7 @@ RUN set -eu; \
             exit 1; \
         fi; \
     fi; \
+    rm -f /opt/hermes/apps/desktop/src/store/suggestion-providers/github.test.ts; \
     rm -rf /root/.npm /root/.cache/electron /root/.cache/node-gyp /root/.cache/uv; \
     test -d "$hermes_web_dist"
 

--- a/agents/hermes/Dockerfile
+++ b/agents/hermes/Dockerfile
@@ -1594,6 +1594,7 @@ RUN check_metadata() { \
             || { echo "ERROR: build-only Hermes path leaked into the final image: $path" >&2; return 1; }; \
     }; \
     check_absent /opt/hermes/tests \
+    && check_absent /opt/hermes/apps/desktop/src/store/suggestion-providers/github.test.ts \
     && check_absent /opt/nemoclaw-hermes-config/image-build-probes.py \
     && check_absent /opt/nemoclaw-hermes-config/finalize-image-layout.sh \
     && check_absent /opt/nemoclaw-hermes-config/patch-gateway-runtime-metadata.py \

--- a/agents/hermes/Dockerfile.base
+++ b/agents/hermes/Dockerfile.base
@@ -466,7 +466,9 @@ RUN mkdir -p /opt/hermes \
     && printf '%s  /tmp/hermes.tar.gz\n' "${HERMES_TARBALL_SHA256}" > /tmp/hermes.tar.gz.sha256 \
     && sha256sum -c /tmp/hermes.tar.gz.sha256 \
     && tar -xzf /tmp/hermes.tar.gz -C /opt/hermes --strip-components=1 \
-    && rm -rf /opt/hermes/tests \
+    && rm -rf \
+        /opt/hermes/tests \
+        /opt/hermes/apps/desktop/src/store/suggestion-providers/github.test.ts \
     && printf '%s  %s\n' \
         "$NEMOCLAW_HERMES_RUNTIME_BOUNDARIES_PATCH_SHA256" /tmp/hermes-runtime-boundaries.patch \
         "$NEMOCLAW_HERMES_SECURE_DIR_PATCH_SHA256" /tmp/hermes-secure-dir-skip-chmod.patch \
@@ -717,7 +719,13 @@ RUN test -r /opt/hermes/.venv/pyvenv.cfg \
 
 # Reject build-only paths before the base image can be published.
 RUN set -eu; \
-    for build_only_path in /opt/hermes/tests /root/.npm /root/.cache/electron /root/.cache/node-gyp /root/.cache/uv; do \
+    for build_only_path in \
+        /opt/hermes/tests \
+        /opt/hermes/apps/desktop/src/store/suggestion-providers/github.test.ts \
+        /root/.npm \
+        /root/.cache/electron \
+        /root/.cache/node-gyp \
+        /root/.cache/uv; do \
         if [ -e "$build_only_path" ] || [ -L "$build_only_path" ]; then \
             echo "ERROR: build-only Hermes path leaked into the base image: $build_only_path" >&2; \
             exit 1; \


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

Hermes image builds now remove an unused suggestion-provider test source that contains a lookalike GitHub URL. Base and managed image checks reject the build if that file remains in a published image.

## Reason

The upstream test source contains the inert fixture `https://github.com.evil.example/x`. A malware scanner classified that fixture as `Script-JS.Hyperlink.Spoofed`, although Hermes does not use the test at runtime.

## Changes

- Remove `github.test.ts` after checksum verification and Hermes source extraction.
- Remove the file from the managed image when its published base predates the base-image cleanup.
- Require the file to remain absent from the Hermes base image and managed image.

## Verification

- `npm run test:changed` — passed 45 growth-guardrail tests; no CLI, plugin, or E2E-support tests matched this Dockerfile-only diff.
- `hadolint agents/hermes/Dockerfile.base agents/hermes/Dockerfile` — passed.
- `scripts/check-production-build-args.sh -f agents/hermes/Dockerfile.base` — passed.
- `scripts/check-production-build-args.sh -f agents/hermes/Dockerfile` — passed.
- Normal `pre-commit` and `commit-msg` hooks — passed, including repository checks, hadolint, gitleaks, and commitlint.
- Diff review — found no secrets, API keys, credentials, or unrelated changes.

## Review notes

The first `rootless-linux` run showed that the managed image can inherit the file from a published base that predates this change. The managed-image cleanup now handles that lagging-base path directly.

An independent documentation writer reviewed commit `7cfb6eb6a`. No user documentation change is required because this removal does not change a command, configuration, default, or runtime behavior.

Docker Desktop is unavailable on the validation host. CI must build the AMD64 and ARM64 images and rescan their immutable manifests before the malware finding can be considered resolved.

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Hermes container build validation to ensure internal test files are excluded from final images.
  * Added safeguards that remove desktop GitHub suggestion-provider tests during image creation and reject builds if those files remain.
  * Improved consistency between standard and base image build paths by applying the same exclusion checks during packaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->