### PR TITLE
test(onboard): fix readiness deadline clock (Fixes #11198)

### DIFF
--- a/src/lib/onboard/sandbox-readiness-tracing.test.ts
+++ b/src/lib/onboard/sandbox-readiness-tracing.test.ts
@@ -80,6 +80,7 @@ describe("createSandboxReadyWaiter", () => {
       target: TARGET,
       isLinuxDockerDriverGatewayEnabled: () => true,
       sleep,
+      now: () => 0,
     });
 
     await expect(waitForSandboxReady(NAME, 2, 3)).resolves.toEqual({


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

The sandbox-readiness adaptive-deadline test now uses its existing injected clock seam, so the first observation deterministically receives the full 6,000 ms budget. Loaded CI runners can no longer turn the exact assertion into a 5,999 ms timing flake.

## Reason

The test mocked observation replay and sleep but left `now` on the real wall clock. A millisecond spent between deadline construction and the first observation legitimately reduced the production timeout while making the test nondeterministic.

### Related issues

Fixes #11198

## Changes

- Inject `now: () => 0` into the existing `createSandboxReadyWaiter` test.
- Keep the exact 6,000 ms assertion, production deadline behavior, and all runtime code unchanged.

## Verification

- `./node_modules/.bin/vitest run src/lib/onboard/sandbox-readiness-tracing.test.ts` — passed six consecutive runs; each run reported 41 passed and one intentional skip.
- Direct pre-commit, commitlint, pre-push, and `git diff --check origin/main...HEAD` gates — passed on commit `4022ea9000cdad72d31721e4d68bf72929d233a0`.
- Collision search by issue number, title/error text, and exact file — no competing implementation or same-file open PR.
- Secret review — the one-line test-only diff contains no secrets, API keys, or credentials.

## Review notes

This is test-only. It uses the production seam already intended for deterministic tests and does not add tolerance or alter the absolute-deadline contract.

---
Signed-off-by: Deepak Jain <deepujain@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test determinism by using a fixed clock when validating Docker-driver readiness timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->