### PR TITLE
fix(cli): keep bare doctor global (Fixes #11159)

### DIFF
--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1646,7 +1646,7 @@ If the sandbox is running an older Deep Agents Code version than this NemoClaw r
 ### `$$nemoclaw <name> doctor`
 
 Run a focused health check for one sandbox and the host services it depends on. The command checks the local CLI build, Docker daemon, OpenShell CLI, NemoClaw gateway container, gateway port mapping, live sandbox state, inference route, configured-provider model invocation, Ollama reachability, and the cloudflared tunnel state.
-Use `$$nemoclaw doctor` when you need only the host and gateway checks or when no sandbox exists yet. If a sandbox is named `doctor`, use `$$nemoclaw doctor --text` to select the global text report explicitly; bare `$$nemoclaw doctor` keeps the existing name-first sandbox connection behavior.
+Use `$$nemoclaw doctor` when you need only the host and gateway checks or when no sandbox exists yet. A sandbox named `doctor` does not change the bare global command; use `$$nemoclaw doctor connect` to connect to that sandbox explicitly.
 
 <AgentOnly variant="openclaw,hermes">
   For gateway-based agents, it also reports messaging channel conflicts within the selected
@@ -3368,7 +3368,7 @@ It checks the NemoClaw CLI build, the selected host runtime provider, the OpenSh
 It does not start, select, restart, or repair a gateway.
 It does not run sandbox, inference, messaging, agent-version, config-permission, or agent-service checks.
 Use `$$nemoclaw <name> doctor` when you need those sandbox checks.
-If a sandbox is named `doctor`, bare `$$nemoclaw doctor` connects to that sandbox under the name-first grammar. Use `$$nemoclaw doctor --text` for the global human-readable report or `$$nemoclaw doctor --json` for the global JSON report.
+If a sandbox is named `doctor`, the bare command still selects this global report. Use `$$nemoclaw doctor connect` to connect to that sandbox explicitly.
 
 ```bash
 $$nemoclaw doctor [--json | --text]

--- a/src/lib/cli/argv-normalizer.test.ts
+++ b/src/lib/cli/argv-normalizer.test.ts
@@ -98,6 +98,7 @@ describe("normalizeArgv", () => {
     { argv: ["doctor", "--help"], kind: "global", action: undefined },
     { argv: ["doctor", "--json"], kind: "global", action: undefined },
     { argv: ["doctor", "--text"], kind: "global", action: undefined },
+    { argv: ["doctor"], kind: "global", action: undefined, registered: true },
     { argv: ["doctor", "--json"], kind: "global", action: undefined, registered: true },
     { argv: ["doctor", "--text"], kind: "global", action: undefined, registered: true },
     { argv: ["doctor", "--probe-only"], kind: "sandbox", action: "connect" },
@@ -116,7 +117,6 @@ describe("normalizeArgv", () => {
   });
 
   it.each([
-    { label: "bare", firstArg: undefined, connectHelpRequested: false },
     { label: "help", firstArg: "--help", connectHelpRequested: true },
     { label: "probe-only", firstArg: "--probe-only", connectHelpRequested: false },
   ])("preserves $label connect for a registered sandbox named doctor (#10212)", (testCase) => {

--- a/src/lib/cli/argv-normalizer.ts
+++ b/src/lib/cli/argv-normalizer.ts
@@ -34,7 +34,7 @@ export function isGlobalCommandInvocation(
   const [command, firstArg] = argv;
   if (!command || !opts.globalCommands.has(command)) return false;
   if (command !== "doctor") return true;
-  if (!firstArg) return !opts.isRegisteredSandbox(command);
+  if (!firstArg) return true;
   if (opts.isSandboxConnectFlag(firstArg)) {
     const isHelpFlag = firstArg === "--help" || firstArg === "-h";
     if (!isHelpFlag || opts.isRegisteredSandbox(command)) return false;

--- a/test/cli/dispatch-basics.test.ts
+++ b/test/cli/dispatch-basics.test.ts
@@ -649,7 +649,7 @@ describe("CLI dispatch", () => {
     );
   });
 
-  it("dispatches the global doctor without a sandbox name (#10212)", async () => {
+  it("dispatches bare doctor globally despite a same-named sandbox (#11159)", async () => {
     await withDirectPublicDispatch(
       async ({
         dispatchCli,
@@ -669,6 +669,7 @@ describe("CLI dispatch", () => {
         expect(recoverRegistryEntries).not.toHaveBeenCalled();
         expect(stderr).toEqual([]);
       },
+      { sandboxNames: ["doctor"] },
     );
   });
 
@@ -944,7 +945,6 @@ describe("CLI dispatch", () => {
   });
 
   it.each([
-    { label: "bare", args: [] as string[], migrationCalls: 1, helpCalls: 0 },
     { label: "help", args: ["--help"], migrationCalls: 0, helpCalls: 1 },
     { label: "probe-only", args: ["--probe-only"], migrationCalls: 1, helpCalls: 0 },
   ])("keeps $label connect for a sandbox literally named doctor (#10212)", async (testCase) => {
@@ -978,7 +978,6 @@ describe("CLI dispatch", () => {
   });
 
   it.each([
-    { label: "bare", args: [] as string[] },
     { label: "probe-only", args: ["--probe-only"] },
   ])("migrates a legacy sandbox named doctor before $label connect (#10212)", async (testCase) => {
     await withDirectPublicDispatch(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

Bare `nemoclaw doctor` now always runs the documented global host and gateway diagnostic, even when a sandbox is registered with the literal name `doctor`. Operators can still reach that sandbox explicitly with `nemoclaw doctor connect` or another name-first sandbox action.

## Reason

The previous collision rule treated bare `doctor` as an implicit sandbox connection whenever the registry contained that name. In non-interactive use, the documented global diagnostic could therefore open an interactive session and hang indefinitely.

### Related issues

Fixes #11159

## Changes

- Make the zero-argument `doctor` form global before consulting sandbox registration state.
- Preserve explicit `doctor status`, `doctor connect`, `doctor --probe-only`, and registered-sandbox help routing.
- Add normalization and public-dispatch coverage for the same-named sandbox collision.
- Update both command-reference descriptions with the explicit sandbox connection form.

## Verification

- `npm run build:cli` - passed.
- `vitest run src/lib/cli/argv-normalizer.test.ts test/cli/dispatch-basics.test.ts` - 84 tests passed.
- `npm run docs:strict` - 0 errors and 5 existing warnings.
- Direct pre-commit, commitlint, pre-push, and `git diff --check origin/main...HEAD` gates - passed on commit `62abdd13456f71360da678a613a54701762b7d53`.
- GitHub commit verification - `verified=true`, `reason=valid`, with the Deepak Jain DCO sign-off.
- Collision search by issue number, command phrase, and behavior - no competing implementation. PR #11095 changes the same generated command-reference source at a distant, unrelated NemoCUA section; code and test paths do not overlap.
- Secret review - the diff contains no secrets, API keys, or credentials.

## Review notes

This changes only the ambiguous zero-argument form. Explicit sandbox actions retain name-first routing, so a sandbox named `doctor` remains reachable without adding a compatibility path or registry migration.

---
Signed-off-by: Deepak Jain <deepujain@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - The bare `nemoclaw doctor` command consistently runs the global doctor report, even when a sandbox is named “doctor.”
  - Use `nemoclaw doctor connect` to connect to that sandbox.
  - Help, diagnostic, and migration command behavior remains supported.

- **Documentation**
  - Clarified recovery retry budgets and deadlines for different transient failure types.
  - Added Hermes Portable forward-repair diagnostics guidance.
  - Documented safe endpoint display for compatible inference providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

