### PR TITLE
test(e2e): stabilize publication budget abort test

### DIFF
--- a/test/e2e/support/base-image-publication.test.ts
+++ b/test/e2e/support/base-image-publication.test.ts
@@ -1101,6 +1101,11 @@ describe("base-image publication evidence", () => {
 
   it("aborts an in-flight GitHub request at the caller's request budget", async () => {
     vi.useFakeTimers();
+    const timeoutSignal = vi.spyOn(AbortSignal, "timeout").mockImplementation((milliseconds) => {
+      const controller = new AbortController();
+      setTimeout(() => controller.abort(), milliseconds);
+      return controller.signal;
+    });
     let observedAbort = false;
 
     try {
@@ -1131,8 +1136,10 @@ describe("base-image publication evidence", () => {
 
       await vi.advanceTimersByTimeAsync(100);
       await rejection;
+      expect(timeoutSignal).toHaveBeenCalledWith(100);
       expect(observedAbort).toBe(true);
     } finally {
+      timeoutSignal.mockRestore();
       vi.useRealTimers();
     }
   }, 2_000);

--- a/test/e2e/support/base-image-publication.test.ts
+++ b/test/e2e/support/base-image-publication.test.ts
@@ -1100,12 +1100,9 @@ describe("base-image publication evidence", () => {
   });
 
   it("aborts an in-flight GitHub request at the caller's request budget", async () => {
-    vi.useFakeTimers();
-    const timeoutSignal = vi.spyOn(AbortSignal, "timeout").mockImplementation((milliseconds) => {
-      const controller = new AbortController();
-      setTimeout(() => controller.abort(), milliseconds);
-      return controller.signal;
-    });
+    const controller = new AbortController();
+    const timeoutSignal = vi.spyOn(AbortSignal, "timeout").mockReturnValue(controller.signal);
+    let currentTime = 0;
     let observedAbort = false;
 
     try {
@@ -1116,6 +1113,7 @@ describe("base-image publication evidence", () => {
           attempts: 1,
           budgetMs: 100,
           timeoutMs: 5_000,
+          now: () => currentTime,
           fetchImpl: async (_input, init) => {
             const signal = required(init.signal ?? undefined, "request signal is required");
             await new Promise<void>((_resolve, reject) => {
@@ -1132,15 +1130,15 @@ describe("base-image publication evidence", () => {
           },
         },
       );
-      const rejection = expect(request).rejects.toThrow();
+      const rejection = expect(request).rejects.toThrow(/time budget/u);
 
-      await vi.advanceTimersByTimeAsync(100);
+      currentTime = 100;
+      controller.abort();
       await rejection;
       expect(timeoutSignal).toHaveBeenCalledWith(100);
       expect(observedAbort).toBe(true);
     } finally {
       timeoutSignal.mockRestore();
-      vi.useRealTimers();
     }
   }, 2_000);
 

--- a/test/e2e/support/base-image-publication.test.ts
+++ b/test/e2e/support/base-image-publication.test.ts
@@ -6,7 +6,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   collectPaginated,
@@ -1100,30 +1100,41 @@ describe("base-image publication evidence", () => {
   });
 
   it("aborts an in-flight GitHub request at the caller's request budget", async () => {
+    vi.useFakeTimers();
     let observedAbort = false;
 
-    await expect(
-      githubRequest("/repos/NVIDIA/NemoClaw/actions/workflows/base-image.yaml", "token", {
-        attempts: 1,
-        budgetMs: 100,
-        timeoutMs: 5_000,
-        fetchImpl: async (_input, init) => {
-          const signal = required(init.signal ?? undefined, "request signal is required");
-          await new Promise<void>((_resolve, reject) => {
-            signal.addEventListener(
-              "abort",
-              () => {
-                observedAbort = true;
-                reject(signal.reason);
-              },
-              { once: true },
-            );
-          });
-          throw new Error("aborted request unexpectedly resumed");
+    try {
+      const request = githubRequest(
+        "/repos/NVIDIA/NemoClaw/actions/workflows/base-image.yaml",
+        "token",
+        {
+          attempts: 1,
+          budgetMs: 100,
+          timeoutMs: 5_000,
+          fetchImpl: async (_input, init) => {
+            const signal = required(init.signal ?? undefined, "request signal is required");
+            await new Promise<void>((_resolve, reject) => {
+              signal.addEventListener(
+                "abort",
+                () => {
+                  observedAbort = true;
+                  reject(signal.reason);
+                },
+                { once: true },
+              );
+            });
+            throw new Error("aborted request unexpectedly resumed");
+          },
         },
-      }),
-    ).rejects.toThrow(/time budget/u);
-    expect(observedAbort).toBe(true);
+      );
+      const rejection = expect(request).rejects.toThrow();
+
+      await vi.advanceTimersByTimeAsync(100);
+      await rejection;
+      expect(observedAbort).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   }, 2_000);
 
   it("fails permanent and malformed GitHub responses without retrying (#7372)", async () => {


### PR DESCRIPTION
## Outcome

The base-image publication budget-abort test now verifies the owned timeout diagnosis and abort propagation without depending on real-time scheduling. It controls the clock and timeout signal directly, then confirms that the in-flight request is aborted at the caller budget.

## Reason

The post-merge `main` CI for #11007 aborted the request as intended, but failed because wall-clock scheduling selected a different valid error message. This keeps the regression coverage while removing that timing-sensitive setup.

### Related issues

Follow-up to #11007.

## Changes

- Return a controlled `AbortController` signal from a scoped `AbortSignal.timeout` spy.
- Advance the injected request clock to the 100 ms caller budget, abort the controller, and assert the time-budget diagnosis, timeout argument, and observed abort.
- Leave production behavior unchanged.

## Verification

- `npx vitest run --project e2e-support test/e2e/support/base-image-publication.test.ts` - 61 tests passed.
- Four focused stability repetitions - all passed and settled in 3 to 6 ms of test execution.
- `npx oxfmt --check test/e2e/support/base-image-publication.test.ts` - passed.
- Repository pre-commit, commit message, and pre-push validation against refreshed canonical `main` - passed.
- Diff inspection - no secrets, API keys, or credentials.

## Review notes

The originating failure is [main CI run 34245263542, job 102125866368](https://github.com/NVIDIA/NemoClaw/actions/runs/34245263542/job/102125866368). Advisor run 34254475580 produced six exact-head reviews: four had no finding, and its operability and reduction findings were addressed in `ca5575428a`. The other three specialists failed externally, two on provider HTTP 429 responses and one after the 900-second service timeout, before producing artifacts. Local advisory review was also retried, but its owned OpenShell gateway again refused connections before any specialist ran. Fresh hosted review is required for the latest commit.

---
Signed-off-by: Rebecca Sliter <571084+rsliter@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved end-to-end coverage for in-flight request timeouts.
  - Verified requests are aborted within the expected 100 ms timeout window.
  - Confirmed abort signals propagate correctly during timeout handling.
  - Improved test cleanup to prevent timeout-related state from affecting subsequent tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
