### PR TITLE
docs(deepagents): clarify forward recovery scope

### DIFF
--- a/docs/manage-sandboxes/recover-rebuild-sandboxes.mdx
+++ b/docs/manage-sandboxes/recover-rebuild-sandboxes.mdx
@@ -43,13 +43,15 @@ If NemoClaw reports that a Docker-driver sandbox is stopped, restart the existin
 $$nemoclaw <sandbox-name> start
 ```
 
-This path preserves the sandbox workspace and repairs the agent runtime and host-side forwards after the container starts. If the container is paused, follow the printed `docker unpause` guidance instead. If Docker no longer has the container, destroy the stale NemoClaw entry and onboard a clean replacement. Restore a separately created snapshot afterward if one is available; rebuild cannot recover a workspace or live OpenShell policy that no longer exists.
+This path preserves the sandbox workspace after the container starts.
+If the container is paused, follow the printed `docker unpause` guidance instead.
+If Docker no longer has the container, destroy the stale NemoClaw entry and onboard a clean replacement.
+Restore a separately created snapshot afterward if one is available; rebuild cannot recover a workspace or live OpenShell policy that no longer exists.
 
 <AgentOnly variant="openclaw,hermes">
-  The `start` command returns success only after it authenticates the recovered agent runtime,
-  OpenShell reports the sandbox ready, and host-side port forwards pass their checks. If a check
-  fails, the command exits nonzero, identifies the failure, and prints recovery guidance before you
-  retry `start`.
+  The `start` command repairs the agent runtime and host-side forwards.
+  It returns success only after it authenticates the recovered agent runtime, OpenShell reports the sandbox ready, and host-side port forwards pass their checks.
+  If a check fails, the command exits nonzero, identifies the failure, and prints recovery guidance before you retry `start`.
 </AgentOnly>
 
 ## Recover the Agent Runtime
@@ -158,7 +160,8 @@ For the controller topology, trust boundary, and fail-closed conditions, refer t
 
 </AgentOnly>
 <AgentOnly variant="deepagents">
-Deep Agents sandboxes are terminal runtimes and do not expose an OpenClaw or Hermes in-sandbox gateway.
+Deep Agents sandboxes are terminal runtimes and do not expose an in-sandbox agent gateway or host-side forward.
+The OpenShell ownership and local endpoint reachability prerequisites for an already active forward do not apply.
 Use `nemo-deepagents <sandbox-name> status`, `logs`, `connect`, and `rebuild` for recovery.
 If the terminal runtime reports degraded health, rebuild the sandbox instead of using `recover` or `gateway restart`.
 </AgentOnly>


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

The Deep Agents recovery guide now explains why the active host-forward ownership and reachability prerequisites do not apply to its terminal runtime.
OpenClaw and Hermes variants continue to state that `start` repairs and verifies their host-side forwards.

## Reason

The shared restart text implied that every agent runtime repaired host-side forwards, while the Deep Agents recovery section did not explain why its variant omitted the active-forward prerequisite.
Deep Agents has no in-sandbox agent gateway or host-side forward, so the guide must state that boundary directly.

### Related issues

Fixes #11176

## Changes

- Scope the `start` host-forward repair statement to OpenClaw and Hermes.
- State that the active-forward ownership and local endpoint reachability prerequisites do not apply to Deep Agents.
- Keep the existing Deep Agents recovery path through `status`, `logs`, `connect`, and `rebuild`.

## Verification

- `npm run docs:sync-agent-variants` — passed; the clarification appears only in the Deep Agents generated page, while OpenClaw and Hermes retain their forward-repair statement.
- `npm run docs` — passed with 0 errors and 5 existing Fern warnings.
- `npm run validate:pr` — passed against canonical `main`.
- Independent documentation writer review of `fe111be4488a265178015848840056e224da8d9c` — passed with no findings.
- No runtime test applies because this change only corrects variant-specific documentation.
- Reviewed the diff for secrets, API keys, and credentials; none are present.

---
<!-- DCO sign-off is required in this PR description. Every commit must appear as Verified in GitHub. -->
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>
