### PR TITLE
refactor(mcp): route provider lifecycle through adapter

### DIFF
--- a/ci/source-architecture-budget.json
+++ b/ci/source-architecture-budget.json
@@ -7,7 +7,7 @@
       "src/lib/actions/sandbox/mcp-bridge-contracts.ts": 25,
       "src/lib/actions/sandbox/process-recovery.ts": 26,
       "src/lib/adapters/docker/index.ts": 42,
-      "src/lib/adapters/openshell/client.ts": 20,
+      "src/lib/adapters/openshell/client.ts": 18,
       "src/lib/adapters/openshell/command-argv.ts": 23,
       "src/lib/adapters/openshell/resolve.ts": 25,
       "src/lib/adapters/openshell/runtime.ts": 53,

--- a/src/lib/actions/credentials-provider-adapter.test.ts
+++ b/src/lib/actions/credentials-provider-adapter.test.ts
@@ -55,8 +55,11 @@ function providerAdapter(
   });
   const detachProvider: OpenShellProviderAdapter["detachProvider"] = async () => ({
     ok: true,
+    value: { changed: true },
   });
   const attachProvider: OpenShellProviderAdapter["attachProvider"] = async () => ({ ok: true });
+  const listProviderAttachments: OpenShellProviderAdapter["listProviderAttachments"] =
+    async () => ({ ok: true, value: { names: [] } });
   const configureProviderRefresh: OpenShellProviderAdapter["configureProviderRefresh"] =
     async () => ({ ok: true });
   const getProviderRefreshStatus: OpenShellProviderAdapter["getProviderRefreshStatus"] =
@@ -71,6 +74,7 @@ function providerAdapter(
     deleteProvider: vi.fn(deleteProvider),
     detachProvider: vi.fn(detachProvider),
     attachProvider: vi.fn(attachProvider),
+    listProviderAttachments: vi.fn(listProviderAttachments),
     configureProviderRefresh: vi.fn(configureProviderRefresh),
     getProviderRefreshStatus: vi.fn(getProviderRefreshStatus),
     ...overrides,
@@ -875,7 +879,7 @@ describe("credential actions use typed OpenShell provider results", () => {
       });
     const detachProvider = vi.fn<OpenShellProviderAdapter["detachProvider"]>(async () => {
       operations.push("detach:alpha");
-      return { ok: true };
+      return { ok: true, value: { changed: true } };
     });
     const adapter = providerAdapter({ deleteProvider, detachProvider });
 
@@ -930,6 +934,7 @@ describe("credential actions use typed OpenShell provider results", () => {
       });
     const detachProvider = vi.fn<OpenShellProviderAdapter["detachProvider"]>(async () => ({
       ok: true,
+      value: { changed: true },
     }));
     const adapter = providerAdapter({ deleteProvider, detachProvider });
 
@@ -1090,6 +1095,7 @@ describe("credential actions use typed OpenShell provider results", () => {
       });
     const detachProvider = vi.fn<OpenShellProviderAdapter["detachProvider"]>(async () => ({
       ok: true,
+      value: { changed: true },
     }));
     const adapter = providerAdapter({ deleteProvider, detachProvider });
 
@@ -1177,6 +1183,7 @@ describe("credential actions use typed OpenShell provider results", () => {
       });
     const detachProvider = vi.fn<OpenShellProviderAdapter["detachProvider"]>(async () => ({
       ok: true,
+      value: { changed: true },
     }));
     const adapter = providerAdapter({ deleteProvider, detachProvider });
 

--- a/src/lib/actions/inference-set-provider.test.ts
+++ b/src/lib/actions/inference-set-provider.test.ts
@@ -59,8 +59,9 @@ function providerAdapter(
       async () => ({ ok: true, value: { credentialKeys: [] } }) as const,
     ),
     deleteProvider: vi.fn(async () => ({ ok: true }) as const),
-    detachProvider: vi.fn(async () => ({ ok: true }) as const),
+    detachProvider: vi.fn(async () => ({ ok: true, value: { changed: true } }) as const),
     attachProvider: vi.fn(async () => ({ ok: true }) as const),
+    listProviderAttachments: vi.fn(async () => ({ ok: true, value: { names: [] } }) as const),
     configureProviderRefresh: vi.fn(async () => ({ ok: true }) as const),
     getProviderRefreshStatus: vi.fn(
       async () => ({ ok: true, value: { status: "refreshed" } }) as const,

--- a/src/lib/actions/sandbox/mcp-bridge-adapter-teardown.test.ts
+++ b/src/lib/actions/sandbox/mcp-bridge-adapter-teardown.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   assertMcpDestroyNotPending: vi.fn(),
   bridgeState: vi.fn(),
   discardSafeIncompleteMcpAdds: vi.fn(),
+  detachProvider: vi.fn(),
   ensureSandboxGatewaySelected: vi.fn(),
   getMcpProviderInspectionRuntimeSelection: vi.fn(() => ({
     gatewayName: "nemoclaw-8091",
@@ -49,7 +50,7 @@ vi.mock("./mcp-bridge-provider", () => ({
   assertMcpProviderRecoverable: vi.fn(),
   assertNoProviderCredentialCollisions: vi.fn(),
   assertNoRegisteredProviderCredentialCollisions: vi.fn(),
-  detachProvider: vi.fn(),
+  detachProvider: mocks.detachProvider,
   getMcpProviderInspectionRuntimeSelection: mocks.getMcpProviderInspectionRuntimeSelection,
   inspectMcpProvider: mocks.inspectMcpProvider,
   preflightMcpEntryTargets: mocks.preflightMcpEntryTargets,
@@ -131,6 +132,7 @@ describe("MCP adapter teardown rollback", () => {
     });
     mocks.bridgeState.mockReset().mockReturnValue({ github: entry });
     mocks.discardSafeIncompleteMcpAdds.mockReset().mockResolvedValue(sandbox);
+    mocks.detachProvider.mockReset().mockResolvedValue("detached");
     mocks.ensureSandboxGatewaySelected.mockReset().mockResolvedValue(undefined);
     mocks.getMcpProviderInspectionRuntimeSelection.mockReset().mockReturnValue(runtimeSelection);
     mocks.getBridgeAdapter.mockReset().mockReturnValue("hermes-config");
@@ -231,6 +233,22 @@ describe("MCP adapter teardown rollback", () => {
     );
     expect(events.slice(0, 2)).toEqual(["gateway-selected", "provider-inspected"]);
   });
+
+  it.each([
+    ["rebuild", prepareMcpBridgesForRebuild],
+    ["destroy", prepareMcpBridgesForDestroy],
+  ] as const)(
+    "awaits %s provider inspection before any later provider mutation (#9806)",
+    async (_lifecycle, prepare) => {
+      mocks.removeGeneratedPolicy.mockReset();
+      mocks.inspectExactMcpDestroyProvider.mockRejectedValueOnce(
+        new Error("provider inspection failed"),
+      );
+
+      await expect(prepare("alpha")).rejects.toThrow("provider inspection failed");
+      expect(mocks.detachProvider).not.toHaveBeenCalled();
+    },
+  );
 
   it.each([
     ["live", prepareMcpBridgesForRebuild],

--- a/src/lib/actions/sandbox/mcp-bridge-add-restart.ts
+++ b/src/lib/actions/sandbox/mcp-bridge-add-restart.ts
@@ -98,13 +98,13 @@ function sameMcpAddIntent(existing: McpBridgeEntry, requested: McpBridgeEntry): 
   );
 }
 
-function assertPreparedMcpAddResourcesAbsent(
+async function assertPreparedMcpAddResourcesAbsent(
   sandboxName: string,
   adapter: AgentMcpAdapter,
   entry: McpBridgeEntry,
   target: McpBridgeTargetValidation,
   providerRuntimeSelection: ReturnType<typeof getMcpProviderInspectionRuntimeSelection>,
-): void {
+): Promise<void> {
   const adapterInspection = inspectAgentAdapterRegistration(
     sandboxName,
     adapter,
@@ -121,7 +121,7 @@ function assertPreparedMcpAddResourcesAbsent(
     );
   }
 
-  const providerInspection = inspectMcpProvider(entry.providerName, providerRuntimeSelection);
+  const providerInspection = await inspectMcpProvider(entry.providerName, providerRuntimeSelection);
   if (providerInspection.exists !== false) {
     const detail =
       providerInspection.exists === null
@@ -430,11 +430,11 @@ async function addMcpBridgeUnlocked(
   assertMcpCredentialBoundaryRuntimeVersion();
   await ensureSandboxGatewaySelected(sandboxName, providerRuntimeSelection);
   if (!existingEntry) {
-    await withMcpCredentialOwnershipLock(() => {
+    await withMcpCredentialOwnershipLock(async () => {
       // Publish the durable MCP reservation under the same cross-command lock
       // used by credentials add. Neither command can pass its collision check
       // before the other records its credential-key reservation.
-      assertNoProviderCredentialCollisions(sandboxName, [entry], providerRuntimeSelection);
+      await assertNoProviderCredentialCollisions(sandboxName, [entry], providerRuntimeSelection);
       writeBridgeEntry(sandboxName, entry);
     });
   }
@@ -446,7 +446,10 @@ async function addMcpBridgeUnlocked(
   try {
     let detachedMissingProviderReference = false;
     if (resumingPreflightedAdd) {
-      const providerInspection = inspectMcpProvider(entry.providerName, providerRuntimeSelection);
+      const providerInspection = await inspectMcpProvider(
+        entry.providerName,
+        providerRuntimeSelection,
+      );
       if (providerInspection.exists === null) {
         throw new McpBridgeError(
           providerInspection.error ??
@@ -460,7 +463,7 @@ async function addMcpBridgeUnlocked(
         // one recovery side effect that must precede the image capability
         // probe. It neither reads nor replaces credential material, and the
         // durable add manifest retains ownership if the later probe fails.
-        detachMissingProviderReference(sandboxName, entry, providerRuntimeSelection);
+        await detachMissingProviderReference(sandboxName, entry, providerRuntimeSelection);
         detachedMissingProviderReference = true;
       }
     }
@@ -473,7 +476,7 @@ async function addMcpBridgeUnlocked(
         // A retry may reuse an exact provider without re-exporting its secret,
         // but recreating a missing provider cannot. This check and any owned
         // policy cleanup happen only after the running-image capability probe.
-        assertMcpProviderRecoverable(entry, providerRuntimeSelection);
+        await assertMcpProviderRecoverable(entry, providerRuntimeSelection);
       } catch (error) {
         removeGeneratedPolicy(sandboxName, entry, {
           bestEffort: true,
@@ -484,7 +487,7 @@ async function addMcpBridgeUnlocked(
     }
 
     if (entry.addState === "prepared") {
-      assertPreparedMcpAddResourcesAbsent(
+      await assertPreparedMcpAddResourcesAbsent(
         sandboxName,
         adapter,
         entry,
@@ -518,8 +521,8 @@ async function addMcpBridgeUnlocked(
     // Credential keys are sandbox-global. Prove this key is not already
     // supplied by a foreign attachment before opening its MCP route, then check
     // again after provider creation to close the intervening race.
-    assertNoProviderCredentialCollisions(sandboxName, [entry], providerRuntimeSelection);
-    ensureMcpBridgeProviderProfile(providerRuntimeSelection);
+    await assertNoProviderCredentialCollisions(sandboxName, [entry], providerRuntimeSelection);
+    await ensureMcpBridgeProviderProfile(providerRuntimeSelection);
     // Load the real protocol:mcp policy without a credential binding before
     // provider mutation. OpenShell requires the endpointless provider to be
     // attached before it accepts credential_binding.provider, and withholds
@@ -529,7 +532,7 @@ async function addMcpBridgeUnlocked(
       runtimeSelection: providerRuntimeSelection,
     });
     policyApplied = true;
-    const providerResult = upsertMcpProvider(providerName ?? "", options.env, {
+    const providerResult = await upsertMcpProvider(providerName ?? "", options.env, {
       // A first mutation must still observe the absence proven above. Only a
       // retry of the durable preflighted transaction may encounter an exact
       // provider whose immutable ID was already persisted by this add.
@@ -563,55 +566,55 @@ async function addMcpBridgeUnlocked(
       // adapter mutations. A process death before this write fails closed.
       writeBridgeEntry(sandboxName, entry);
     }
-    assertNoProviderCredentialCollisions(sandboxName, [entry], providerRuntimeSelection);
+    await assertNoProviderCredentialCollisions(sandboxName, [entry], providerRuntimeSelection);
     if (providerResult.action === "updated" && previousCredentialRevision === undefined) {
       throw new McpBridgeError(
         `Could not retain the prior OpenShell credential revision for provider '${entry.providerName}'.`,
       );
     }
     providerAttachAttempted = true;
-    attachProvider(sandboxName, entry, providerRuntimeSelection);
+    await attachProvider(sandboxName, entry, providerRuntimeSelection);
     applyGeneratedPolicy(sandboxName, entry, target, {
       runtimeSelection: providerRuntimeSelection,
     });
     let refreshedAfterObservedAbsence = false;
-    let credentialRevision = waitForAttachedMcpCredential(
+    let credentialRevision = await waitForAttachedMcpCredential(
       sandboxName,
       entry,
       providerRuntimeSelection,
       {
-      ...(providerResult.action === "updated"
-        ? {
-            previousRevision: previousCredentialRevision,
+        ...(providerResult.action === "updated"
+          ? {
+              previousRevision: previousCredentialRevision,
+            }
+          : {}),
+        // A no-field provider update advances only the provider resource version.
+        // If the credential remains available, republish it after observing an
+        // absence; otherwise, a hostless recovery advances the provider revision.
+        refreshAfterObservedAbsence: async () => {
+          refreshedAfterObservedAbsence = true;
+          // invalidState: OpenShell 0.0.106 can coalesce a no-field provider
+          // refresh without publishing the credential into fresh sandbox execs.
+          // sourceBoundary: OpenShell owns provider revision projection.
+          // whyNotSourceFix: NemoClaw can only observe absence after the bound
+          // policy is active, then republish when this process still has the host
+          // credential value. Hostless recovery retains the credential-free path.
+          // regressionTest: mcp-add-crash-consistency.test.ts covers republish
+          // and hostless recovery; mcp-provider-ownership.test.ts covers loss of
+          // the persisted provider identity before republish.
+          // removalCondition: remove the credential-bearing republish when the
+          // supported OpenShell version guarantees that a post-policy no-field
+          // refresh projects the bound credential into fresh sandbox execs.
+          const republished = await upsertMcpProvider(entry.providerName ?? "", options.env, {
+            allowExisting: true,
+            expectedProviderId: entry.providerId,
+            requireExisting: true,
+            runtimeSelection: providerRuntimeSelection,
+          });
+          if (republished.action !== "updated") {
+            await refreshMcpProviderEnvironment(entry, providerRuntimeSelection);
           }
-        : {}),
-      // A no-field provider update advances only the provider resource version.
-      // If the credential remains available, republish it after observing an
-      // absence; otherwise, a hostless recovery advances the provider revision.
-      refreshAfterObservedAbsence: () => {
-        refreshedAfterObservedAbsence = true;
-        // invalidState: OpenShell 0.0.106 can coalesce a no-field provider
-        // refresh without publishing the credential into fresh sandbox execs.
-        // sourceBoundary: OpenShell owns provider revision projection.
-        // whyNotSourceFix: NemoClaw can only observe absence after the bound
-        // policy is active, then republish when this process still has the host
-        // credential value. Hostless recovery retains the credential-free path.
-        // regressionTest: mcp-add-crash-consistency.test.ts covers republish
-        // and hostless recovery; mcp-provider-ownership.test.ts covers loss of
-        // the persisted provider identity before republish.
-        // removalCondition: remove the credential-bearing republish when the
-        // supported OpenShell version guarantees that a post-policy no-field
-        // refresh projects the bound credential into fresh sandbox execs.
-        const republished = upsertMcpProvider(entry.providerName ?? "", options.env, {
-          allowExisting: true,
-          expectedProviderId: entry.providerId,
-          requireExisting: true,
-          runtimeSelection: providerRuntimeSelection,
-        });
-        if (republished.action !== "updated") {
-          refreshMcpProviderEnvironment(entry, providerRuntimeSelection);
-        }
-      },
+        },
       },
     );
     if (Object.hasOwn(adapterEnvValues, entry.env[0]) && !refreshedAfterObservedAbsence) {
@@ -620,13 +623,13 @@ async function addMcpBridgeUnlocked(
       // bound policy is active and require a different observed revision.
       // This prevents a quick series of reads from accepting an intermediate
       // generation while the final credential-bearing update is still queued.
-      upsertMcpProvider(entry.providerName ?? "", options.env, {
+      await upsertMcpProvider(entry.providerName ?? "", options.env, {
         allowExisting: true,
         expectedProviderId: entry.providerId,
         requireExisting: true,
         runtimeSelection: providerRuntimeSelection,
       });
-      credentialRevision = waitForAttachedMcpCredential(
+      credentialRevision = await waitForAttachedMcpCredential(
         sandboxName,
         entry,
         providerRuntimeSelection,
@@ -655,7 +658,7 @@ async function addMcpBridgeUnlocked(
   } catch (error) {
     const rollbackProviderInspection =
       (providerAttachAttempted || providerCreated) && entry.providerId
-        ? inspectMcpProvider(providerName, providerRuntimeSelection)
+        ? await inspectMcpProvider(providerName, providerRuntimeSelection)
         : undefined;
     const rollbackProviderOwned =
       !!rollbackProviderInspection &&
@@ -674,7 +677,7 @@ async function addMcpBridgeUnlocked(
       });
     }
     const detachOutcome = providerAttachAttempted
-      ? detachProvider(sandboxName, entry, {
+      ? await detachProvider(sandboxName, entry, {
           bestEffort: true,
           runtimeSelection: providerRuntimeSelection,
         })
@@ -689,9 +692,9 @@ async function addMcpBridgeUnlocked(
       }
     }
     if (providerCreated && rollbackProviderOwned && reservationCleanupProved) {
-      const beforeDelete = inspectMcpProvider(providerName, providerRuntimeSelection);
+      const beforeDelete = await inspectMcpProvider(providerName, providerRuntimeSelection);
       if (providerMatchesCredential(beforeDelete, entry.env[0], entry.providerId)) {
-        deleteProvider(entry, {
+        await deleteProvider(entry, {
           allowMissing: true,
           bestEffort: true,
           runtimeSelection: providerRuntimeSelection,

--- a/src/lib/actions/sandbox/mcp-bridge-destroy-preflight.ts
+++ b/src/lib/actions/sandbox/mcp-bridge-destroy-preflight.ts
@@ -102,7 +102,7 @@ export async function discardSafeIncompleteMcpAdds(
     if (entry.addState === "prepared") continue;
     if (entry.addState === "preflighted" && !entry.providerId) {
       assertAuthenticatedBridgeEntry(entry);
-      const inspection = inspectMcpProvider(entry.providerName, providerRuntimeSelection!);
+      const inspection = await inspectMcpProvider(entry.providerName, providerRuntimeSelection!);
       if (inspection.exists === false) {
         providerlessPreflighted.push(entry);
         continue;
@@ -147,21 +147,21 @@ export function assertMcpDestroySnapshotCurrent(
   return sandbox;
 }
 
-export function inspectExactMcpDestroyProvider(
+export async function inspectExactMcpDestroyProvider(
   entry: McpBridgeEntry,
   options: {
     allowMissing: boolean;
     force?: boolean;
     runtimeSelection: McpProviderInspectionRuntimeSelection;
   },
-): McpProviderInspection {
+): Promise<McpProviderInspection> {
   assertAuthenticatedBridgeEntry(entry);
   if (!entry.providerId) {
     throw new McpBridgeError(
       `MCP server '${entry.server}' has no stable OpenShell provider ID. Refusing destructive cleanup of same-name provider '${entry.providerName}'. Remove the legacy bridge with --force only after independently cleaning that provider.`,
     );
   }
-  const inspection = inspectMcpProvider(entry.providerName, options.runtimeSelection);
+  const inspection = await inspectMcpProvider(entry.providerName, options.runtimeSelection);
   if (inspection.exists === null) {
     throw new McpBridgeError(
       inspection.error ?? `Could not inspect OpenShell provider '${entry.providerName}'.`,
@@ -216,7 +216,7 @@ export async function prepareMcpBridgesForAbsentSandboxDestroy(
     providerRuntimeSelection ??= getMcpProviderInspectionRuntimeSelection(sandbox);
   }
   for (const entry of entries) {
-    inspectExactMcpDestroyProvider(entry, {
+    await inspectExactMcpDestroyProvider(entry, {
       allowMissing: true,
       force: options.force,
       runtimeSelection: providerRuntimeSelection!,

--- a/src/lib/actions/sandbox/mcp-bridge-destroy.ts
+++ b/src/lib/actions/sandbox/mcp-bridge-destroy.ts
@@ -97,7 +97,7 @@ export async function prepareMcpBridgesForDestroy(
   // retry, a provider may therefore already be absent due to partial cleanup;
   // the retained entries are the durable, idempotent cleanup manifest.
   for (const entry of entries) {
-    inspectExactMcpDestroyProvider(entry, {
+    await inspectExactMcpDestroyProvider(entry, {
       allowMissing: destroyAlreadyPending,
       runtimeSelection: providerRuntimeSelection,
     });
@@ -280,11 +280,12 @@ export async function restoreMcpBridgesAfterDestroyAbort(
   try {
     // Reattach only the exact existing providers. This restoration path never
     // reads host secret values and therefore cannot rotate preserved credentials.
-    for (const entry of preparation.entries)
-      inspectExactMcpDestroyProvider(entry, {
+    for (const entry of preparation.entries) {
+      await inspectExactMcpDestroyProvider(entry, {
         allowMissing: false,
         runtimeSelection: providerRuntimeSelection,
       });
+    }
     await restoreExistingMcpBridgeRuntime(sandboxName, preparation.entries, {
       lifecyclePhase: "teardown-rollback",
       runtimeSelection: providerRuntimeSelection,

--- a/src/lib/actions/sandbox/mcp-bridge-destroy.ts
+++ b/src/lib/actions/sandbox/mcp-bridge-destroy.ts
@@ -148,11 +148,11 @@ export async function prepareMcpBridgesForDestroy(
       removedPolicies.push(entry);
     }
     for (const entry of entries) {
-      inspectExactMcpDestroyProvider(entry, {
+      await inspectExactMcpDestroyProvider(entry, {
         allowMissing: false,
         runtimeSelection: providerRuntimeSelection,
       });
-      const detachOutcome = detachProvider(sandboxName, entry, {
+      const detachOutcome = await detachProvider(sandboxName, entry, {
         allowLegacyGeneric: true,
         runtimeSelection: providerRuntimeSelection,
       });
@@ -357,27 +357,29 @@ export async function finalizeMcpBridgesAfterSandboxDelete(
   // Inspect every provider before deleting any so ownership drift cannot
   // produce a predictable partial cleanup. Missing is safe only now that the
   // durable pending marker proves the sandbox was already deleted.
-  const inspections = entries.map((entry) =>
-    inspectExactMcpDestroyProvider(entry, {
-      allowMissing: true,
-      force: options.force,
-      runtimeSelection: providerRuntimeSelection,
-    }),
+  const inspections = await Promise.all(
+    entries.map((entry) =>
+      inspectExactMcpDestroyProvider(entry, {
+        allowMissing: true,
+        force: options.force,
+        runtimeSelection: providerRuntimeSelection,
+      }),
+    ),
   );
   for (const [index, entry] of entries.entries()) {
     if (!inspections[index]?.exists) continue;
-    const beforeDelete = inspectExactMcpDestroyProvider(entry, {
+    const beforeDelete = await inspectExactMcpDestroyProvider(entry, {
       allowMissing: true,
       force: options.force,
       runtimeSelection: providerRuntimeSelection,
     });
     if (!beforeDelete.exists) continue;
-    deleteProvider(entry, {
+    await deleteProvider(entry, {
       allowLegacyGeneric: true,
       allowMissing: true,
       runtimeSelection: providerRuntimeSelection,
     });
-    const after = inspectMcpProvider(entry.providerName, providerRuntimeSelection);
+    const after = await inspectMcpProvider(entry.providerName, providerRuntimeSelection);
     if (after.exists !== false) {
       throw new McpBridgeError(
         after.error ??

--- a/src/lib/actions/sandbox/mcp-bridge-input-runtime.test.ts
+++ b/src/lib/actions/sandbox/mcp-bridge-input-runtime.test.ts
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it, vi } from "vitest";
+import { createCliOpenShellProviderAdapter } from "../../adapters/openshell/provider-adapter-cli";
+import { selectedOpenShellGateway } from "../../adapters/openshell/sandbox-observer";
 import * as portableAgentLifecycle from "../../onboard/experimental/portable-agent-lifecycle";
 
 import {
   addMcpBridge,
-  buildMcpBridgeProviderArgs,
   dispatchMcpBridgeCommand,
   redactCredentialValuesForDisplay,
   removeMcpBridge,
@@ -33,9 +34,7 @@ describe("MCP input runtime boundaries", () => {
         env: [{ name: "TOKEN" }],
       }),
     ).rejects.toThrow("schema-5 rejected");
-    await expect(removeMcpBridge("missing-sandbox", "github")).rejects.toThrow(
-      "schema-5 rejected",
-    );
+    await expect(removeMcpBridge("missing-sandbox", "github")).rejects.toThrow("schema-5 rejected");
     await expect(restartMcpBridge("missing-sandbox", "github")).rejects.toThrow(
       "schema-5 rejected",
     );
@@ -91,14 +90,20 @@ describe("MCP input runtime boundaries", () => {
     expect(output).not.toContain("inline-secret-value");
   });
 
-  it("passes MCP provider credentials by environment name, not argv value", () => {
-    const args = buildMcpBridgeProviderArgs(
-      "create",
-      "alpha-mcp-github",
-      [{ name: "TOKEN", value: "inline-secret-value" }],
-      { TOKEN: "inline-secret-value" },
-    );
+  it("passes MCP provider credentials by environment name, not argv value", async () => {
+    const run = vi.fn((_args: string[]) => ({ status: 0, stdout: "", stderr: "" }));
+    const adapter = createCliOpenShellProviderAdapter({ run });
 
+    await adapter.createProvider({
+      name: "alpha-mcp-github",
+      type: "nemoclaw-mcp-v1",
+      credentials: [{ name: "TOKEN", value: "inline-secret-value" }],
+      config: [],
+      fromExisting: false,
+      target: selectedOpenShellGateway(),
+    });
+
+    const args = run.mock.calls[0]?.[0] ?? [];
     expect(args).toEqual([
       "provider",
       "create",

--- a/src/lib/actions/sandbox/mcp-bridge-input-validation.test.ts
+++ b/src/lib/actions/sandbox/mcp-bridge-input-validation.test.ts
@@ -8,7 +8,6 @@ import {
   SUBPROCESS_ENV_ALLOWED_PREFIXES,
 } from "../../subprocess-env";
 import {
-  buildMcpBridgeProviderArgs,
   MCP_SERVER_URL_MAX_LENGTH,
   normalizeMcpServerUrl,
   parseMcpAddArgs,
@@ -207,11 +206,6 @@ describe("MCP CLI input validation", () => {
       expect(() => resolveCredentialEnv([{ name, value: "host-only-secret" }])).toThrow(
         /would be skipped instead of attached/,
       );
-      expect(() =>
-        buildMcpBridgeProviderArgs("create", "provider", [{ name }], {
-          [name]: "host-only-secret",
-        }),
-      ).toThrow(/reserved for OpenShell credential revisions/);
     },
   );
 
@@ -231,11 +225,6 @@ describe("MCP CLI input validation", () => {
         parseMcpAddArgs(["github", "--url", "https://mcp.example.test/mcp", ...envArgs]),
       ).toThrow(error);
       expect(() => resolveCredentialEnv([{ name, value: "host-only-secret" }])).toThrow(error);
-      expect(() =>
-        buildMcpBridgeProviderArgs("create", "provider", [{ name }], {
-          [name]: "host-only-secret",
-        }),
-      ).toThrow(error);
     },
   );
 
@@ -273,11 +262,6 @@ describe("MCP CLI input validation", () => {
     expect(() => resolveCredentialEnv([{ name, value: "host-only-secret" }])).toThrow(
       /could alter or prevent agent commands/,
     );
-    expect(() =>
-      buildMcpBridgeProviderArgs("create", "provider", [{ name }], {
-        [name]: "host-only-secret",
-      }),
-    ).toThrow(/reserved for sandbox runtime control/);
   });
 
   it("rejects host stdio commands", () => {

--- a/src/lib/actions/sandbox/mcp-bridge-provider-attachments.ts
+++ b/src/lib/actions/sandbox/mcp-bridge-provider-attachments.ts
@@ -7,12 +7,11 @@
  * this compensation until attachment mutations expose an immutable-ID CAS API.
  */
 
-import { stripAnsi } from "../../adapters/openshell/client";
-import { runOpenshellProviderCommand } from "../../adapters/openshell/provider-command";
+import type { OpenShellProviderAdapter } from "../../adapters/openshell/provider-adapter";
 import type { McpBridgeEntry } from "../../state/registry";
 import { McpBridgeError } from "./mcp-bridge-contracts";
-import { commandOutput, type OpenShellCommandResult } from "./mcp-bridge-output";
 import {
+  createMcpProviderAdapterBoundary,
   inspectMcpProvider,
   inspectMcpProviderAttachments,
   type McpProviderAttachment,
@@ -27,12 +26,17 @@ import {
   assertPersistedAuthenticatedBridgeEntry,
 } from "./mcp-bridge-validation";
 
-function exactAttachment(
+async function exactAttachment(
   sandboxName: string,
   entry: McpBridgeEntry,
   runtimeSelection: McpProviderInspectionRuntimeSelection,
-): { inspection: McpProviderAttachmentInspection; attachment?: McpProviderAttachment } {
-  const inspection = inspectMcpProviderAttachments(sandboxName, runtimeSelection);
+  providerAdapter?: OpenShellProviderAdapter,
+): Promise<{ inspection: McpProviderAttachmentInspection; attachment?: McpProviderAttachment }> {
+  const inspection = await inspectMcpProviderAttachments(
+    sandboxName,
+    runtimeSelection,
+    providerAdapter,
+  );
   return {
     inspection,
     attachment: inspection.attachments?.find(
@@ -54,11 +58,12 @@ function attachmentMatchesCurrentProviderSnapshot(
   );
 }
 
-export function attachProvider(
+export async function attachProvider(
   sandboxName: string,
   entry: McpBridgeEntry,
   runtimeSelection: McpProviderInspectionRuntimeSelection,
-): void {
+  providerAdapter?: OpenShellProviderAdapter,
+): Promise<void> {
   if (!entry.providerName) return;
   assertAuthenticatedBridgeEntry(entry);
   if (!entry.providerId) {
@@ -66,7 +71,12 @@ export function attachProvider(
       `MCP server '${entry.server}' has no stable OpenShell provider ID. Refusing to attach same-name provider '${entry.providerName}'.`,
     );
   }
-  const inspection = inspectMcpProvider(entry.providerName, runtimeSelection);
+  const boundary = createMcpProviderAdapterBoundary(runtimeSelection, providerAdapter);
+  const inspection = await inspectMcpProvider(
+    entry.providerName,
+    runtimeSelection,
+    boundary.adapter,
+  );
   if (inspection.exists === false) {
     throw new McpBridgeError(
       `OpenShell provider '${entry.providerName}' disappeared before attach.`,
@@ -80,21 +90,26 @@ export function attachProvider(
   if (!inspection.id || !inspection.resourceVersion) {
     throw new McpBridgeError(`OpenShell provider '${entry.providerName}' has incomplete metadata.`);
   }
-  const result = runOpenshellProviderCommand(
-    ["sandbox", "provider", "attach", sandboxName, entry.providerName],
-    { ignoreError: true, runtimeSelection, stdio: ["ignore", "pipe", "pipe"] },
-  ) as OpenShellCommandResult;
-  if (result.status !== 0) {
-    const output = commandOutput(result);
-    const afterError = exactAttachment(sandboxName, entry, runtimeSelection);
+  const result = await boundary.adapter.attachProvider({
+    providerName: entry.providerName,
+    sandboxName,
+    target: boundary.target,
+  });
+  if (!result.ok) {
+    const afterError = await exactAttachment(
+      sandboxName,
+      entry,
+      runtimeSelection,
+      boundary.adapter,
+    );
     if (attachmentMatchesCurrentProviderSnapshot(afterError.attachment, entry)) return;
     throw new McpBridgeError(
-      output ||
+      result.error.message ||
         afterError.inspection.error ||
         `Failed to attach MCP provider '${entry.providerName}'.`,
     );
   }
-  const after = exactAttachment(sandboxName, entry, runtimeSelection);
+  const after = await exactAttachment(sandboxName, entry, runtimeSelection, boundary.adapter);
   if (!attachmentMatchesCurrentProviderSnapshot(after.attachment, entry)) {
     throw new McpBridgeError(
       after.inspection.error ??
@@ -103,35 +118,20 @@ export function attachProvider(
   }
 }
 
-export function providerDetachChangedState(status: number | null, output: string): boolean {
-  return (
-    status === 0 &&
-    !/\bwas\s+not\s+attached\b|\balready\s+detached\b|\bNotAttached\b/i.test(stripAnsi(output))
-  );
-}
-
 export type ProviderDetachOutcome = "detached" | "absent" | "unknown";
 
 const MCP_PROVIDER_DETACH_ATTEMPTS = 2;
 
-function isRetryableSandboxMutationConflict(status: number | null, output: string): boolean {
-  return (
-    status !== 0 &&
-    /Failed to detach provider:\s*sandbox was modified by another operation\.\s*Please retry the command\.?/i.test(
-      stripAnsi(output),
-    )
-  );
-}
-
-export function detachProvider(
+export async function detachProvider(
   sandboxName: string,
   entry: McpBridgeEntry,
   options: {
     allowLegacyGeneric?: boolean;
     bestEffort?: boolean;
     runtimeSelection: McpProviderInspectionRuntimeSelection;
+    providerAdapter?: OpenShellProviderAdapter;
   },
-): ProviderDetachOutcome {
+): Promise<ProviderDetachOutcome> {
   if (!entry.providerName) return "absent";
   assertPersistedAuthenticatedBridgeEntry(entry);
   if (!entry.providerId) {
@@ -140,8 +140,16 @@ export function detachProvider(
       `MCP server '${entry.server}' has no recorded provider ID for prechecked detach.`,
     );
   }
+  const boundary = createMcpProviderAdapterBoundary(
+    options.runtimeSelection,
+    options.providerAdapter,
+  );
   for (let attempt = 0; attempt < MCP_PROVIDER_DETACH_ATTEMPTS; attempt += 1) {
-    const provider = inspectMcpProvider(entry.providerName, options.runtimeSelection);
+    const provider = await inspectMcpProvider(
+      entry.providerName,
+      options.runtimeSelection,
+      boundary.adapter,
+    );
     if (
       !providerMatchesManagedCredential(provider, entry.env[0], entry.providerId, {
         allowLegacyGeneric: options.allowLegacyGeneric,
@@ -152,7 +160,12 @@ export function detachProvider(
         `OpenShell provider '${entry.providerName}' changed before detach. ${providerShapeDetail(provider, entry.env[0], entry.providerId)} Refusing to mutate it.`,
       );
     }
-    const before = exactAttachment(sandboxName, entry, options.runtimeSelection);
+    const before = await exactAttachment(
+      sandboxName,
+      entry,
+      options.runtimeSelection,
+      boundary.adapter,
+    );
     if (!before.inspection.attachments) {
       if (options.bestEffort) return "unknown";
       throw new McpBridgeError(
@@ -166,31 +179,33 @@ export function detachProvider(
         `Provider attachment '${entry.providerName}' does not match MCP server '${entry.server}'. Expected stable provider ID '${entry.providerId}', found '${before.attachment.providerId ?? "missing"}', with credential keys '${before.attachment.credentialKeys.join(", ") || "none"}'.`,
       );
     }
-    const result = runOpenshellProviderCommand(
-      ["sandbox", "provider", "detach", sandboxName, entry.providerName],
-      {
-        ignoreError: true,
-        runtimeSelection: options.runtimeSelection,
-        stdio: ["ignore", "pipe", "pipe"],
-        suppressOutput: true,
-      } as Record<string, unknown>,
-    ) as OpenShellCommandResult;
-    const output = commandOutput(result);
-    const after = exactAttachment(sandboxName, entry, options.runtimeSelection);
+    const result = await boundary.adapter.detachProvider({
+      providerName: entry.providerName,
+      sandboxName,
+      target: boundary.target,
+    });
+    const after = await exactAttachment(
+      sandboxName,
+      entry,
+      options.runtimeSelection,
+      boundary.adapter,
+    );
     if (after.inspection.attachments && !after.attachment) {
-      return providerDetachChangedState(result.status, output) ? "detached" : "absent";
+      return result.ok && result.value.changed ? "detached" : "absent";
     }
     if (
       attempt + 1 < MCP_PROVIDER_DETACH_ATTEMPTS &&
       after.inspection.attachments &&
       attachmentMatchesCurrentProviderSnapshot(after.attachment, entry) &&
-      isRetryableSandboxMutationConflict(result.status, output)
+      !result.ok &&
+      result.error.kind === "command" &&
+      result.error.reason === "conflict"
     ) {
       continue;
     }
     if (options.bestEffort) return "unknown";
     throw new McpBridgeError(
-      output ||
+      (!result.ok ? result.error.message : "") ||
         after.inspection.error ||
         `OpenShell did not confirm removal of provider attachment '${entry.providerName}'.`,
     );
@@ -204,14 +219,16 @@ export function detachProvider(
  * list attachments while a referenced provider is missing, but its detach
  * command removes the name directly from the sandbox spec under CAS.
  */
-export function detachMissingProviderReference(
+export async function detachMissingProviderReference(
   sandboxName: string,
   entry: McpBridgeEntry,
   runtimeSelection: McpProviderInspectionRuntimeSelection,
-): ProviderDetachOutcome {
+  providerAdapter?: OpenShellProviderAdapter,
+): Promise<ProviderDetachOutcome> {
   if (!entry.providerName) return "absent";
   assertPersistedAuthenticatedBridgeEntry(entry);
-  const before = inspectMcpProvider(entry.providerName, runtimeSelection);
+  const boundary = createMcpProviderAdapterBoundary(runtimeSelection, providerAdapter);
+  const before = await inspectMcpProvider(entry.providerName, runtimeSelection, boundary.adapter);
   if (before.exists !== false) {
     const detail =
       before.exists === null
@@ -221,28 +238,27 @@ export function detachMissingProviderReference(
       `OpenShell provider '${entry.providerName}' is not provably absent before dangling-reference cleanup: ${detail}.`,
     );
   }
-  const result = runOpenshellProviderCommand(
-    ["sandbox", "provider", "detach", sandboxName, entry.providerName],
-    { ignoreError: true, runtimeSelection, stdio: ["ignore", "pipe", "pipe"] },
-  ) as OpenShellCommandResult;
-  const output = commandOutput(result);
-  if (result.status !== 0) {
+  const result = await boundary.adapter.detachProvider({
+    providerName: entry.providerName,
+    sandboxName,
+    target: boundary.target,
+  });
+  if (!result.ok) {
     throw new McpBridgeError(
-      output || `Failed to remove dangling provider reference '${entry.providerName}'.`,
+      result.error.message ||
+        `Failed to remove dangling provider reference '${entry.providerName}'.`,
     );
   }
-  const afterProvider = inspectMcpProvider(entry.providerName, runtimeSelection);
+  const afterProvider = await inspectMcpProvider(
+    entry.providerName,
+    runtimeSelection,
+    boundary.adapter,
+  );
   if (afterProvider.exists !== false) {
     throw new McpBridgeError(
       afterProvider.error ??
         `A same-name provider appeared while removing dangling reference '${entry.providerName}'. Refusing to create or adopt it.`,
     );
   }
-  const cleanOutput = stripAnsi(output);
-  if (!/\bDetached provider\b|\bwas not attached to sandbox\b/i.test(cleanOutput)) {
-    throw new McpBridgeError(
-      `OpenShell returned an unrecognized result while removing dangling provider reference '${entry.providerName}'.`,
-    );
-  }
-  return providerDetachChangedState(result.status, output) ? "detached" : "absent";
+  return result.value.changed ? "detached" : "absent";
 }

--- a/src/lib/actions/sandbox/mcp-bridge-provider-inspection.test.ts
+++ b/src/lib/actions/sandbox/mcp-bridge-provider-inspection.test.ts
@@ -14,6 +14,7 @@ import {
 } from "./mcp-bridge-provider-inspection";
 
 const temporaryDirectories: string[] = [];
+const runtimeSelection = { gatewayName: "nemoclaw-8080", workspace: "default" } as const;
 
 afterEach(() => {
   setProviderCommandRuntimeHooksForTest({});
@@ -156,7 +157,7 @@ describe("MCP provider runtime selection", () => {
 });
 
 describe("MCP provider absence inspection", () => {
-  it("accepts only an exact provider-specific absence diagnostic (#10514)", () => {
+  it("accepts only an exact provider-specific absence diagnostic (#10514)", async () => {
     setProviderCommandRuntimeHooksForTest({
       runOpenshell: (() => ({
         status: 1,
@@ -165,7 +166,7 @@ describe("MCP provider absence inspection", () => {
       })) as never,
     });
 
-    expect(inspectMcpProvider("alpha-mcp-fake")).toEqual({
+    await expect(inspectMcpProvider("alpha-mcp-fake", runtimeSelection)).resolves.toEqual({
       exists: false,
       id: null,
       resourceVersion: null,
@@ -181,20 +182,20 @@ describe("MCP provider absence inspection", () => {
     'status: NotFound, message: "gateway not found"',
     "workspace 'default' does not exist",
     "transport unavailable",
-  ])("keeps ambiguous lookup failure indeterminate: %s (#10514)", (diagnostic) => {
+  ])("keeps ambiguous lookup failure indeterminate: %s (#10514)", async (diagnostic) => {
     setProviderCommandRuntimeHooksForTest({
       runOpenshell: (() => ({ status: 1, stdout: "", stderr: diagnostic })) as never,
     });
 
-    expect(inspectMcpProvider("alpha-mcp-fake")).toMatchObject({
+    await expect(inspectMcpProvider("alpha-mcp-fake", runtimeSelection)).resolves.toMatchObject({
       exists: null,
-      error: diagnostic,
+      error: expect.any(String),
     });
   });
 
   it.each([null, 2])(
     "keeps exact-looking absence indeterminate for noncanonical exit %s (#10514)",
-    (status) => {
+    async (status) => {
       setProviderCommandRuntimeHooksForTest({
         runOpenshell: (() => ({
           status,
@@ -203,9 +204,9 @@ describe("MCP provider absence inspection", () => {
         })) as never,
       });
 
-      expect(inspectMcpProvider("alpha-mcp-fake")).toMatchObject({
+      await expect(inspectMcpProvider("alpha-mcp-fake", runtimeSelection)).resolves.toMatchObject({
         exists: null,
-        error: "provider 'alpha-mcp-fake' not found",
+        error: expect.any(String),
       });
     },
   );

--- a/src/lib/actions/sandbox/mcp-bridge-provider-inspection.ts
+++ b/src/lib/actions/sandbox/mcp-bridge-provider-inspection.ts
@@ -5,14 +5,18 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { stripAnsi } from "../../adapters/openshell/client";
+import type { OpenShellProviderAdapter } from "../../adapters/openshell/provider-adapter";
+import {
+  createCliOpenShellProviderAdapter,
+  type RunProviderCommand,
+} from "../../adapters/openshell/provider-adapter-cli";
 import {
   type OpenShellRuntimeSelection,
   runOpenshellProviderCommand,
 } from "../../adapters/openshell/provider-command";
+import { selectedOpenShellGateway } from "../../adapters/openshell/sandbox-observer";
 import { OPENSHELL_DEFAULT_WORKSPACE } from "../../adapters/openshell/sandbox-ssh-host";
 import { getDockerDriverGatewayLocalTlsDir } from "../../onboard/docker-driver-gateway-local-tls";
-import { reportsExactProviderNotFound } from "../../adapters/openshell/provider-diagnostic-cli";
 import { resolveGatewayStateDirForPort } from "../../onboard/gateway/state-dir";
 import { resolveGatewayCredentialMutationAuthority } from "../../onboard/gateway-teardown-authority";
 import {
@@ -24,7 +28,6 @@ import { replayTrustedPrivateEndpoint } from "../../security/trusted-private-end
 import { listExtraProviders, type McpBridgeEntry, type SandboxEntry } from "../../state/registry";
 import { getPersistedSandboxTargetGateway } from "./gateway-target";
 import { McpBridgeError } from "./mcp-bridge-contracts";
-import { commandOutput, type OpenShellCommandResult } from "./mcp-bridge-output";
 import type { McpBridgeTargetValidation } from "./mcp-bridge-url-validation";
 import {
   assertAuthenticatedBridgeEntry,
@@ -58,6 +61,29 @@ export type McpProviderInspectionRuntimeSelection = OpenShellRuntimeSelection;
 
 const GATEWAY_CLIENT_TLS_FILES = ["ca.crt", "client/tls.crt", "client/tls.key"] as const;
 
+export function createMcpProviderAdapterBoundary(
+  runtimeSelection: OpenShellRuntimeSelection,
+  adapter?: OpenShellProviderAdapter,
+): Readonly<{
+  adapter: OpenShellProviderAdapter;
+  target: ReturnType<typeof selectedOpenShellGateway>;
+}> {
+  return {
+    adapter:
+      adapter ??
+      createCliOpenShellProviderAdapter({
+        run: ((args, options) =>
+          runOpenshellProviderCommand(args, {
+            ...options,
+            runtimeSelection,
+          })) as RunProviderCommand,
+      }),
+    // The command runner owns the exact gateway, workspace, and TLS
+    // selection, so the CLI adapter must not add a second selector.
+    target: selectedOpenShellGateway(),
+  };
+}
+
 function readableGatewayClientTlsDir(localTlsDir: string, required: boolean): string | undefined {
   const observations = GATEWAY_CLIENT_TLS_FILES.map((relativePath) => {
     const filePath = path.join(localTlsDir, relativePath);
@@ -74,10 +100,7 @@ function readableGatewayClientTlsDir(localTlsDir: string, required: boolean): st
     return undefined;
   }
   const unreadable = observations.find(({ readable }) => !readable)?.filePath ?? localTlsDir;
-  throw new McpBridgeError(
-    `OpenShell gateway TLS file is missing or unreadable: ${unreadable}`,
-    1,
-  );
+  throw new McpBridgeError(`OpenShell gateway TLS file is missing or unreadable: ${unreadable}`, 1);
 }
 
 function providerRuntimeLocalTlsDir(
@@ -89,7 +112,10 @@ function providerRuntimeLocalTlsDir(
     if (!configuration.ok) throw new McpBridgeError(configuration.message, 1);
     if (!owner.endpoint || new URL(owner.endpoint).protocol !== "https:") return undefined;
     if (!owner.stateDir) {
-      throw new McpBridgeError("Externally supervised HTTPS gateway requires a state directory.", 1);
+      throw new McpBridgeError(
+        "Externally supervised HTTPS gateway requires a state directory.",
+        1,
+      );
     }
     return readableGatewayClientTlsDir(path.join(owner.stateDir, "tls"), true);
   }
@@ -119,39 +145,11 @@ export function getMcpProviderInspectionRuntimeSelection(
   };
 }
 
-const MCP_PROVIDER_ID_RE = /^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$/;
-
-export function parseMcpProviderMetadata(output: string): Omit<McpProviderInspection, "exists"> {
-  const clean = stripAnsi(output).replace(/\r/g, "");
-  const idMatch = clean.match(/^\s*Id:\s*(\S.*?)\s*$/m);
-  const resourceVersionMatch = clean.match(/^\s*Resource version:\s*(\d+)\s*$/m);
-  const typeMatch = clean.match(/^\s*Type:\s*(\S.*?)\s*$/m);
-  const credentialMatch = clean.match(/^\s*Credential keys:\s*(.*?)\s*$/m);
-  const rawId = idMatch?.[1]?.trim();
-  const parsedResourceVersion = resourceVersionMatch
-    ? Number.parseInt(resourceVersionMatch[1] ?? "", 10)
-    : null;
-  const rawKeys = credentialMatch?.[1]?.trim();
-  return {
-    id: rawId && MCP_PROVIDER_ID_RE.test(rawId) ? rawId : null,
-    resourceVersion:
-      parsedResourceVersion !== null && Number.isSafeInteger(parsedResourceVersion)
-        ? parsedResourceVersion
-        : null,
-    type: typeMatch?.[1]?.trim() || null,
-    credentialKeys:
-      rawKeys === undefined
-        ? null
-        : rawKeys === "<none>" || rawKeys === ""
-          ? []
-          : rawKeys.split(",").map((key) => key.trim()),
-  };
-}
-
-export function inspectMcpProvider(
+export async function inspectMcpProvider(
   providerName: string | undefined,
   runtimeSelection?: McpProviderInspectionRuntimeSelection,
-): McpProviderInspection {
+  providerAdapter?: OpenShellProviderAdapter,
+): Promise<McpProviderInspection> {
   if (!providerName) {
     return {
       exists: false,
@@ -161,14 +159,13 @@ export function inspectMcpProvider(
       credentialKeys: null,
     };
   }
-  const result = runOpenshellProviderCommand(["provider", "get", providerName], {
-    ignoreError: true,
-    runtimeSelection,
-    stdio: ["ignore", "pipe", "pipe"],
-  }) as OpenShellCommandResult;
-  if (result.status !== 0) {
-    const output = commandOutput(result);
-    if (result.status === 1 && reportsExactProviderNotFound(output, providerName, output.length)) {
+  if (!runtimeSelection) {
+    throw new McpBridgeError("MCP provider inspection requires an OpenShell runtime target.");
+  }
+  const { adapter, target } = createMcpProviderAdapterBoundary(runtimeSelection, providerAdapter);
+  const result = await adapter.getProvider({ providerName, target });
+  if (!result.ok) {
+    if (result.error.kind === "command" && result.error.reason === "not_found") {
       return {
         exists: false,
         id: null,
@@ -183,69 +180,54 @@ export function inspectMcpProvider(
       resourceVersion: null,
       type: null,
       credentialKeys: null,
-      error: output || `Could not inspect OpenShell provider '${providerName}'.`,
+      error: result.error.message,
     };
   }
   return {
     exists: true,
-    ...parseMcpProviderMetadata(commandOutput(result)),
+    id: result.value.revision?.id ?? null,
+    resourceVersion: result.value.revision?.resourceVersion ?? null,
+    type: result.value.type,
+    credentialKeys: [...result.value.credentialKeys],
   };
 }
 
-export function parseMcpProviderAttachmentNames(output: string): string[] {
-  const clean = stripAnsi(output).replace(/\r/g, "").trim();
-  if (/^No providers attached to sandbox\b/m.test(clean)) return [];
-  const lines = clean
-    .split("\n")
-    .map((line) => line.trim())
-    .filter(Boolean);
-  const headerIndex = lines.findIndex((line) =>
-    /^NAME\s+TYPE\s+CREDENTIAL_KEYS\s+CONFIG_KEYS$/.test(line),
-  );
-  if (headerIndex < 0) throw new Error("missing provider attachment table header");
-  return lines.slice(headerIndex + 1).map((line) => {
-    const match = line.match(/^(\S+)\s+(\S+)\s+(\d+)\s+(\d+)$/);
-    if (!match?.[1]) throw new Error("invalid provider attachment table row");
-    return match[1];
-  });
-}
-
-export function inspectMcpProviderAttachments(
+export async function inspectMcpProviderAttachments(
   sandboxName: string,
   runtimeSelection?: McpProviderInspectionRuntimeSelection,
-): McpProviderAttachmentInspection {
-  const result = runOpenshellProviderCommand(["sandbox", "provider", "list", sandboxName], {
-    ignoreError: true,
-    runtimeSelection,
-    stdio: ["ignore", "pipe", "pipe"],
-  }) as OpenShellCommandResult;
-  const output = commandOutput(result);
-  if (result.status !== 0) {
-    return { attachments: null, error: output || "provider attachment inspection failed" };
+  providerAdapter?: OpenShellProviderAdapter,
+): Promise<McpProviderAttachmentInspection> {
+  if (!runtimeSelection) {
+    return {
+      attachments: null,
+      error: "MCP provider inspection requires an OpenShell runtime target.",
+    };
   }
+  const { adapter, target } = createMcpProviderAdapterBoundary(runtimeSelection, providerAdapter);
+  const result = await adapter.listProviderAttachments({ sandboxName, target });
+  if (!result.ok) return { attachments: null, error: result.error.message };
   try {
-    const clean = stripAnsi(output).replace(/\r/g, "").trim();
-    if (/^No providers attached to sandbox\b/m.test(clean)) return { attachments: [] };
-    const names = parseMcpProviderAttachmentNames(clean);
-    const attachments = names.map((name) => {
-      const provider = inspectMcpProvider(name, runtimeSelection);
-      if (
-        provider.exists !== true ||
-        !provider.id ||
-        !provider.resourceVersion ||
-        !provider.type ||
-        !provider.credentialKeys
-      ) {
-        throw new Error(
-          provider.error ?? `attached provider '${name}' disappeared or has incomplete metadata`,
-        );
-      }
-      return {
-        name,
-        providerId: provider.id,
-        credentialKeys: provider.credentialKeys,
-      };
-    });
+    const attachments = await Promise.all(
+      result.value.names.map(async (name) => {
+        const provider = await inspectMcpProvider(name, runtimeSelection, adapter);
+        if (
+          provider.exists !== true ||
+          !provider.id ||
+          !provider.resourceVersion ||
+          !provider.type ||
+          !provider.credentialKeys
+        ) {
+          throw new Error(
+            provider.error ?? `attached provider '${name}' disappeared or has incomplete metadata`,
+          );
+        }
+        return {
+          name,
+          providerId: provider.id,
+          credentialKeys: provider.credentialKeys,
+        };
+      }),
+    );
     return { attachments };
   } catch (error) {
     return {
@@ -255,14 +237,14 @@ export function inspectMcpProviderAttachments(
   }
 }
 
-export function assertNoAttachedProviderCredentialCollisions(
+export async function assertNoAttachedProviderCredentialCollisions(
   sandboxName: string,
   entries: readonly McpBridgeEntry[],
   runtimeSelection: McpProviderInspectionRuntimeSelection,
-): void {
+): Promise<void> {
   if (entries.length === 0) return;
   for (const entry of entries) assertAuthenticatedBridgeEntry(entry);
-  const inspection = inspectMcpProviderAttachments(sandboxName, runtimeSelection);
+  const inspection = await inspectMcpProviderAttachments(sandboxName, runtimeSelection);
   if (!inspection.attachments) {
     throw new McpBridgeError(
       inspection.error ?? `Could not inspect providers attached to sandbox '${sandboxName}'.`,
@@ -283,14 +265,14 @@ export function assertNoAttachedProviderCredentialCollisions(
   }
 }
 
-export function assertNoRegisteredProviderCredentialCollisions(
+export async function assertNoRegisteredProviderCredentialCollisions(
   entries: readonly McpBridgeEntry[],
   deps: {
     listExtraProviders?: () => string[];
-    inspectProvider?: (providerName: string) => McpProviderInspection;
+    inspectProvider?: (providerName: string) => Promise<McpProviderInspection>;
     runtimeSelection?: McpProviderInspectionRuntimeSelection;
   } = {},
-): void {
+): Promise<void> {
   if (entries.length === 0) return;
   for (const entry of entries) assertAuthenticatedBridgeEntry(entry);
   const queryExtraProviders = deps.listExtraProviders ?? listExtraProviders;
@@ -298,7 +280,7 @@ export function assertNoRegisteredProviderCredentialCollisions(
     deps.inspectProvider ??
     ((providerName: string) => inspectMcpProvider(providerName, deps.runtimeSelection));
   for (const providerName of queryExtraProviders()) {
-    const provider = inspectProvider(providerName);
+    const provider = await inspectProvider(providerName);
     if (provider.exists === false) continue;
     if (provider.exists !== true || !provider.id || !provider.credentialKeys) {
       throw new McpBridgeError(
@@ -320,13 +302,13 @@ export function assertNoRegisteredProviderCredentialCollisions(
   }
 }
 
-export function assertNoProviderCredentialCollisions(
+export async function assertNoProviderCredentialCollisions(
   sandboxName: string,
   entries: readonly McpBridgeEntry[],
   runtimeSelection: McpProviderInspectionRuntimeSelection,
-): void {
-  assertNoAttachedProviderCredentialCollisions(sandboxName, entries, runtimeSelection);
-  assertNoRegisteredProviderCredentialCollisions(entries, { runtimeSelection });
+): Promise<void> {
+  await assertNoAttachedProviderCredentialCollisions(sandboxName, entries, runtimeSelection);
+  await assertNoRegisteredProviderCredentialCollisions(entries, { runtimeSelection });
 }
 
 export function providerMatchesCredential(
@@ -400,10 +382,10 @@ export function providerShapeDetail(
   return `Expected ${MCP_BRIDGE_PROVIDER_TYPE} provider with only credential key '${expectedCredential ?? "<missing>"}', found type '${type}' with keys '${keys}'.`;
 }
 
-export function assertMcpProviderRecoverable(
+export async function assertMcpProviderRecoverable(
   entry: McpBridgeEntry,
   runtimeSelection: McpProviderInspectionRuntimeSelection,
-): McpProviderInspection {
+): Promise<McpProviderInspection> {
   assertAuthenticatedBridgeEntry(entry);
   if (!entry.providerId) {
     throw new McpBridgeError(
@@ -411,7 +393,7 @@ export function assertMcpProviderRecoverable(
     );
   }
   const expectedCredential = entry.env[0];
-  const inspection = inspectMcpProvider(entry.providerName, runtimeSelection);
+  const inspection = await inspectMcpProvider(entry.providerName, runtimeSelection);
   if (inspection.exists === null) {
     throw new McpBridgeError(
       inspection.error ?? `Could not inspect OpenShell provider '${entry.providerName}'.`,
@@ -500,13 +482,13 @@ export async function preflightMcpEntryTargets(
   return new Map(results);
 }
 
-export function providerAttached(
+export async function providerAttached(
   sandboxName: string,
   providerName: string | undefined,
   runtimeSelection?: McpProviderInspectionRuntimeSelection,
-): boolean | null {
+): Promise<boolean | null> {
   if (!providerName) return null;
-  const inspection = inspectMcpProviderAttachments(sandboxName, runtimeSelection);
+  const inspection = await inspectMcpProviderAttachments(sandboxName, runtimeSelection);
   if (!inspection.attachments) return null;
   return inspection.attachments.some((attachment) => attachment.name === providerName);
 }

--- a/src/lib/actions/sandbox/mcp-bridge-provider-mutation.ts
+++ b/src/lib/actions/sandbox/mcp-bridge-provider-mutation.ts
@@ -15,18 +15,14 @@
  * targets.
  */
 
-import { runOpenshellProviderCommand } from "../../adapters/openshell/provider-command";
+import type { OpenShellProviderAdapter } from "../../adapters/openshell/provider-adapter";
 import { endpointlessProviderProfilePath } from "../../adapters/openshell/provider-profile";
-import {
-  checkOpenAiInferenceProviderProfile,
-  registerCheckedInProviderProfile,
-} from "../../adapters/openshell/provider-profile-registration";
+import { OPENAI_GATEWAY_PROVIDER_TYPE } from "../../adapters/openshell/provider-profile-registration";
 import { REPOSITORY_ROOT } from "../../core/repository-root";
-import { reportsExactProviderNotFound } from "../../adapters/openshell/provider-diagnostic-cli";
 import type { McpBridgeEntry } from "../../state/registry";
 import { McpBridgeError, type ParsedEnvReference } from "./mcp-bridge-contracts";
-import { commandOutput, type OpenShellCommandResult } from "./mcp-bridge-output";
 import {
+  createMcpProviderAdapterBoundary,
   inspectMcpProvider,
   MCP_BRIDGE_PROVIDER_TYPE,
   type McpProviderInspectionRuntimeSelection,
@@ -47,7 +43,6 @@ export {
   attachProvider,
   detachMissingProviderReference,
   detachProvider,
-  providerDetachChangedState,
 } from "./mcp-bridge-provider-attachments";
 
 /**
@@ -69,70 +64,50 @@ export {
  * removalCondition: remove this import when the minimum supported OpenShell
  * release classifies the `openai` inference credential as gateway-only itself.
  */
-function ensureOpenAiGatewayProviderProfile(
+async function ensureOpenAiGatewayProviderProfile(
   runtimeSelection: McpProviderInspectionRuntimeSelection,
-): void {
-  const result = checkOpenAiInferenceProviderProfile({
-    runOpenshell: (args, options) =>
-      runOpenshellProviderCommand(args, {
-        ...options,
-        runtimeSelection,
-      }) as OpenShellCommandResult,
+  providerAdapter?: OpenShellProviderAdapter,
+): Promise<void> {
+  const { adapter, target } = createMcpProviderAdapterBoundary(runtimeSelection, providerAdapter);
+  const result = await adapter.importProviderProfile({
+    profilePath: endpointlessProviderProfilePath(REPOSITORY_ROOT, OPENAI_GATEWAY_PROVIDER_TYPE),
+    target,
   });
   if (result.ok) return;
-  throw new McpBridgeError(result.messages.join("\n"));
-}
-
-/** Ensure the endpointless profile required by OpenShell static credential binding. */
-export function ensureMcpBridgeProviderProfile(
-  runtimeSelection: McpProviderInspectionRuntimeSelection,
-): void {
-  ensureOpenAiGatewayProviderProfile(runtimeSelection);
-  const result = registerCheckedInProviderProfile({
-    profilePath: endpointlessProviderProfilePath(REPOSITORY_ROOT, MCP_BRIDGE_PROVIDER_TYPE),
-    runOpenshell: (args, options) =>
-      runOpenshellProviderCommand(args, {
-        ...options,
-        runtimeSelection,
-      }) as OpenShellCommandResult,
-  });
-  if (result.ok) return;
-  if (result.operation === "import") {
+  if (result.error.kind === "command" && result.error.reason === "profile_incompatible") {
     throw new McpBridgeError(
-      `Could not import OpenShell provider profile '${MCP_BRIDGE_PROVIDER_TYPE}'.`,
-    );
-  }
-  if (!(result.error.kind === "command" && result.error.reason === "profile_incompatible")) {
-    throw new McpBridgeError(
-      `OpenShell provider profile '${MCP_BRIDGE_PROVIDER_TYPE}' could not be exported for validation. Refusing to attach MCP credentials to it.`,
+      "OpenShell provider profile 'openai' already exists but does not match NemoClaw's endpointless inference contract.\n    Remove the conflicting profile, then retry this command.",
     );
   }
   throw new McpBridgeError(
-    `OpenShell provider profile '${MCP_BRIDGE_PROVIDER_TYPE}' already exists but does not match NemoClaw's endpointless credential contract. Refusing to attach MCP credentials to it.`,
+    result.operation === "import"
+      ? "OpenShell could not import the checked-in 'openai' inference provider profile.\n    Confirm OpenShell is available and authorized, then retry this command."
+      : "OpenShell provider profile 'openai' could not be read for validation.\n    Confirm OpenShell is available, authorized, and the profile is readable, then retry this command.",
   );
 }
 
-export function buildMcpBridgeProviderArgs(
-  action: "create" | "update",
-  providerName: string,
-  env: readonly ParsedEnvReference[],
-  envValues: Record<string, string>,
-): string[] {
-  const args =
-    action === "create"
-      ? ["provider", "create", "--name", providerName, "--type", MCP_BRIDGE_PROVIDER_TYPE]
-      : ["provider", "update", providerName];
-  for (const entry of env) {
-    validateMcpCredentialEnvName(entry.name);
-    const value = envValues[entry.name];
-    if (value !== undefined && value !== "") {
-      args.push("--credential", entry.name);
-    }
-  }
-  return args;
+/** Ensure the endpointless profile required by OpenShell static credential binding. */
+export async function ensureMcpBridgeProviderProfile(
+  runtimeSelection: McpProviderInspectionRuntimeSelection,
+  providerAdapter?: OpenShellProviderAdapter,
+): Promise<void> {
+  const boundary = createMcpProviderAdapterBoundary(runtimeSelection, providerAdapter);
+  await ensureOpenAiGatewayProviderProfile(runtimeSelection, boundary.adapter);
+  const result = await boundary.adapter.importProviderProfile({
+    profilePath: endpointlessProviderProfilePath(REPOSITORY_ROOT, MCP_BRIDGE_PROVIDER_TYPE),
+    target: boundary.target,
+  });
+  if (result.ok) return;
+  throw new McpBridgeError(
+    result.error.kind === "command" && result.error.reason === "profile_incompatible"
+      ? `OpenShell provider profile '${MCP_BRIDGE_PROVIDER_TYPE}' already exists but does not match NemoClaw's endpointless credential contract. Refusing to attach MCP credentials to it.`
+      : result.operation === "import"
+        ? `Could not import OpenShell provider profile '${MCP_BRIDGE_PROVIDER_TYPE}'.`
+        : `OpenShell provider profile '${MCP_BRIDGE_PROVIDER_TYPE}' could not be exported for validation. Refusing to attach MCP credentials to it.`,
+  );
 }
 
-export function upsertMcpProvider(
+export async function upsertMcpProvider(
   providerName: string,
   env: readonly ParsedEnvReference[],
   options: {
@@ -141,11 +116,12 @@ export function upsertMcpProvider(
     requireExisting?: boolean;
     prepareMutation?: (action: "create" | "update") => void;
     runtimeSelection: McpProviderInspectionRuntimeSelection;
+    providerAdapter?: OpenShellProviderAdapter;
   },
-): {
+): Promise<{
   action: "created" | "updated" | "reused" | "none";
   inspection: McpProviderInspection;
-} {
+}> {
   const envNames = uniqueEnvNames(env);
   if (envNames.length === 0) {
     return {
@@ -160,7 +136,15 @@ export function upsertMcpProvider(
     };
   }
   const envValues = resolveCredentialEnv(env);
-  const inspection = inspectMcpProvider(providerName, options.runtimeSelection);
+  const boundary = createMcpProviderAdapterBoundary(
+    options.runtimeSelection,
+    options.providerAdapter,
+  );
+  const inspection = await inspectMcpProvider(
+    providerName,
+    options.runtimeSelection,
+    boundary.adapter,
+  );
   if (inspection.exists === null) {
     throw new McpBridgeError(
       inspection.error ?? `Could not inspect OpenShell provider '${providerName}'.`,
@@ -213,7 +197,11 @@ export function upsertMcpProvider(
   // removalCondition: use native immutable provider IDs or caller-supplied CAS
   // once OpenShell exposes them, then remove this inspect-mutate-inspect
   // compensation.
-  const beforeMutation = inspectMcpProvider(providerName, options.runtimeSelection);
+  const beforeMutation = await inspectMcpProvider(
+    providerName,
+    options.runtimeSelection,
+    boundary.adapter,
+  );
   if (action === "create" && beforeMutation.exists !== false) {
     const detail =
       beforeMutation.exists === null
@@ -231,24 +219,36 @@ export function upsertMcpProvider(
       `OpenShell provider '${providerName}' changed before update. ${providerShapeDetail(beforeMutation, envNames[0], options.expectedProviderId)} Refusing to mutate it.`,
     );
   }
-  const result = runOpenshellProviderCommand(
-    buildMcpBridgeProviderArgs(action, providerName, env, envValues),
-    {
-      ignoreError: true,
-      env: envValues,
-      runtimeSelection: options.runtimeSelection,
-      stdio: ["ignore", "pipe", "pipe"],
-    },
-  ) as OpenShellCommandResult;
-  if (result.status !== 0) {
+  const credentials = env.flatMap((entry) => {
+    validateMcpCredentialEnvName(entry.name);
+    const value = envValues[entry.name];
+    return value ? [{ name: entry.name, value }] : [];
+  });
+  const result =
+    action === "create"
+      ? await boundary.adapter.createProvider({
+          name: providerName,
+          type: MCP_BRIDGE_PROVIDER_TYPE,
+          credentials,
+          config: [],
+          fromExisting: false,
+          target: boundary.target,
+        })
+      : await boundary.adapter.updateProvider({
+          providerName,
+          credentials,
+          config: [],
+          target: boundary.target,
+        });
+  if (!result.ok) {
     // Never infer that our update committed from a later resource-version
     // increase: a concurrent writer can advance the same provider after our
     // command failed. A non-zero result is ambiguous and must fail closed.
     throw new McpBridgeError(
-      commandOutput(result, envValues) || `Failed to ${action} MCP provider '${providerName}'.`,
+      result.error.message || `Failed to ${action} MCP provider '${providerName}'.`,
     );
   }
-  const after = inspectMcpProvider(providerName, options.runtimeSelection);
+  const after = await inspectMcpProvider(providerName, options.runtimeSelection, boundary.adapter);
   if (after.exists !== true || !after.id) {
     throw new McpBridgeError(
       after.error ??
@@ -275,34 +275,37 @@ export function upsertMcpProvider(
  * revision without reading or rotating the stored credential, giving the
  * sidecar a post-policy generation to synchronize.
  */
-export function refreshMcpProviderEnvironment(
+export async function refreshMcpProviderEnvironment(
   entry: McpBridgeEntry,
   runtimeSelection: McpProviderInspectionRuntimeSelection,
-): McpProviderInspection {
+  providerAdapter?: OpenShellProviderAdapter,
+): Promise<McpProviderInspection> {
   assertPersistedAuthenticatedBridgeEntry(entry);
   if (!entry.providerName || !entry.providerId) {
     throw new McpBridgeError(
       `MCP server '${entry.server}' has no stable OpenShell provider identity for credential synchronization.`,
     );
   }
-  const before = inspectMcpProvider(entry.providerName, runtimeSelection);
+  const boundary = createMcpProviderAdapterBoundary(runtimeSelection, providerAdapter);
+  const before = await inspectMcpProvider(entry.providerName, runtimeSelection, boundary.adapter);
   if (!providerMatchesCredential(before, entry.env[0], entry.providerId)) {
     throw new McpBridgeError(
       `OpenShell provider '${entry.providerName}' changed before credential synchronization. ${providerShapeDetail(before, entry.env[0], entry.providerId)} Refusing to mutate it.`,
     );
   }
-  const result = runOpenshellProviderCommand(["provider", "update", entry.providerName], {
-    ignoreError: true,
-    runtimeSelection,
-    stdio: ["ignore", "pipe", "pipe"],
-  }) as OpenShellCommandResult;
-  if (result.status !== 0) {
+  const result = await boundary.adapter.updateProvider({
+    providerName: entry.providerName,
+    credentials: [],
+    config: [],
+    target: boundary.target,
+  });
+  if (!result.ok) {
     throw new McpBridgeError(
-      commandOutput(result) ||
+      result.error.message ||
         `Failed to synchronize MCP provider '${entry.providerName}' after policy binding.`,
     );
   }
-  const after = inspectMcpProvider(entry.providerName, runtimeSelection);
+  const after = await inspectMcpProvider(entry.providerName, runtimeSelection, boundary.adapter);
   if (
     !providerMatchesCredential(after, entry.env[0], entry.providerId) ||
     !after.resourceVersion ||
@@ -315,15 +318,16 @@ export function refreshMcpProviderEnvironment(
   return after;
 }
 
-function inspectMcpProviderForDeletion(
+async function inspectMcpProviderForDeletion(
   entry: McpBridgeEntry,
   options: {
     allowLegacyGeneric?: boolean;
     allowMissing?: boolean;
     bestEffort?: boolean;
     runtimeSelection: McpProviderInspectionRuntimeSelection;
+    providerAdapter?: OpenShellProviderAdapter;
   },
-): McpProviderInspection | null {
+): Promise<McpProviderInspection | null> {
   if (!entry.providerName) return null;
   try {
     assertPersistedAuthenticatedBridgeEntry(entry);
@@ -332,7 +336,11 @@ function inspectMcpProviderForDeletion(
         `MCP server '${entry.server}' has no stable OpenShell provider ID. Refusing to delete same-name provider '${entry.providerName}'.`,
       );
     }
-    const inspection = inspectMcpProvider(entry.providerName, options.runtimeSelection);
+    const inspection = await inspectMcpProvider(
+      entry.providerName,
+      options.runtimeSelection,
+      options.providerAdapter,
+    );
     if (inspection.exists === false) {
       if (options.allowMissing) return inspection;
       throw new McpBridgeError(
@@ -355,37 +363,48 @@ function inspectMcpProviderForDeletion(
   }
 }
 
-export function deleteProvider(
+export async function deleteProvider(
   entry: McpBridgeEntry,
   options: {
     allowLegacyGeneric?: boolean;
     allowMissing?: boolean;
     bestEffort?: boolean;
     runtimeSelection: McpProviderInspectionRuntimeSelection;
+    providerAdapter?: OpenShellProviderAdapter;
   },
-): void {
+): Promise<void> {
   if (!entry.providerName) return;
-  const inspection = inspectMcpProviderForDeletion(entry, options);
+  const boundary = createMcpProviderAdapterBoundary(
+    options.runtimeSelection,
+    options.providerAdapter,
+  );
+  const inspection = await inspectMcpProviderForDeletion(entry, {
+    ...options,
+    providerAdapter: boundary.adapter,
+  });
   if (!inspection?.exists || !inspection.id || !inspection.resourceVersion) return;
-  const result = runOpenshellProviderCommand(["provider", "delete", entry.providerName], {
-    ignoreError: true,
-    runtimeSelection: options.runtimeSelection,
-    stdio: ["ignore", "pipe", "pipe"],
-    suppressOutput: true,
-  } as Record<string, unknown>) as OpenShellCommandResult;
-  if (result.status !== 0) {
-    const output = commandOutput(result);
+  const result = await boundary.adapter.deleteProvider({
+    providerName: entry.providerName,
+    target: boundary.target,
+  });
+  if (!result.ok) {
     if (
       options.allowMissing &&
-      result.status === 1 &&
-      reportsExactProviderNotFound(output, entry.providerName, output.length)
-    ) {
+      result.error.kind === "command" &&
+      result.error.reason === "not_found"
+    )
       return;
-    }
     if (options.bestEffort) return;
-    throw new McpBridgeError(output || `Failed to delete MCP provider '${entry.providerName}'.`);
+    throw new McpBridgeError(
+      result.error.message ||
+        `Failed to delete MCP provider '${entry.providerName}'.`,
+    );
   }
-  const after = inspectMcpProvider(entry.providerName, options.runtimeSelection);
+  const after = await inspectMcpProvider(
+    entry.providerName,
+    options.runtimeSelection,
+    boundary.adapter,
+  );
   if (after.exists !== false && !options.bestEffort) {
     throw new McpBridgeError(
       after.error ?? `OpenShell provider '${entry.providerName}' still exists after delete.`,

--- a/src/lib/actions/sandbox/mcp-bridge-provider-profile.test.ts
+++ b/src/lib/actions/sandbox/mcp-bridge-provider-profile.test.ts
@@ -27,7 +27,7 @@ function exportedEndpointlessProfile(id: string, inferenceCapable: boolean): str
 }
 
 describe("OpenShell MCP provider profile", () => {
-  it("imports the endpointless profile before managed provider use", () => {
+  it("imports the endpointless profile before managed provider use", async () => {
     const runOpenshell = vi
       .fn()
       .mockReturnValueOnce({ status: 1, stdout: "", stderr: "provider profile not found" })
@@ -46,7 +46,7 @@ describe("OpenShell MCP provider profile", () => {
       });
     setProviderCommandRuntimeHooksForTest({ runOpenshell: runOpenshell as never });
 
-    expect(() => ensureMcpBridgeProviderProfile(runtimeSelection)).not.toThrow();
+    await expect(ensureMcpBridgeProviderProfile(runtimeSelection)).resolves.toBeUndefined();
     expect(runOpenshell).toHaveBeenCalledTimes(6);
     expect(runOpenshell).toHaveBeenCalledWith(
       ["provider", "profile", "import", "--file", expect.stringMatching(/openai\.yaml$/)],
@@ -58,7 +58,7 @@ describe("OpenShell MCP provider profile", () => {
     );
   });
 
-  it("accepts existing profiles only after proving both exact endpointless boundaries", () => {
+  it("accepts existing profiles only after proving both exact endpointless boundaries", async () => {
     const runOpenshell = vi
       .fn()
       .mockReturnValueOnce({
@@ -73,7 +73,7 @@ describe("OpenShell MCP provider profile", () => {
       });
     setProviderCommandRuntimeHooksForTest({ runOpenshell: runOpenshell as never });
 
-    expect(() => ensureMcpBridgeProviderProfile(runtimeSelection)).not.toThrow();
+    await expect(ensureMcpBridgeProviderProfile(runtimeSelection)).resolves.toBeUndefined();
     expect(runOpenshell).toHaveBeenCalledWith(
       ["provider", "profile", "export", "openai", "--output", "json"],
       expect.any(Object),
@@ -84,7 +84,7 @@ describe("OpenShell MCP provider profile", () => {
     );
   });
 
-  it("rejects an existing profile that can supply its own endpoint authority", () => {
+  it("rejects an existing profile that can supply its own endpoint authority", async () => {
     const runOpenshell = vi
       .fn()
       .mockReturnValueOnce({
@@ -105,12 +105,12 @@ describe("OpenShell MCP provider profile", () => {
       });
     setProviderCommandRuntimeHooksForTest({ runOpenshell: runOpenshell as never });
 
-    expect(() => ensureMcpBridgeProviderProfile(runtimeSelection)).toThrow(
+    await expect(ensureMcpBridgeProviderProfile(runtimeSelection)).rejects.toThrow(
       /does not match NemoClaw's endpointless credential contract/,
     );
   });
 
-  it("fails closed when the gateway-only OpenAI profile cannot be registered", () => {
+  it("fails closed when the gateway-only OpenAI profile cannot be registered", async () => {
     const secret = "openai-import-secret-must-not-leak";
     const runOpenshell = vi
       .fn()
@@ -120,7 +120,7 @@ describe("OpenShell MCP provider profile", () => {
 
     let message = "";
     try {
-      ensureMcpBridgeProviderProfile(runtimeSelection);
+      await ensureMcpBridgeProviderProfile(runtimeSelection);
     } catch (error) {
       message = error instanceof Error ? error.message : String(error);
     }
@@ -133,7 +133,7 @@ describe("OpenShell MCP provider profile", () => {
     expect(runOpenshell).toHaveBeenCalledTimes(2);
   });
 
-  it("suppresses MCP profile import output at the bridge error boundary", () => {
+  it("suppresses MCP profile import output at the bridge error boundary", async () => {
     const secret = "mcp-import-secret-must-not-leak";
     const runOpenshell = vi
       .fn()
@@ -148,7 +148,7 @@ describe("OpenShell MCP provider profile", () => {
 
     let message = "";
     try {
-      ensureMcpBridgeProviderProfile(runtimeSelection);
+      await ensureMcpBridgeProviderProfile(runtimeSelection);
     } catch (error) {
       message = error instanceof Error ? error.message : String(error);
     }
@@ -181,11 +181,11 @@ describe("OpenShell MCP provider profile", () => {
       }),
     ],
     ["malformed export output", "not-json"],
-  ])("rejects an existing OpenAI profile with %s before MCP setup", (_case, stdout) => {
+  ])("rejects an existing OpenAI profile with %s before MCP setup", async (_case, stdout) => {
     const runOpenshell = vi.fn().mockReturnValueOnce({ status: 0, stdout, stderr: "" });
     setProviderCommandRuntimeHooksForTest({ runOpenshell: runOpenshell as never });
 
-    expect(() => ensureMcpBridgeProviderProfile(runtimeSelection)).toThrow(
+    await expect(ensureMcpBridgeProviderProfile(runtimeSelection)).rejects.toThrow(
       /does not match NemoClaw's endpointless inference contract/,
     );
     expect(runOpenshell).toHaveBeenCalledOnce();
@@ -195,7 +195,7 @@ describe("OpenShell MCP provider profile", () => {
     );
   });
 
-  it("fails closed when the OpenAI profile cannot be exported", () => {
+  it("fails closed when the OpenAI profile cannot be exported", async () => {
     const runOpenshell = vi.fn().mockReturnValueOnce({
       status: 1,
       stdout: "",
@@ -203,13 +203,13 @@ describe("OpenShell MCP provider profile", () => {
     });
     setProviderCommandRuntimeHooksForTest({ runOpenshell: runOpenshell as never });
 
-    expect(() => ensureMcpBridgeProviderProfile(runtimeSelection)).toThrow(
+    await expect(ensureMcpBridgeProviderProfile(runtimeSelection)).rejects.toThrow(
       /could not be read for validation/,
     );
     expect(runOpenshell).toHaveBeenCalledOnce();
   });
 
-  it("fails closed when the MCP profile cannot be exported", () => {
+  it("fails closed when the MCP profile cannot be exported", async () => {
     const runOpenshell = vi
       .fn()
       .mockReturnValueOnce({
@@ -220,7 +220,7 @@ describe("OpenShell MCP provider profile", () => {
       .mockReturnValueOnce({ status: 1, stdout: "", stderr: "export rejected" });
     setProviderCommandRuntimeHooksForTest({ runOpenshell: runOpenshell as never });
 
-    expect(() => ensureMcpBridgeProviderProfile(runtimeSelection)).toThrow(
+    await expect(ensureMcpBridgeProviderProfile(runtimeSelection)).rejects.toThrow(
       /nemoclaw-mcp-v1.*could not be exported for validation/u,
     );
     expect(runOpenshell).toHaveBeenCalledTimes(2);

--- a/src/lib/actions/sandbox/mcp-bridge-provider-readiness.ts
+++ b/src/lib/actions/sandbox/mcp-bridge-provider-readiness.ts
@@ -5,7 +5,7 @@ import { shellQuote } from "../../runner";
 import type { McpBridgeEntry } from "../../state/registry";
 import { McpBridgeError } from "./mcp-bridge-contracts";
 import type { McpProviderInspectionRuntimeSelection } from "./mcp-bridge-provider-inspection";
-import { waitForMcpBridgeCondition } from "./mcp-bridge/timing";
+import { waitForMcpBridgeCondition, waitForMcpBridgeConditionAsync } from "./mcp-bridge/timing";
 import {
   assertAuthenticatedBridgeEntry,
   assertPersistedAuthenticatedBridgeEntry,
@@ -159,15 +159,15 @@ export function observeMcpCredentialRevision(
   return attempt.observation;
 }
 
-export function waitForAttachedMcpCredential(
+export async function waitForAttachedMcpCredential(
   sandboxName: string,
   entry: McpBridgeEntry,
   runtimeSelection: McpProviderInspectionRuntimeSelection,
   options: {
     previousRevision?: McpCredentialRevisionObservation;
-    refreshAfterObservedAbsence?: () => void;
+    refreshAfterObservedAbsence?: () => void | Promise<void>;
   } = {},
-): McpAttachedCredentialRevision {
+): Promise<McpAttachedCredentialRevision> {
   assertAuthenticatedBridgeEntry(entry);
   const envName = entry.env[0];
   if (
@@ -184,8 +184,8 @@ export function waitForAttachedMcpCredential(
   let lastAttempt: McpCredentialRevisionAttempt = { kind: "transport-unavailable" };
   let candidateRevision: McpAttachedCredentialRevision | undefined;
   let attachedRevision: McpAttachedCredentialRevision | undefined;
-  const ready = waitForMcpBridgeCondition(
-    () => {
+  const ready = await waitForMcpBridgeConditionAsync(
+    async () => {
       // Each exec is a fresh OpenShell process. Only the bounded placeholder
       // classification crosses back to the host, where the comparison cannot
       // be influenced by a same-UID sandbox process rewriting a snapshot file.
@@ -198,7 +198,7 @@ export function waitForAttachedMcpCredential(
         options.refreshAfterObservedAbsence
       ) {
         refreshedAfterObservedAbsence = true;
-        options.refreshAfterObservedAbsence();
+        await options.refreshAfterObservedAbsence();
         attempt = tryObserveMcpCredentialRevision(sandboxName, envName, runtimeSelection);
         lastAttempt = attempt;
       }
@@ -273,8 +273,7 @@ export function waitForDetachedMcpCredential(
         sandboxName,
         buildMcpCredentialDetachedCommand(envName),
         runtimeSelection,
-      )
-        ?.status === 0,
+      )?.status === 0,
     Number.isFinite(timeoutSeconds) && timeoutSeconds > 0 ? timeoutSeconds : 30,
     1_000,
   );

--- a/src/lib/actions/sandbox/mcp-bridge-provider.test.ts
+++ b/src/lib/actions/sandbox/mcp-bridge-provider.test.ts
@@ -6,13 +6,7 @@ import { spawnSync } from "node:child_process";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import * as providerCommand from "../../adapters/openshell/provider-command";
 import type { McpBridgeEntry } from "../../state/registry";
-import {
-  buildMcpCredentialRevisionObservationCommand,
-  parseMcpProviderAttachmentNames,
-  parseMcpProviderMetadata,
-  providerDetachChangedState,
-} from "./mcp-bridge";
-import { commandOutput } from "./mcp-bridge-output";
+import { buildMcpCredentialRevisionObservationCommand } from "./mcp-bridge";
 import {
   assertNoAttachedProviderCredentialCollisions,
   assertNoRegisteredProviderCredentialCollisions,
@@ -41,60 +35,28 @@ const runtimeSelection = {
   workspace: "default",
 } as const;
 
+function providerMetadataOutput(
+  name: string,
+  type: string,
+  id: string,
+  resourceVersion: number,
+  credentialKey: string,
+): string {
+  return [
+    `Name: ${name}`,
+    `Id: ${id}`,
+    `Type: ${type}`,
+    `Resource version: ${resourceVersion}`,
+    `Credential keys: ${credentialKey}`,
+    "Config keys: <none>",
+  ].join("\n");
+}
+
 describe("OpenShell MCP provider state", () => {
   afterEach(() => {
     providerCommand.setProviderCommandRuntimeHooksForTest({});
     vi.restoreAllMocks();
     vi.unstubAllEnvs();
-  });
-
-  it("parses provider type and credential keys without values", () => {
-    expect(
-      parseMcpProviderMetadata(`
-Provider:
-
-  Id: 11111111-2222-4333-8444-555555555555
-  Name: alpha-mcp-github
-  Type: nemoclaw-mcp-v1
-  Resource version: 7
-  Credential keys: GITHUB_TOKEN
-  Config keys: <none>
-`),
-    ).toEqual({
-      id: "11111111-2222-4333-8444-555555555555",
-      resourceVersion: 7,
-      type: "nemoclaw-mcp-v1",
-      credentialKeys: ["GITHUB_TOKEN"],
-    });
-    expect(parseMcpProviderMetadata("Type: nemoclaw-mcp-v1\nCredential keys: <none>\n")).toEqual({
-      id: null,
-      resourceVersion: null,
-      type: "nemoclaw-mcp-v1",
-      credentialKeys: [],
-    });
-  });
-
-  it("parses ANSI-decorated OpenShell provider metadata after redaction", () => {
-    const output = commandOutput({
-      status: 0,
-      stdout: [
-        "\u001b[2mProvider:\u001b[0m",
-        "\u001b[2m  Id:\u001b[0m 11111111-2222-4333-8444-555555555555",
-        "\u001b[2m  Type:\u001b[0m nemoclaw-mcp-v1",
-        "\u001b[2m  Resource version:\u001b[0m 7",
-        "\u001b[2m  Credential keys:\u001b[0m GITHUB_TOKEN",
-      ].join("\n"),
-      stderr: "",
-    });
-
-    expect(parseMcpProviderMetadata(output)).toEqual({
-      id: "11111111-2222-4333-8444-555555555555",
-      resourceVersion: 7,
-      type: "nemoclaw-mcp-v1",
-      credentialKeys: ["GITHUB_TOKEN"],
-    });
-    expect(output).not.toContain("\u001b");
-    expect(output).not.toMatch(/\[[0-9;]*m/);
   });
 
   it("accepts an exact legacy generic provider only for cleanup", () => {
@@ -119,18 +81,29 @@ Provider:
     ).toBe(true);
   });
 
-  it("rejects a legacy generic provider before active MCP reconciliation", () => {
+  it("rejects a legacy generic provider before active MCP reconciliation", async () => {
     vi.spyOn(providerCommand, "runOpenshellProviderCommand").mockReturnValue({
       pid: 1234,
       status: 0,
       signal: null,
       output: [
         null,
-        "Id: 11111111-2222-4333-8444-555555555555\nType: generic\nResource version: 7\nCredential keys: GITHUB_TOKEN\n",
+        providerMetadataOutput(
+          "alpha-mcp-github",
+          "generic",
+          "11111111-2222-4333-8444-555555555555",
+          7,
+          "GITHUB_TOKEN",
+        ),
         "",
       ],
-      stdout:
-        "Id: 11111111-2222-4333-8444-555555555555\nType: generic\nResource version: 7\nCredential keys: GITHUB_TOKEN\n",
+      stdout: providerMetadataOutput(
+        "alpha-mcp-github",
+        "generic",
+        "11111111-2222-4333-8444-555555555555",
+        7,
+        "GITHUB_TOKEN",
+      ),
       stderr: "",
     });
     const entry: McpBridgeEntry = {
@@ -145,12 +118,12 @@ Provider:
       addedAt: "2026-08-19T00:00:00.000Z",
     };
 
-    expect(() => assertMcpProviderRecoverable(entry, runtimeSelection)).toThrow(
+    await expect(assertMcpProviderRecoverable(entry, runtimeSelection)).rejects.toThrow(
       /legacy generic profile.*cannot bind to an MCP endpoint/,
     );
   });
 
-  it("republishes an exact provider only after policy binding without reading its credential", () => {
+  it("republishes an exact provider only after policy binding without reading its credential", async () => {
     const id = "11111111-2222-4333-8444-555555555555";
     const providerResult = (resourceVersion: number) => ({
       pid: 1234,
@@ -158,10 +131,22 @@ Provider:
       signal: null,
       output: [
         null,
-        `Id: ${id}\nType: nemoclaw-mcp-v1\nResource version: ${resourceVersion}\nCredential keys: GITHUB_TOKEN\n`,
+        providerMetadataOutput(
+          "alpha-mcp-github",
+          "nemoclaw-mcp-v1",
+          id,
+          resourceVersion,
+          "GITHUB_TOKEN",
+        ),
         "",
       ],
-      stdout: `Id: ${id}\nType: nemoclaw-mcp-v1\nResource version: ${resourceVersion}\nCredential keys: GITHUB_TOKEN\n`,
+      stdout: providerMetadataOutput(
+        "alpha-mcp-github",
+        "nemoclaw-mcp-v1",
+        id,
+        resourceVersion,
+        "GITHUB_TOKEN",
+      ),
       stderr: "",
     });
     const run = vi
@@ -177,7 +162,7 @@ Provider:
       })
       .mockReturnValueOnce(providerResult(8));
 
-    expect(
+    await expect(
       refreshMcpProviderEnvironment(
         {
           server: "github",
@@ -195,12 +180,12 @@ Provider:
           workspace: "default",
         },
       ),
-    ).toMatchObject({ resourceVersion: 8 });
+    ).resolves.toMatchObject({ resourceVersion: 8 });
     expect(run.mock.calls[1]?.[0]).toEqual(["provider", "update", "alpha-mcp-github"]);
     expect(run.mock.calls[1]?.[0]).not.toContain("--credential");
   });
 
-  it("pins every managed MCP provider lifecycle read and write to the recorded runtime target (#10514)", () => {
+  it("pins every managed MCP provider lifecycle read and write to the recorded runtime target (#10514)", async () => {
     vi.stubEnv("EXPECTED_TOKEN", "host-only-secret");
     vi.stubEnv("OPENSHELL_GATEWAY", "ambient-gateway");
     vi.stubEnv("OPENSHELL_GATEWAY_ENDPOINT", "http://ambient.invalid");
@@ -214,12 +199,13 @@ Provider:
     let providerAttached = false;
     let resourceVersion = 0;
     const providerOutput = () =>
-      [
-        `Id: ${providerId}`,
-        `Type: ${MCP_BRIDGE_PROVIDER_TYPE}`,
-        `Resource version: ${resourceVersion}`,
-        "Credential keys: EXPECTED_TOKEN",
-      ].join("\n");
+      providerMetadataOutput(
+        "alpha-mcp-fake",
+        MCP_BRIDGE_PROVIDER_TYPE,
+        providerId,
+        resourceVersion,
+        "EXPECTED_TOKEN",
+      );
     const profileOutput = (id: string, inferenceCapable: boolean) =>
       JSON.stringify({
         id,
@@ -301,8 +287,8 @@ Provider:
     });
     providerCommand.setProviderCommandRuntimeHooksForTest({ runOpenshell: runOpenshell as never });
 
-    ensureMcpBridgeProviderProfile(runtimeSelection);
-    const created = upsertMcpProvider("alpha-mcp-fake", [{ name: "EXPECTED_TOKEN" }], {
+    await ensureMcpBridgeProviderProfile(runtimeSelection);
+    const created = await upsertMcpProvider("alpha-mcp-fake", [{ name: "EXPECTED_TOKEN" }], {
       allowExisting: false,
       runtimeSelection,
     });
@@ -317,11 +303,13 @@ Provider:
       policyName: "mcp-bridge-fake",
       addedAt: "2026-06-01T00:00:00.000Z",
     };
-    attachProvider("alpha", entry, runtimeSelection);
-    refreshMcpProviderEnvironment(entry, runtimeSelection);
-    expect(detachProvider("alpha", entry, { runtimeSelection })).toBe("detached");
-    deleteProvider(entry, { runtimeSelection });
-    expect(detachMissingProviderReference("alpha", entry, runtimeSelection)).toBe("absent");
+    await attachProvider("alpha", entry, runtimeSelection);
+    await refreshMcpProviderEnvironment(entry, runtimeSelection);
+    await expect(detachProvider("alpha", entry, { runtimeSelection })).resolves.toBe("detached");
+    await deleteProvider(entry, { runtimeSelection });
+    await expect(detachMissingProviderReference("alpha", entry, runtimeSelection)).resolves.toBe(
+      "absent",
+    );
 
     expect(commandFamilies).toEqual(
       new Set(["profile", "get", "create", "attach", "list", "update", "detach", "delete"]),
@@ -334,7 +322,7 @@ Provider:
     'status: NotFound, message: "gateway nemoclaw-8091 not found"',
   ])(
     "rejects ambiguous provider-delete output %s while cleanup is retryable (#10514)",
-    (diagnostic) => {
+    async (diagnostic) => {
       const id = "11111111-2222-4333-8444-555555555555";
       const runtimeSelection = { gatewayName: "nemoclaw-8091", workspace: "default" };
       const run = vi
@@ -345,10 +333,16 @@ Provider:
           signal: null,
           output: [
             null,
-            `Id: ${id}\nType: nemoclaw-mcp-v1\nResource version: 7\nCredential keys: GITHUB_TOKEN\n`,
+            providerMetadataOutput("alpha-mcp-github", "nemoclaw-mcp-v1", id, 7, "GITHUB_TOKEN"),
             "",
           ],
-          stdout: `Id: ${id}\nType: nemoclaw-mcp-v1\nResource version: 7\nCredential keys: GITHUB_TOKEN\n`,
+          stdout: providerMetadataOutput(
+            "alpha-mcp-github",
+            "nemoclaw-mcp-v1",
+            id,
+            7,
+            "GITHUB_TOKEN",
+          ),
           stderr: "",
         })
         .mockReturnValueOnce({
@@ -371,14 +365,14 @@ Provider:
         addedAt: "2026-08-19T00:00:00.000Z",
       };
 
-      expect(() => deleteProvider(entry, { allowMissing: true, runtimeSelection })).toThrow(
+      await expect(deleteProvider(entry, { allowMissing: true, runtimeSelection })).rejects.toThrow(
         diagnostic,
       );
       expect(run).toHaveBeenCalledTimes(2);
     },
   );
 
-  it("accepts an exact provider-delete absence while cleanup is retryable (#10514)", () => {
+  it("accepts an exact provider-delete absence while cleanup is retryable (#10514)", async () => {
     const id = "11111111-2222-4333-8444-555555555555";
     const runtimeSelection = { gatewayName: "nemoclaw-8091", workspace: "default" };
     const run = vi
@@ -389,10 +383,16 @@ Provider:
         signal: null,
         output: [
           null,
-          `Id: ${id}\nType: nemoclaw-mcp-v1\nResource version: 7\nCredential keys: GITHUB_TOKEN\n`,
+          providerMetadataOutput("alpha-mcp-github", "nemoclaw-mcp-v1", id, 7, "GITHUB_TOKEN"),
           "",
         ],
-        stdout: `Id: ${id}\nType: nemoclaw-mcp-v1\nResource version: 7\nCredential keys: GITHUB_TOKEN\n`,
+        stdout: providerMetadataOutput(
+          "alpha-mcp-github",
+          "nemoclaw-mcp-v1",
+          id,
+          7,
+          "GITHUB_TOKEN",
+        ),
         stderr: "",
       })
       .mockReturnValueOnce({
@@ -415,36 +415,13 @@ Provider:
       addedAt: "2026-08-19T00:00:00.000Z",
     };
 
-    expect(() => deleteProvider(entry, { allowMissing: true, runtimeSelection })).not.toThrow();
+    await expect(
+      deleteProvider(entry, { allowMissing: true, runtimeSelection }),
+    ).resolves.toBeUndefined();
     expect(run).toHaveBeenCalledTimes(2);
   });
 
-  it("distinguishes a real detach from OpenShell's idempotent success", () => {
-    expect(
-      providerDetachChangedState(0, "✓ Detached provider alpha-mcp-github from sandbox alpha"),
-    ).toBe(true);
-    expect(
-      providerDetachChangedState(0, "Provider alpha-mcp-github was not attached to sandbox alpha."),
-    ).toBe(false);
-  });
-
-  it("parses the stock OpenShell sandbox provider table", () => {
-    expect(
-      parseMcpProviderAttachmentNames(`
-NAME              TYPE     CREDENTIAL_KEYS   CONFIG_KEYS
-alpha-mcp-github  generic  1                 0
-alpha-mcp-slack   generic  1                 0
-`),
-    ).toEqual(["alpha-mcp-github", "alpha-mcp-slack"]);
-    expect(parseMcpProviderAttachmentNames("No providers attached to sandbox alpha.\n")).toEqual(
-      [],
-    );
-    expect(() => parseMcpProviderAttachmentNames("unexpected output\n")).toThrow(
-      /attachment table header/,
-    );
-  });
-
-  it("rejects a multi-key bridge before provider collision inspection", () => {
+  it("rejects a multi-key bridge before provider collision inspection", async () => {
     const providerCommandRun = vi.spyOn(providerCommand, "runOpenshellProviderCommand");
     const entry: McpBridgeEntry = {
       server: "example",
@@ -458,18 +435,18 @@ alpha-mcp-slack   generic  1                 0
       addedAt: "2026-06-01T00:00:00.000Z",
     };
 
-    expect(() =>
+    await expect(
       assertNoAttachedProviderCredentialCollisions("alpha", [entry], runtimeSelection),
-    ).toThrow("MCP server 'example' has no complete authenticated credential binding");
-    expect(() =>
+    ).rejects.toThrow("MCP server 'example' has no complete authenticated credential binding");
+    await expect(
       assertNoRegisteredProviderCredentialCollisions([entry], {
         listExtraProviders: () => ["foreign-registered"],
       }),
-    ).toThrow("MCP server 'example' has no complete authenticated credential binding");
+    ).rejects.toThrow("MCP server 'example' has no complete authenticated credential binding");
     expect(providerCommandRun).not.toHaveBeenCalled();
   });
 
-  it("rejects a registered provider that will collide on the next rebuild (#9388)", () => {
+  it("rejects a registered provider that will collide on the next rebuild (#9388)", async () => {
     const entry: McpBridgeEntry = {
       server: "test-dir1",
       agent: "hermes",
@@ -481,10 +458,10 @@ alpha-mcp-slack   generic  1                 0
       addedAt: "2026-08-18T00:00:00.000Z",
     };
 
-    expect(() =>
+    await expect(
       assertNoRegisteredProviderCredentialCollisions([entry], {
         listExtraProviders: () => ["test-dir1"],
-        inspectProvider: () => ({
+        inspectProvider: async () => ({
           exists: true,
           id: "99999999-8888-4777-8666-555555555555",
           resourceVersion: 1,
@@ -492,12 +469,12 @@ alpha-mcp-slack   generic  1                 0
           credentialKeys: ["TEST_DIR1_TOKEN"],
         }),
       }),
-    ).toThrow(
+    ).rejects.toThrow(
       "Credential key 'TEST_DIR1_TOKEN' is already supplied by registered provider 'test-dir1'",
     );
   });
 
-  it("pins attachment collision inspection to the recorded runtime target (#10514)", () => {
+  it("pins attachment collision inspection to the recorded runtime target (#10514)", async () => {
     const runtimeSelection = { gatewayName: "nemoclaw-9090", workspace: "default" };
     const run = vi
       .spyOn(providerCommand, "runOpenshellProviderCommand")
@@ -519,11 +496,22 @@ alpha-mcp-slack   generic  1                 0
         signal: null,
         output: [
           null,
-          "Id: 99999999-8888-4777-8666-555555555555\nType: nemoclaw-mcp-v1\nResource version: 1\nCredential keys: GITHUB_TOKEN\n",
+          providerMetadataOutput(
+            "foreign-provider",
+            "nemoclaw-mcp-v1",
+            "99999999-8888-4777-8666-555555555555",
+            1,
+            "GITHUB_TOKEN",
+          ),
           "",
         ],
-        stdout:
-          "Id: 99999999-8888-4777-8666-555555555555\nType: nemoclaw-mcp-v1\nResource version: 1\nCredential keys: GITHUB_TOKEN\n",
+        stdout: providerMetadataOutput(
+          "foreign-provider",
+          "nemoclaw-mcp-v1",
+          "99999999-8888-4777-8666-555555555555",
+          1,
+          "GITHUB_TOKEN",
+        ),
         stderr: "",
       });
     const entry: McpBridgeEntry = {
@@ -538,9 +526,9 @@ alpha-mcp-slack   generic  1                 0
       addedAt: "2026-08-19T00:00:00.000Z",
     };
 
-    expect(() =>
+    await expect(
       assertNoAttachedProviderCredentialCollisions("alpha", [entry], runtimeSelection),
-    ).toThrow("Credential key 'GITHUB_TOKEN' is already supplied by attached provider");
+    ).rejects.toThrow("Credential key 'GITHUB_TOKEN' is already supplied by attached provider");
     expect(run).toHaveBeenCalledTimes(2);
     expect(
       run.mock.calls.every(
@@ -551,7 +539,7 @@ alpha-mcp-slack   generic  1                 0
     ).toBe(true);
   });
 
-  it("pins registered collision inspection to the recorded runtime target (#10514)", () => {
+  it("pins registered collision inspection to the recorded runtime target (#10514)", async () => {
     const runtimeSelection = { gatewayName: "nemoclaw-9090", workspace: "default" };
     const run = vi.spyOn(providerCommand, "runOpenshellProviderCommand").mockReturnValue({
       pid: 1234,
@@ -559,11 +547,22 @@ alpha-mcp-slack   generic  1                 0
       signal: null,
       output: [
         null,
-        "Id: 99999999-8888-4777-8666-555555555555\nType: nemoclaw-mcp-v1\nResource version: 1\nCredential keys: GITHUB_TOKEN\n",
+        providerMetadataOutput(
+          "foreign-provider",
+          "nemoclaw-mcp-v1",
+          "99999999-8888-4777-8666-555555555555",
+          1,
+          "GITHUB_TOKEN",
+        ),
         "",
       ],
-      stdout:
-        "Id: 99999999-8888-4777-8666-555555555555\nType: nemoclaw-mcp-v1\nResource version: 1\nCredential keys: GITHUB_TOKEN\n",
+      stdout: providerMetadataOutput(
+        "foreign-provider",
+        "nemoclaw-mcp-v1",
+        "99999999-8888-4777-8666-555555555555",
+        1,
+        "GITHUB_TOKEN",
+      ),
       stderr: "",
     });
     const entry: McpBridgeEntry = {
@@ -578,12 +577,12 @@ alpha-mcp-slack   generic  1                 0
       addedAt: "2026-08-19T00:00:00.000Z",
     };
 
-    expect(() =>
+    await expect(
       assertNoRegisteredProviderCredentialCollisions([entry], {
         listExtraProviders: () => ["foreign-provider"],
         runtimeSelection,
       }),
-    ).toThrow("Credential key 'GITHUB_TOKEN' is already supplied by registered provider");
+    ).rejects.toThrow("Credential key 'GITHUB_TOKEN' is already supplied by registered provider");
     expect(run).toHaveBeenCalledWith(
       ["provider", "get", "foreign-provider"],
       expect.objectContaining({ runtimeSelection }),
@@ -636,17 +635,21 @@ alpha-mcp-slack   generic  1                 0
     });
 
     expect(
-      observeMcpCredentialRevision("alpha", {
-        server: "github",
-        agent: "openclaw",
-        adapter: "mcporter",
-        url: "https://mcp.example.test/mcp",
-        env: ["GITHUB_TOKEN"],
-        providerName: "alpha-mcp-github-0123456789abcdef",
-        providerId: "11111111-2222-4333-8444-555555555555",
-        policyName: "mcp-bridge-github",
-        addedAt: "2026-06-01T00:00:00.000Z",
-      }, runtimeSelection),
+      observeMcpCredentialRevision(
+        "alpha",
+        {
+          server: "github",
+          agent: "openclaw",
+          adapter: "mcporter",
+          url: "https://mcp.example.test/mcp",
+          env: ["GITHUB_TOKEN"],
+          providerName: "alpha-mcp-github-0123456789abcdef",
+          providerId: "11111111-2222-4333-8444-555555555555",
+          policyName: "mcp-bridge-github",
+          addedAt: "2026-06-01T00:00:00.000Z",
+        },
+        runtimeSelection,
+      ),
     ).toBe("v11");
     const proofCommand = exec.mock.calls[0]?.[1] ?? "";
     expect(proofCommand).toContain("\n");
@@ -660,28 +663,32 @@ alpha-mcp-slack   generic  1                 0
 
     exec.mockReturnValue({ status: 0, stdout: "raw-secret", stderr: "" });
     expect(() =>
-      observeMcpCredentialRevision("alpha", {
-        server: "github",
-        agent: "openclaw",
-        adapter: "mcporter",
-        url: "https://mcp.example.test/mcp",
-        env: ["GITHUB_TOKEN"],
-        providerName: "alpha-mcp-github-0123456789abcdef",
-        providerId: "11111111-2222-4333-8444-555555555555",
-        policyName: "mcp-bridge-github",
-        addedAt: "2026-06-01T00:00:00.000Z",
-      }, runtimeSelection),
+      observeMcpCredentialRevision(
+        "alpha",
+        {
+          server: "github",
+          agent: "openclaw",
+          adapter: "mcporter",
+          url: "https://mcp.example.test/mcp",
+          env: ["GITHUB_TOKEN"],
+          providerName: "alpha-mcp-github-0123456789abcdef",
+          providerId: "11111111-2222-4333-8444-555555555555",
+          policyName: "mcp-bridge-github",
+          addedAt: "2026-06-01T00:00:00.000Z",
+        },
+        runtimeSelection,
+      ),
     ).toThrow(/Could not observe the current OpenShell credential revision/);
   });
 
-  it("waits for native multiline OpenShell exec to expose an attached revision", () => {
+  it("waits for native multiline OpenShell exec to expose an attached revision", async () => {
     const exec = vi
       .spyOn(processRecovery, "executeSandboxExecCommand")
       .mockReturnValueOnce({ status: 0, stdout: "canonical", stderr: "" })
       .mockReturnValue({ status: 0, stdout: "v11", stderr: "" });
     const refreshAfterObservedAbsence = vi.fn();
 
-    const revision = waitForAttachedMcpCredential(
+    const revision = await waitForAttachedMcpCredential(
       "alpha",
       {
         server: "github",
@@ -708,7 +715,7 @@ alpha-mcp-slack   generic  1                 0
     expect(revision).toBe("v11");
   });
 
-  it("waits for a post-policy credential revision to settle before returning", () => {
+  it("waits for a post-policy credential revision to settle before returning", async () => {
     const entry: McpBridgeEntry = {
       server: "github",
       agent: "openclaw",
@@ -725,11 +732,13 @@ alpha-mcp-slack   generic  1                 0
       .mockReturnValueOnce({ status: 0, stdout: "v11", stderr: "" })
       .mockReturnValue({ status: 0, stdout: "v12", stderr: "" });
 
-    expect(waitForAttachedMcpCredential("alpha", entry, runtimeSelection)).toBe("v12");
+    await expect(waitForAttachedMcpCredential("alpha", entry, runtimeSelection)).resolves.toBe(
+      "v12",
+    );
     expect(exec).toHaveBeenCalledTimes(3);
   });
 
-  it("rejects a stable pre-update revision until the opaque provider mutation is projected", () => {
+  it("rejects a stable pre-update revision until the opaque provider mutation is projected", async () => {
     const entry: McpBridgeEntry = {
       server: "github",
       agent: "openclaw",
@@ -748,15 +757,15 @@ alpha-mcp-slack   generic  1                 0
       .mockReturnValueOnce({ status: 0, stdout: "v7480654703696766813", stderr: "" })
       .mockReturnValue({ status: 0, stdout: "v7480654703696766813", stderr: "" });
 
-    expect(
+    await expect(
       waitForAttachedMcpCredential("alpha", entry, runtimeSelection, {
         previousRevision: "v15566468742889590075",
       }),
-    ).toBe("v7480654703696766813");
+    ).resolves.toBe("v7480654703696766813");
     expect(exec).toHaveBeenCalledTimes(4);
   });
 
-  it("does not accept an identityless placeholder as attachment readiness", () => {
+  it("does not accept an identityless placeholder as attachment readiness", async () => {
     vi.stubEnv("NEMOCLAW_MCP_PROVIDER_SYNC_TIMEOUT_SECONDS", "1");
     vi.spyOn(processRecovery, "executeSandboxExecCommand").mockReturnValue({
       status: 0,
@@ -765,22 +774,26 @@ alpha-mcp-slack   generic  1                 0
     });
     vi.spyOn(Date, "now").mockReturnValueOnce(0).mockReturnValueOnce(0).mockReturnValue(1_000);
 
-    expect(() =>
-      waitForAttachedMcpCredential("alpha", {
-        server: "github",
-        agent: "deepagents-code",
-        adapter: "deepagents-config",
-        url: "https://mcp.example.test/mcp",
-        env: ["GITHUB_TOKEN"],
-        providerName: "alpha-mcp-github-0123456789abcdef",
-        providerId: "11111111-2222-4333-8444-555555555555",
-        policyName: "mcp-bridge-github",
-        addedAt: "2026-06-01T00:00:00.000Z",
-      }, runtimeSelection),
-    ).toThrow(/last bounded observation: canonical/);
+    await expect(
+      waitForAttachedMcpCredential(
+        "alpha",
+        {
+          server: "github",
+          agent: "deepagents-code",
+          adapter: "deepagents-config",
+          url: "https://mcp.example.test/mcp",
+          env: ["GITHUB_TOKEN"],
+          providerName: "alpha-mcp-github-0123456789abcdef",
+          providerId: "11111111-2222-4333-8444-555555555555",
+          policyName: "mcp-bridge-github",
+          addedAt: "2026-06-01T00:00:00.000Z",
+        },
+        runtimeSelection,
+      ),
+    ).rejects.toThrow(/last bounded observation: canonical/);
   });
 
-  it("reports an absent attached credential without attempting policy recovery", () => {
+  it("reports an absent attached credential without attempting policy recovery", async () => {
     vi.stubEnv("NEMOCLAW_MCP_PROVIDER_SYNC_TIMEOUT_SECONDS", "1");
     const exec = vi.spyOn(processRecovery, "executeSandboxExecCommand").mockReturnValue({
       status: 0,
@@ -789,23 +802,27 @@ alpha-mcp-slack   generic  1                 0
     });
     vi.spyOn(Date, "now").mockReturnValueOnce(0).mockReturnValueOnce(0).mockReturnValue(1_000);
 
-    expect(() =>
-      waitForAttachedMcpCredential("alpha", {
-        server: "github",
-        agent: "openclaw",
-        adapter: "mcporter",
-        url: "https://mcp.example.test/mcp",
-        env: ["GITHUB_TOKEN"],
-        providerName: "alpha-mcp-github-0123456789abcdef",
-        providerId: "11111111-2222-4333-8444-555555555555",
-        policyName: "mcp-bridge-github",
-        addedAt: "2026-06-01T00:00:00.000Z",
-      }, runtimeSelection),
-    ).toThrow(/last bounded observation: absent/);
+    await expect(
+      waitForAttachedMcpCredential(
+        "alpha",
+        {
+          server: "github",
+          agent: "openclaw",
+          adapter: "mcporter",
+          url: "https://mcp.example.test/mcp",
+          env: ["GITHUB_TOKEN"],
+          providerName: "alpha-mcp-github-0123456789abcdef",
+          providerId: "11111111-2222-4333-8444-555555555555",
+          policyName: "mcp-bridge-github",
+          addedAt: "2026-06-01T00:00:00.000Z",
+        },
+        runtimeSelection,
+      ),
+    ).rejects.toThrow(/last bounded observation: absent/);
     expect(exec).toHaveBeenCalledOnce();
   });
 
-  it("runs one provider-owned refresh after a fresh exec reports the credential absent", () => {
+  it("runs one provider-owned refresh after a fresh exec reports the credential absent", async () => {
     const entry: McpBridgeEntry = {
       server: "github",
       agent: "openclaw",
@@ -823,16 +840,16 @@ alpha-mcp-slack   generic  1                 0
       .mockReturnValue({ status: 0, stdout: "v12", stderr: "" });
     const refreshAfterObservedAbsence = vi.fn();
 
-    expect(
+    await expect(
       waitForAttachedMcpCredential("alpha", entry, runtimeSelection, {
         refreshAfterObservedAbsence,
       }),
-    ).toBe("v12");
+    ).resolves.toBe("v12");
     expect(refreshAfterObservedAbsence).toHaveBeenCalledOnce();
     expect(exec).toHaveBeenCalledTimes(3);
   });
 
-  it("does not repeat the provider refresh when the credential remains absent", () => {
+  it("does not repeat the provider refresh when the credential remains absent", async () => {
     vi.stubEnv("NEMOCLAW_MCP_PROVIDER_SYNC_TIMEOUT_SECONDS", "1");
     const exec = vi.spyOn(processRecovery, "executeSandboxExecCommand").mockReturnValue({
       status: 0,
@@ -842,7 +859,7 @@ alpha-mcp-slack   generic  1                 0
     vi.spyOn(Date, "now").mockReturnValueOnce(0).mockReturnValueOnce(0).mockReturnValue(1_000);
     const refreshAfterObservedAbsence = vi.fn();
 
-    expect(() =>
+    await expect(
       waitForAttachedMcpCredential(
         "alpha",
         {
@@ -859,7 +876,7 @@ alpha-mcp-slack   generic  1                 0
         runtimeSelection,
         { refreshAfterObservedAbsence },
       ),
-    ).toThrow(/post-absence provider refresh attempted: yes/u);
+    ).rejects.toThrow(/post-absence provider refresh attempted: yes/u);
     expect(refreshAfterObservedAbsence).toHaveBeenCalledOnce();
     expect(exec).toHaveBeenCalledTimes(2);
   });
@@ -868,7 +885,7 @@ alpha-mcp-slack   generic  1                 0
     ["unavailable", null, "transport-unavailable"],
     ["malformed", { status: 0, stdout: "raw-secret", stderr: "" }, "invalid-bounded-output"],
     ["rejected", { status: 1, stdout: "", stderr: "" }, "proof-command-exit-1"],
-  ])("does not refresh when a credential observation is %s", (_case, result, diagnostic) => {
+  ])("does not refresh when a credential observation is %s", async (_case, result, diagnostic) => {
     vi.stubEnv("NEMOCLAW_MCP_PROVIDER_SYNC_TIMEOUT_SECONDS", "1");
     vi.spyOn(processRecovery, "executeSandboxExecCommand").mockReturnValue(result);
     vi.spyOn(Date, "now").mockReturnValueOnce(0).mockReturnValueOnce(0).mockReturnValue(1_000);
@@ -876,7 +893,7 @@ alpha-mcp-slack   generic  1                 0
 
     let failure: unknown;
     try {
-      waitForAttachedMcpCredential(
+      await waitForAttachedMcpCredential(
         "alpha",
         {
           server: "github",
@@ -901,7 +918,7 @@ alpha-mcp-slack   generic  1                 0
     expect(refreshAfterObservedAbsence).not.toHaveBeenCalled();
   });
 
-  it("propagates a provider refresh failure after observed absence", () => {
+  it("propagates a provider refresh failure after observed absence", async () => {
     vi.spyOn(processRecovery, "executeSandboxExecCommand").mockReturnValue({
       status: 0,
       stdout: "absent",
@@ -911,7 +928,7 @@ alpha-mcp-slack   generic  1                 0
       throw new Error("provider refresh failed");
     });
 
-    expect(() =>
+    await expect(
       waitForAttachedMcpCredential(
         "alpha",
         {
@@ -928,11 +945,11 @@ alpha-mcp-slack   generic  1                 0
         runtimeSelection,
         { refreshAfterObservedAbsence },
       ),
-    ).toThrow("provider refresh failed");
+    ).rejects.toThrow("provider refresh failed");
     expect(refreshAfterObservedAbsence).toHaveBeenCalledOnce();
   });
 
-  it("does not accept a stale revision after the provider refresh", () => {
+  it("does not accept a stale revision after the provider refresh", async () => {
     vi.stubEnv("NEMOCLAW_MCP_PROVIDER_SYNC_TIMEOUT_SECONDS", "1");
     const exec = vi
       .spyOn(processRecovery, "executeSandboxExecCommand")
@@ -941,7 +958,7 @@ alpha-mcp-slack   generic  1                 0
     vi.spyOn(Date, "now").mockReturnValueOnce(0).mockReturnValueOnce(0).mockReturnValue(1_000);
     const refreshAfterObservedAbsence = vi.fn();
 
-    expect(() =>
+    await expect(
       waitForAttachedMcpCredential(
         "alpha",
         {
@@ -958,7 +975,9 @@ alpha-mcp-slack   generic  1                 0
         runtimeSelection,
         { previousRevision: "v11", refreshAfterObservedAbsence },
       ),
-    ).toThrow(/last bounded observation: v11; post-absence provider refresh attempted: yes/u);
+    ).rejects.toThrow(
+      /last bounded observation: v11; post-absence provider refresh attempted: yes/u,
+    );
     expect(refreshAfterObservedAbsence).toHaveBeenCalledOnce();
     expect(exec).toHaveBeenCalledTimes(2);
   });
@@ -969,17 +988,21 @@ alpha-mcp-slack   generic  1                 0
     vi.spyOn(Date, "now").mockReturnValueOnce(0).mockReturnValueOnce(0).mockReturnValue(1_000);
 
     expect(() =>
-      waitForDetachedMcpCredential("alpha", {
-        server: "github",
-        agent: "openclaw",
-        adapter: "mcporter",
-        url: "https://mcp.example.test/mcp",
-        env: ["GITHUB_TOKEN"],
-        providerName: "alpha-mcp-github-0123456789abcdef",
-        providerId: "11111111-2222-4333-8444-555555555555",
-        policyName: "mcp-bridge-github",
-        addedAt: "2026-06-01T00:00:00.000Z",
-      }, runtimeSelection),
+      waitForDetachedMcpCredential(
+        "alpha",
+        {
+          server: "github",
+          agent: "openclaw",
+          adapter: "mcporter",
+          url: "https://mcp.example.test/mcp",
+          env: ["GITHUB_TOKEN"],
+          providerName: "alpha-mcp-github-0123456789abcdef",
+          providerId: "11111111-2222-4333-8444-555555555555",
+          policyName: "mcp-bridge-github",
+          addedAt: "2026-06-01T00:00:00.000Z",
+        },
+        runtimeSelection,
+      ),
     ).toThrow(/did not confirm credential 'GITHUB_TOKEN' was revoked/);
 
     const proofCommand = exec.mock.calls[0]?.[1] ?? "";
@@ -991,7 +1014,7 @@ alpha-mcp-slack   generic  1                 0
     });
   });
 
-  it("requires a changed credential revision after provider updates", () => {
+  it("requires a changed credential revision after provider updates", async () => {
     const entry = {
       server: "github",
       agent: "openclaw",
@@ -1009,22 +1032,22 @@ alpha-mcp-slack   generic  1                 0
       stderr: "",
     });
 
-    expect(
+    await expect(
       waitForAttachedMcpCredential("alpha", entry, runtimeSelection, {
         previousRevision: "v11",
       }),
-    ).toBe("v12");
+    ).resolves.toBe("v12");
     expect(exec).toHaveBeenCalledTimes(2);
 
     vi.stubEnv("NEMOCLAW_MCP_PROVIDER_SYNC_TIMEOUT_SECONDS", "1");
     exec.mockClear();
     exec.mockReturnValue({ status: 0, stdout: "v11", stderr: "" });
     vi.spyOn(Date, "now").mockReturnValueOnce(0).mockReturnValueOnce(0).mockReturnValue(1_000);
-    expect(() =>
+    await expect(
       waitForAttachedMcpCredential("alpha", entry, runtimeSelection, {
         previousRevision: "v11",
       }),
-    ).toThrow(/did not synchronize the expected credential revision/);
+    ).rejects.toThrow(/did not synchronize the expected credential revision/);
     expect(exec).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/actions/sandbox/mcp-bridge-provider.ts
+++ b/src/lib/actions/sandbox/mcp-bridge-provider.ts
@@ -16,8 +16,6 @@ export {
   inspectMcpProvider,
   inspectMcpProviderAttachments,
   MCP_BRIDGE_PROVIDER_TYPE,
-  parseMcpProviderAttachmentNames,
-  parseMcpProviderMetadata,
   preflightMcpEntryTargets,
   providerAttached,
   providerMatchesCredential,
@@ -27,13 +25,11 @@ export {
 export type { ProviderDetachOutcome } from "./mcp-bridge-provider-mutation";
 export {
   attachProvider,
-  buildMcpBridgeProviderArgs,
   deleteProvider,
   detachMissingProviderReference,
   detachProvider,
   ensureMcpBridgeProviderProfile,
   refreshMcpProviderEnvironment,
-  providerDetachChangedState,
   upsertMcpProvider,
 } from "./mcp-bridge-provider-mutation";
 export type { McpCredentialRevisionObservation } from "./mcp-bridge-provider-readiness";

--- a/src/lib/actions/sandbox/mcp-bridge-rebuild-exec-unavailable.ts
+++ b/src/lib/actions/sandbox/mcp-bridge-rebuild-exec-unavailable.ts
@@ -123,7 +123,9 @@ function snapshotCompleteEntries(sandboxName: string): {
   };
 }
 
-function providerFingerprint(provider: ReturnType<typeof inspectExactMcpDestroyProvider>): string {
+function providerFingerprint(
+  provider: Awaited<ReturnType<typeof inspectExactMcpDestroyProvider>>,
+): string {
   return JSON.stringify({
     exists: provider.exists,
     id: provider.id,
@@ -173,14 +175,14 @@ async function inspectReadOnlyRecoveryState(
   const targetsByServer = new Map<string, string>();
   for (const entry of entries) {
     const target = resolvedTargets.get(entry.server);
-    const provider = inspectExactMcpDestroyProvider(entry, {
+    const provider = await inspectExactMcpDestroyProvider(entry, {
       allowMissing: false,
       runtimeSelection: providerRuntimeSelection,
     });
     providerByServer.set(entry.server, providerFingerprint(provider));
     targetsByServer.set(entry.server, targetFingerprint(target));
   }
-  assertNoProviderCredentialCollisions(sandboxName, entries, providerRuntimeSelection);
+  await assertNoProviderCredentialCollisions(sandboxName, entries, providerRuntimeSelection);
   return { providerByServer, runtimeSelection: providerRuntimeSelection, targetsByServer };
 }
 

--- a/src/lib/actions/sandbox/mcp-bridge-rebuild.ts
+++ b/src/lib/actions/sandbox/mcp-bridge-rebuild.ts
@@ -221,8 +221,8 @@ export async function prepareMcpBridgesForAbsentSandboxRebuild(
   for (const entry of entries) {
     assertGeneratedPolicyRegistrationMutationSafe(sandboxName, entry);
   }
-  for (const entry of entries) assertMcpProviderRecoverable(entry, providerRuntimeSelection);
-  assertNoRegisteredProviderCredentialCollisions(entries, {
+  for (const entry of entries) await assertMcpProviderRecoverable(entry, providerRuntimeSelection);
+  await assertNoRegisteredProviderCredentialCollisions(entries, {
     runtimeSelection: providerRuntimeSelection,
   });
   return {
@@ -261,8 +261,8 @@ export async function prepareMcpBridgesForRebuild(
     entries,
     providerRuntimeSelection,
   );
-  for (const entry of entries) assertMcpProviderRecoverable(entry, providerRuntimeSelection);
-  assertNoProviderCredentialCollisions(sandboxName, entries, providerRuntimeSelection);
+  for (const entry of entries) await assertMcpProviderRecoverable(entry, providerRuntimeSelection);
+  await assertNoProviderCredentialCollisions(sandboxName, entries, providerRuntimeSelection);
   // This is the bounded replacement handoff, not a durable NemoClaw policy
   // record. Capture OpenShell immediately before the internal teardown
   // mutations so the replacement receives the complete operator-owned
@@ -313,7 +313,7 @@ export async function prepareMcpBridgesForRebuild(
         allowMissing: false,
         runtimeSelection: providerRuntimeSelection,
       });
-      const detachOutcome = detachProvider(sandboxName, entry, {
+      const detachOutcome = await detachProvider(sandboxName, entry, {
         runtimeSelection: providerRuntimeSelection,
       });
       if (detachOutcome === "unknown") {

--- a/src/lib/actions/sandbox/mcp-bridge-rebuild.ts
+++ b/src/lib/actions/sandbox/mcp-bridge-rebuild.ts
@@ -309,7 +309,7 @@ export async function prepareMcpBridgesForRebuild(
     for (const entry of entries) {
       // Keep the provider and its host-only credentials for the replacement
       // sandbox, but detach it before OpenShell deletes the old attachment.
-      inspectExactMcpDestroyProvider(entry, {
+      await inspectExactMcpDestroyProvider(entry, {
         allowMissing: false,
         runtimeSelection: providerRuntimeSelection,
       });

--- a/src/lib/actions/sandbox/mcp-bridge-remove.ts
+++ b/src/lib/actions/sandbox/mcp-bridge-remove.ts
@@ -55,21 +55,21 @@ function requiresProviderDetachBeforeAdapterCleanup(entry: McpBridgeEntry): bool
   }
 }
 
-function assertExactMcpRemoveProvider(
+async function assertExactMcpRemoveProvider(
   entry: McpBridgeEntry,
   options: {
     allowMissing: boolean;
     force?: boolean;
     runtimeSelection: McpProviderInspectionRuntimeSelection;
   },
-): void {
+): Promise<void> {
   assertPersistedAuthenticatedBridgeEntry(entry);
   if (!entry.providerId) {
     throw new McpBridgeError(
       `MCP server '${entry.server}' has no stable OpenShell provider ID. Refusing destructive cleanup of same-name provider '${entry.providerName}'. Remove the legacy bridge with --force only after independently cleaning that provider.`,
     );
   }
-  const inspection = inspectMcpProvider(entry.providerName, options.runtimeSelection);
+  const inspection = await inspectMcpProvider(entry.providerName, options.runtimeSelection);
   if (inspection.exists === null) {
     throw new McpBridgeError(
       inspection.error ?? `Could not inspect OpenShell provider '${entry.providerName}'.`,
@@ -217,7 +217,7 @@ async function removeMcpBridgeUnlocked(
   let providerWasMissing = false;
   if (entry.providerName) {
     if (!entry.providerId) {
-      const inspection = inspectMcpProvider(entry.providerName, providerRuntimeSelection);
+      const inspection = await inspectMcpProvider(entry.providerName, providerRuntimeSelection);
       if (inspection.exists === false) {
         // With no live provider there is no global object to adopt or destroy.
         // This lets an operator independently remove a legacy/orphan provider,
@@ -233,7 +233,7 @@ async function removeMcpBridgeUnlocked(
         failures.push(detail);
       }
     } else {
-      const inspection = inspectMcpProvider(entry.providerName, providerRuntimeSelection);
+      const inspection = await inspectMcpProvider(entry.providerName, providerRuntimeSelection);
       if (inspection.exists === false) {
         providerOwnershipProved = true;
         providerWasMissing = true;
@@ -269,7 +269,7 @@ async function removeMcpBridgeUnlocked(
     detachBeforeAdapterCleanup
   ) {
     try {
-      detachMissingProviderReference(sandboxName, entry, providerRuntimeSelection);
+      await detachMissingProviderReference(sandboxName, entry, providerRuntimeSelection);
       missingProviderReferenceDetached = true;
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error);
@@ -285,7 +285,7 @@ async function removeMcpBridgeUnlocked(
         ? missingProviderReferenceDetached
           ? "detached"
           : "unknown"
-        : detachProvider(sandboxName, entry, {
+        : await detachProvider(sandboxName, entry, {
             allowLegacyGeneric: true,
             runtimeSelection: providerRuntimeSelection,
           });
@@ -314,11 +314,7 @@ async function removeMcpBridgeUnlocked(
       // this probe precedes every provider/policy/adapter side effect. Hermes
       // retains its helper/lifecycle validation; Deep Agents intentionally
       // skips only the marker that an older image cannot expose.
-      assertAgentMcpTeardownRuntimeCapability(
-        sandboxName,
-        adapter,
-        providerRuntimeSelection,
-      );
+      assertAgentMcpTeardownRuntimeCapability(sandboxName, adapter, providerRuntimeSelection);
       const adapterRemoval = unregisterAgentAdapter(
         sandboxName,
         (entry.adapter as AgentMcpAdapter | undefined) ?? adapter,
@@ -380,11 +376,11 @@ async function removeMcpBridgeUnlocked(
       if (providerWasMissing) {
         detachOutcome = missingProviderReferenceDetached
           ? "detached"
-          : detachMissingProviderReference(sandboxName, entry, providerRuntimeSelection);
+          : await detachMissingProviderReference(sandboxName, entry, providerRuntimeSelection);
       } else {
         detachOutcome = providerDetachedBeforeAdapterCleanup
           ? "detached"
-          : detachProvider(sandboxName, entry, {
+          : await detachProvider(sandboxName, entry, {
               allowLegacyGeneric: true,
               runtimeSelection: providerRuntimeSelection,
             });
@@ -421,12 +417,12 @@ async function removeMcpBridgeUnlocked(
       // replacement window. OpenShell main does not expose an atomic
       // identity-conditioned delete, so concurrent direct provider mutation
       // remains outside this lifecycle command's safety boundary.
-      assertExactMcpRemoveProvider(entry, {
+      await assertExactMcpRemoveProvider(entry, {
         allowMissing: false,
         force: options.force,
         runtimeSelection: providerRuntimeSelection,
       });
-      deleteProvider(entry, {
+      await deleteProvider(entry, {
         allowLegacyGeneric: true,
         allowMissing: options.force === true || entry.addState === "preflighted",
         runtimeSelection: providerRuntimeSelection,

--- a/src/lib/actions/sandbox/mcp-bridge-restart.ts
+++ b/src/lib/actions/sandbox/mcp-bridge-restart.ts
@@ -179,18 +179,14 @@ async function restartMcpBridgeUnlocked(sandboxName: string, server?: string): P
   // A hostless restart may reuse an attached stored credential only after the
   // existing wire probe verifies it. Check every target before policy or
   // provider mutation so a multi-server restart cannot half-apply (#10750).
-  await assertRestartCredentialsAvailable(
-    sandboxName,
-    targetEntries,
-    providerRuntimeSelection,
-  );
+  await assertRestartCredentialsAvailable(sandboxName, targetEntries, providerRuntimeSelection);
   // Validate every generated policy name before inspecting or updating any provider.
   for (const entry of targetEntries) assertGeneratedPolicyMutationSafe(sandboxName, entry);
   const providerInspectionByServer = new Map<string, McpProviderInspection>();
   for (const entry of targetEntries) {
     providerInspectionByServer.set(
       entry.server,
-      assertMcpProviderRecoverable(entry, providerRuntimeSelection),
+      await assertMcpProviderRecoverable(entry, providerRuntimeSelection),
     );
   }
   const missingProviderEntries = targetEntries.filter(
@@ -202,7 +198,7 @@ async function restartMcpBridgeUnlocked(sandboxName: string, server?: string): P
   // already proven absent; no live credential is removed before the runtime
   // capability probe, and the durable bridge manifest is retained on failure.
   for (const entry of missingProviderEntries) {
-    detachMissingProviderReference(sandboxName, entry, providerRuntimeSelection);
+    await detachMissingProviderReference(sandboxName, entry, providerRuntimeSelection);
   }
   assertMcpAdapterMutationRuntimeCapabilities(
     sandboxName,
@@ -215,7 +211,7 @@ async function restartMcpBridgeUnlocked(sandboxName: string, server?: string): P
   }
   // Inspect registered providers once before the first mutation. Per-entry
   // checks below inspect only attached providers at each mutation edge.
-  assertNoProviderCredentialCollisions(sandboxName, targetEntries, providerRuntimeSelection);
+  await assertNoProviderCredentialCollisions(sandboxName, targetEntries, providerRuntimeSelection);
   for (const [name, storedEntry] of targets) {
     // Validated as a complete authenticated entry before gateway side effects.
     if (!storedEntry) continue;
@@ -228,16 +224,20 @@ async function restartMcpBridgeUnlocked(sandboxName: string, server?: string): P
       writeBridgeEntry(sandboxName, retainPendingDenyToolJournal(entry, storedEntry));
     }
     let previousCredentialRevision: McpCredentialRevisionObservation | undefined;
-    assertNoAttachedProviderCredentialCollisions(sandboxName, [entry], providerRuntimeSelection);
+    await assertNoAttachedProviderCredentialCollisions(
+      sandboxName,
+      [entry],
+      providerRuntimeSelection,
+    );
     // Revalidate the actual running supervisor before rotating or recreating
     // credentials. The temporary policy cannot bind the provider until an
     // endpointless profile is attached.
-    ensureMcpBridgeProviderProfile(providerRuntimeSelection);
+    await ensureMcpBridgeProviderProfile(providerRuntimeSelection);
     applyGeneratedPolicy(sandboxName, entry, target, {
       bindCredential: false,
       runtimeSelection: providerRuntimeSelection,
     });
-    const providerResult = upsertMcpProvider(entry.providerName ?? "", envRefs, {
+    const providerResult = await upsertMcpProvider(entry.providerName ?? "", envRefs, {
       allowExisting: true,
       expectedProviderId: entry.providerId,
       runtimeSelection: providerRuntimeSelection,
@@ -262,25 +262,26 @@ async function restartMcpBridgeUnlocked(sandboxName: string, server?: string): P
     if (refreshedEntry !== entry) {
       // A missing owned provider may be recreated during restart. Record the
       // replacement object's immutable ID before policy/attach/adapter work.
-      writeBridgeEntry(
-        sandboxName,
-        retainPendingDenyToolJournal(refreshedEntry, storedEntry),
-      );
+      writeBridgeEntry(sandboxName, retainPendingDenyToolJournal(refreshedEntry, storedEntry));
       entry = refreshedEntry;
     }
-    assertNoAttachedProviderCredentialCollisions(sandboxName, [entry], providerRuntimeSelection);
+    await assertNoAttachedProviderCredentialCollisions(
+      sandboxName,
+      [entry],
+      providerRuntimeSelection,
+    );
     if (providerResult.action === "updated" && previousCredentialRevision === undefined) {
       throw new McpBridgeError(
         `Could not retain the prior OpenShell credential revision for provider '${entry.providerName}'.`,
       );
     }
-    attachProvider(sandboxName, entry, providerRuntimeSelection);
+    await attachProvider(sandboxName, entry, providerRuntimeSelection);
     applyGeneratedPolicy(sandboxName, entry, target, {
       runtimeSelection: providerRuntimeSelection,
     });
-    refreshMcpProviderEnvironment(entry, providerRuntimeSelection);
+    await refreshMcpProviderEnvironment(entry, providerRuntimeSelection);
     const entryAdapter = (entry.adapter as AgentMcpAdapter | undefined) ?? adapter;
-    const credentialRevision = waitForAttachedMcpCredential(
+    const credentialRevision = await waitForAttachedMcpCredential(
       sandboxName,
       entry,
       providerRuntimeSelection,
@@ -355,7 +356,7 @@ export async function restoreExistingMcpBridgeRuntime(
   const defaultAdapter = getBridgeAdapter(getSandboxAgent(sandbox));
   for (const entry of entries) {
     assertGeneratedPolicyMutationSafe(sandboxName, entry);
-    const provider = assertMcpProviderRecoverable(entry, providerRuntimeSelection);
+    const provider = await assertMcpProviderRecoverable(entry, providerRuntimeSelection);
     if (provider.exists !== true) {
       throw new McpBridgeError(
         `OpenShell provider '${entry.providerName}' is missing. Runtime restoration refuses to create or rotate credentials; run explicit MCP restart after exporting '${entry.env[0]}'.`,
@@ -366,25 +367,29 @@ export async function restoreExistingMcpBridgeRuntime(
   // pre-existing collision on a later entry cannot follow an earlier restore
   // mutation. Per-entry attached-provider checks detect new collisions at each
   // restore mutation edge.
-  assertNoProviderCredentialCollisions(sandboxName, entries, providerRuntimeSelection);
+  await assertNoProviderCredentialCollisions(sandboxName, entries, providerRuntimeSelection);
   for (const entry of entries) {
-    assertNoAttachedProviderCredentialCollisions(sandboxName, [entry], providerRuntimeSelection);
-    ensureMcpBridgeProviderProfile(providerRuntimeSelection);
+    await assertNoAttachedProviderCredentialCollisions(
+      sandboxName,
+      [entry],
+      providerRuntimeSelection,
+    );
+    await ensureMcpBridgeProviderProfile(providerRuntimeSelection);
     if (options.applyPolicy !== false) {
       applyGeneratedPolicy(sandboxName, entry, resolvedTargetPins(resolvedByServer, entry), {
         bindCredential: false,
         runtimeSelection: providerRuntimeSelection,
       });
     }
-    attachProvider(sandboxName, entry, providerRuntimeSelection);
+    await attachProvider(sandboxName, entry, providerRuntimeSelection);
     if (options.applyPolicy !== false) {
       applyGeneratedPolicy(sandboxName, entry, resolvedTargetPins(resolvedByServer, entry), {
         runtimeSelection: providerRuntimeSelection,
       });
     }
     const adapter = (entry.adapter as AgentMcpAdapter | undefined) ?? defaultAdapter;
-    refreshMcpProviderEnvironment(entry, providerRuntimeSelection);
-    const credentialRevision = waitForAttachedMcpCredential(
+    await refreshMcpProviderEnvironment(entry, providerRuntimeSelection);
+    const credentialRevision = await waitForAttachedMcpCredential(
       sandboxName,
       entry,
       providerRuntimeSelection,

--- a/src/lib/actions/sandbox/mcp-bridge-status-boundaries.test.ts
+++ b/src/lib/actions/sandbox/mcp-bridge-status-boundaries.test.ts
@@ -48,7 +48,7 @@ providerCommands.setProviderCommandRuntimeHooksForTest({ runOpenshell: (args, op
   if (args[0] === "provider" && args[1] === "get") {
     return {
       status: 0,
-      stdout: "Id: 11111111-2222-4333-8444-555555555555\nType: nemoclaw-mcp-v1\nResource version: 4\nCredential keys: GITHUB_TOKEN\n",
+      stdout: "Name: alpha-mcp-github\nId: 11111111-2222-4333-8444-555555555555\nType: nemoclaw-mcp-v1\nResource version: 4\nCredential keys: GITHUB_TOKEN\nConfig keys: <none>\n",
       stderr: "",
     };
   }
@@ -143,7 +143,7 @@ providerCommands.runOpenshellProviderCommand = (args) => {
   if (args[0] === "provider" && args[1] === "get") {
     return {
       status: 0,
-      stdout: "Id: 11111111-2222-4333-8444-555555555555\nType: nemoclaw-mcp-v1\nResource version: 4\nCredential keys: LD_PRELOAD\n",
+      stdout: "Name: alpha-mcp-fake\nId: 11111111-2222-4333-8444-555555555555\nType: nemoclaw-mcp-v1\nResource version: 4\nCredential keys: LD_PRELOAD\nConfig keys: <none>\n",
       stderr: "",
     };
   }

--- a/src/lib/actions/sandbox/mcp-bridge-status-resolution.test.ts
+++ b/src/lib/actions/sandbox/mcp-bridge-status-resolution.test.ts
@@ -56,19 +56,24 @@ let providerAttachmentState = "attached";
 let providerInspectionState = "present";
 let providerCredentialKey = "GITHUB_TOKEN";
 let persistedCredentialRevision = "v11";
+let includeSecondAttachment = false;
+let providerAttachmentInspectionCount = 0;
 const hermesIntentPayloads = [];
 providerCommands.runOpenshellProviderCommand = (args) => {
   if (args[0] === "provider" && args[1] === "get") {
     if (providerInspectionState === "absent") {
       return { status: 1, stdout: "", stderr: "provider not found" };
     }
+    const providerName = args[2];
+    const credentialKey = providerName === "alpha-mcp-slack" ? "SLACK_TOKEN" : providerCredentialKey;
     return {
       status: 0,
-      stdout: "Name: alpha-mcp-github\nId: 11111111-2222-4333-8444-555555555555\nType: nemoclaw-mcp-v1\nResource version: 4\nCredential keys: " + providerCredentialKey + "\nConfig keys: <none>\n",
+      stdout: "Name: " + providerName + "\nId: 11111111-2222-4333-8444-555555555555\nType: nemoclaw-mcp-v1\nResource version: 4\nCredential keys: " + credentialKey + "\nConfig keys: <none>\n",
       stderr: "",
     };
   }
   if (args[0] === "sandbox" && args[1] === "provider" && args[2] === "list") {
+    providerAttachmentInspectionCount += 1;
     if (providerAttachmentState === "unknown") {
       return { status: 1, stdout: "", stderr: "attachment inspection failed" };
     }
@@ -77,7 +82,8 @@ providerCommands.runOpenshellProviderCommand = (args) => {
     }
     return {
       status: 0,
-      stdout: "NAME TYPE CREDENTIAL_KEYS CONFIG_KEYS\nalpha-mcp-github nemoclaw-mcp-v1 1 0\n",
+      stdout: "NAME TYPE CREDENTIAL_KEYS CONFIG_KEYS\nalpha-mcp-github nemoclaw-mcp-v1 1 0\n" +
+        (includeSecondAttachment ? "alpha-mcp-slack nemoclaw-mcp-v1 1 0\n" : ""),
       stderr: "",
     };
   }
@@ -205,6 +211,40 @@ ${body}
 }
 
 describe("MCP status wire-level credential-resolution probe", { timeout: 15_000 }, () => {
+  it("inspects the attachment inventory once for a multi-server status read (#9806)", () => {
+    const home = createTempHome("nemoclaw-mcp-status-attachments-");
+    const { stdout } = runHarness(
+      home,
+      String.raw`
+  const current = registry.getSandbox("alpha");
+  registry.updateSandbox("alpha", {
+    mcp: { bridges: {
+      ...current.mcp.bridges,
+      slack: {
+        ...current.mcp.bridges.github,
+        server: "slack",
+        env: ["SLACK_TOKEN"],
+        providerName: "alpha-mcp-slack",
+        policyName: "mcp-bridge-slack",
+      },
+    } },
+  });
+  includeSecondAttachment = true;
+  providerAttachmentInspectionCount = 0;
+  const statuses = await bridge.statusMcpBridge("alpha");
+  writeHarnessResult(JSON.stringify({
+    attachmentInspections: providerAttachmentInspectionCount,
+    attached: statuses.map((status) => status.provider.attached),
+  }));
+`,
+    );
+
+    expect(JSON.parse(stdout)).toEqual({
+      attachmentInspections: 1,
+      attached: [true, true],
+    });
+  });
+
   it("probes by default for a single named server and surfaces the wire failure (#6379)", () => {
     const home = createTempHome("nemoclaw-mcp-resolution-single-");
     const { stdout } = runHarness(

--- a/src/lib/actions/sandbox/mcp-bridge-status-resolution.test.ts
+++ b/src/lib/actions/sandbox/mcp-bridge-status-resolution.test.ts
@@ -64,7 +64,7 @@ providerCommands.runOpenshellProviderCommand = (args) => {
     }
     return {
       status: 0,
-      stdout: "Id: 11111111-2222-4333-8444-555555555555\nType: nemoclaw-mcp-v1\nResource version: 4\nCredential keys: " + providerCredentialKey + "\n",
+      stdout: "Name: alpha-mcp-github\nId: 11111111-2222-4333-8444-555555555555\nType: nemoclaw-mcp-v1\nResource version: 4\nCredential keys: " + providerCredentialKey + "\nConfig keys: <none>\n",
       stderr: "",
     };
   }

--- a/src/lib/actions/sandbox/mcp-bridge-status.ts
+++ b/src/lib/actions/sandbox/mcp-bridge-status.ts
@@ -322,186 +322,191 @@ export async function statusMcpBridge(
     }),
   );
 
-  return entries.map(([name, entry]) => {
-    const support = entry ? getPersistedBridgeSupport(entry) : getSupportSummary(agent);
-    const registeredPolicy = getRegisteredGeneratedPolicy(sandboxName, entry);
-    const policyState = getPolicyGatewayState(sandboxName, entry, providerRuntimeSelection);
-    const policyPresence =
-      policyState === "match" ? true : policyState === "absent" ? false : null;
-    const hasCredentialBinding =
-      !!entry &&
-      Array.isArray(entry.env) &&
-      entry.env.length === 1 &&
-      !!entry.providerName &&
-      !!entry.providerId;
-    const missingEnv = entry
-      ? entry.env.filter(
-          (envName: string) => process.env[envName] === undefined || process.env[envName] === "",
-        )
-      : [];
-    const expectedCredential = entry?.env.length === 1 ? entry.env[0] : undefined;
-    const providerInspection = inspectMcpProvider(entry?.providerName, providerRuntimeSelection);
-    const providerCredentialReady = providerMatchesCredential(
-      providerInspection,
-      expectedCredential,
-      entry?.providerId,
-    );
-    const providerDetail = providerShapeDetail(
-      providerInspection,
-      expectedCredential,
-      entry?.providerId,
-    );
-    const attached = providerAttached(
-      sandboxName,
-      entry?.providerName,
-      providerRuntimeSelection,
-    );
-    const warnings: string[] = [];
-    let credentialWarning: string | undefined;
-    if (entry) {
-      const urlWarning = storedUrlWarning(entry);
-      if (urlWarning) warnings.push(urlWarning);
-      credentialWarning = storedCredentialWarning(entry);
-      if (credentialWarning) warnings.push(credentialWarning);
-      if (entry.pendingDenyTools !== undefined) {
+  return Promise.all(
+    entries.map(async ([name, entry]) => {
+      const support = entry ? getPersistedBridgeSupport(entry) : getSupportSummary(agent);
+      const registeredPolicy = getRegisteredGeneratedPolicy(sandboxName, entry);
+      const policyState = getPolicyGatewayState(sandboxName, entry, providerRuntimeSelection);
+      const policyPresence =
+        policyState === "match" ? true : policyState === "absent" ? false : null;
+      const hasCredentialBinding =
+        !!entry &&
+        Array.isArray(entry.env) &&
+        entry.env.length === 1 &&
+        !!entry.providerName &&
+        !!entry.providerId;
+      const missingEnv = entry
+        ? entry.env.filter(
+            (envName: string) => process.env[envName] === undefined || process.env[envName] === "",
+          )
+        : [];
+      const expectedCredential = entry?.env.length === 1 ? entry.env[0] : undefined;
+      const providerInspection = await inspectMcpProvider(
+        entry?.providerName,
+        providerRuntimeSelection,
+      );
+      const providerCredentialReady = providerMatchesCredential(
+        providerInspection,
+        expectedCredential,
+        entry?.providerId,
+      );
+      const providerDetail = providerShapeDetail(
+        providerInspection,
+        expectedCredential,
+        entry?.providerId,
+      );
+      const attached = await providerAttached(
+        sandboxName,
+        entry?.providerName,
+        providerRuntimeSelection,
+      );
+      const warnings: string[] = [];
+      let credentialWarning: string | undefined;
+      if (entry) {
+        const urlWarning = storedUrlWarning(entry);
+        if (urlWarning) warnings.push(urlWarning);
+        credentialWarning = storedCredentialWarning(entry);
+        if (credentialWarning) warnings.push(credentialWarning);
+        if (entry.pendingDenyTools !== undefined) {
+          warnings.push(
+            `Denied-tool update is interrupted. Run \`nemoclaw ${sandboxName} mcp restart ${entry.server}\` to commit it and restore the generated policy.`,
+          );
+        } else if (policyState === "drift") {
+          warnings.push(
+            `Generated policy differs from registered MCP intent. Run \`nemoclaw ${sandboxName} mcp restart ${entry.server}\` to restore it.`,
+          );
+        } else if (policyState === "absent") {
+          warnings.push(
+            `Generated policy is missing for registered MCP intent. Run \`nemoclaw ${sandboxName} mcp restart ${entry.server}\` to restore it.`,
+          );
+        }
+      }
+      const privatePinStatus = privatePinStatusByServer.get(name);
+      if (privatePinStatus?.state === "drift") {
         warnings.push(
-          `Denied-tool update is interrupted. Run \`nemoclaw ${sandboxName} mcp restart ${entry.server}\` to commit it and restore the generated policy.`,
+          "Trusted-private DNS answers differ from the recorded pins. Remove and re-add this server to approve changed pins.",
         );
-      } else if (policyState === "drift") {
+      } else if (privatePinStatus?.state === "unresolved") {
         warnings.push(
-          `Generated policy differs from registered MCP intent. Run \`nemoclaw ${sandboxName} mcp restart ${entry.server}\` to restore it.`,
-        );
-      } else if (policyState === "absent") {
-        warnings.push(
-          `Generated policy is missing for registered MCP intent. Run \`nemoclaw ${sandboxName} mcp restart ${entry.server}\` to restore it.`,
+          "Trusted-private DNS resolution is unavailable. The recorded policy pins were not changed.",
         );
       }
-    }
-    const privatePinStatus = privatePinStatusByServer.get(name);
-    if (privatePinStatus?.state === "drift") {
-      warnings.push(
-        "Trusted-private DNS answers differ from the recorded pins. Remove and re-add this server to approve changed pins.",
+      const unsafeCredentialMayBeAttached =
+        !!credentialWarning && !!entry?.providerName && attached !== false;
+      const credentialObservation = entry ? credentialObservations.get(name) : undefined;
+      const credentialRevision = attachedCredentialRevision(credentialObservation);
+      const observationDetail = credentialObservationDetail(credentialObservation);
+      const readiness = {
+        policyGatewayPresent: policyPresence,
+        providerAttached: attached,
+        providerCredentialReady,
+      };
+      const adapterRegistration = getAdapterRegistration(
+        sandboxName,
+        support.adapter,
+        entry,
+        providerRuntimeSelection,
+        hermesReconciliation,
+        credentialRevision,
+        unsafeCredentialMayBeAttached ? UNSUPPORTED_ATTACHED_CREDENTIAL_DETAIL : observationDetail,
       );
-    } else if (privatePinStatus?.state === "unresolved") {
-      warnings.push(
-        "Trusted-private DNS resolution is unavailable. The recorded policy pins were not changed.",
-      );
-    }
-    const unsafeCredentialMayBeAttached =
-      !!credentialWarning && !!entry?.providerName && attached !== false;
-    const credentialObservation = entry ? credentialObservations.get(name) : undefined;
-    const credentialRevision = attachedCredentialRevision(credentialObservation);
-    const observationDetail = credentialObservationDetail(credentialObservation);
-    const readiness = {
-      policyGatewayPresent: policyPresence,
-      providerAttached: attached,
-      providerCredentialReady,
-    };
-    const adapterRegistration = getAdapterRegistration(
-      sandboxName,
-      support.adapter,
-      entry,
-      providerRuntimeSelection,
-      hermesReconciliation,
-      credentialRevision,
-      unsafeCredentialMayBeAttached ? UNSUPPORTED_ATTACHED_CREDENTIAL_DETAIL : observationDetail,
-    );
-    const credentialResolution =
-      options.probeCredentialResolution && entry
-        ? unsafeCredentialMayBeAttached
-          ? {
-              ok: null,
-              detail: `probe skipped: ${UNSUPPORTED_ATTACHED_CREDENTIAL_DETAIL}`,
-            }
-          : observationDetail
-            ? { ok: null, detail: `probe skipped: ${observationDetail}` }
-            : adapterRegistration.registered !== true &&
-                options.allowCredentialProbeWithAdapterMismatch !== true
-              ? {
-                  ok: null,
-                  detail:
-                    "probe skipped: the managed agent adapter does not match the current credential revision",
-                }
-              : probeCredentialResolution(
-                  sandboxName,
-                  entry,
-                  support.adapter,
-                  readiness,
-                  providerRuntimeSelection,
-                  credentialRevision,
-                )
+      const credentialResolution =
+        options.probeCredentialResolution && entry
+          ? unsafeCredentialMayBeAttached
+            ? {
+                ok: null,
+                detail: `probe skipped: ${UNSUPPORTED_ATTACHED_CREDENTIAL_DETAIL}`,
+              }
+            : observationDetail
+              ? { ok: null, detail: `probe skipped: ${observationDetail}` }
+              : adapterRegistration.registered !== true &&
+                  options.allowCredentialProbeWithAdapterMismatch !== true
+                ? {
+                    ok: null,
+                    detail:
+                      "probe skipped: the managed agent adapter does not match the current credential revision",
+                  }
+                : probeCredentialResolution(
+                    sandboxName,
+                    entry,
+                    support.adapter,
+                    readiness,
+                    providerRuntimeSelection,
+                    credentialRevision,
+                  )
+          : undefined;
+      const resolutionWarning = credentialResolution
+        ? credentialResolutionWarning(entry?.env[0], credentialResolution)
         : undefined;
-    const resolutionWarning = credentialResolution
-      ? credentialResolutionWarning(entry?.env[0], credentialResolution)
-      : undefined;
-    if (resolutionWarning) warnings.push(resolutionWarning);
-    const toolDiscovery =
-      options.discoverTools && entry
-        ? unsafeCredentialMayBeAttached
+      if (resolutionWarning) warnings.push(resolutionWarning);
+      const toolDiscovery =
+        options.discoverTools && entry
+          ? unsafeCredentialMayBeAttached
+            ? {
+                ok: false,
+                count: 0,
+                tools: [],
+                truncated: false,
+                detail: `tool discovery skipped: ${UNSUPPORTED_ATTACHED_CREDENTIAL_DETAIL}`,
+              }
+            : discoverMcpTools(
+                sandboxName,
+                entry,
+                support.adapter,
+                readiness,
+                providerRuntimeSelection,
+              )
+          : undefined;
+      return {
+        server: name,
+        agent: entry?.agent ?? agent.name,
+        warnings,
+        support,
+        ...(entry ? { url: entry.url } : {}),
+        ...(entry?.trustedPrivateHost && entry.allowedIps && privatePinStatus
           ? {
-              ok: false,
-              count: 0,
-              tools: [],
-              truncated: false,
-              detail: `tool discovery skipped: ${UNSUPPORTED_ATTACHED_CREDENTIAL_DETAIL}`,
+              trustedPrivateTarget: {
+                host: entry.trustedPrivateHost,
+                recordedPins: [...entry.allowedIps],
+                ...(privatePinStatus.currentAddresses
+                  ? { currentPins: privatePinStatus.currentAddresses }
+                  : {}),
+                state: privatePinStatus.state,
+                ...(privatePinStatus.detail ? { detail: privatePinStatus.detail } : {}),
+              },
             }
-          : discoverMcpTools(
-              sandboxName,
-              entry,
-              support.adapter,
-              readiness,
-              providerRuntimeSelection,
-            )
-        : undefined;
-    return {
-      server: name,
-      agent: entry?.agent ?? agent.name,
-      warnings,
-      support,
-      ...(entry ? { url: entry.url } : {}),
-      ...(entry?.trustedPrivateHost && entry.allowedIps && privatePinStatus
-        ? {
-            trustedPrivateTarget: {
-              host: entry.trustedPrivateHost,
-              recordedPins: [...entry.allowedIps],
-              ...(privatePinStatus.currentAddresses
-                ? { currentPins: privatePinStatus.currentAddresses }
-                : {}),
-              state: privatePinStatus.state,
-              ...(privatePinStatus.detail ? { detail: privatePinStatus.detail } : {}),
-            },
-          }
-        : {}),
-      ...(entry?.addState ? { addState: entry.addState } : {}),
-      env: {
-        names: entry?.env ?? [],
-        missing: missingEnv,
-        ready:
-          hasCredentialBinding &&
-          !entry?.addState &&
-          (providerInspection.exists ? providerCredentialReady : missingEnv.length === 0),
-      },
-      provider: {
-        name: entry?.providerName,
-        registryPresent: !!entry?.providerName,
-        gatewayPresent: entry?.providerName ? providerInspection.exists : null,
-        attached,
-        credentialReady: entry ? providerCredentialReady : null,
-        ...(providerDetail ? { detail: providerDetail } : {}),
-        ...(credentialResolution ? { credentialResolution } : {}),
-      },
-      policy: {
-        name: entry?.policyName,
-        registryPresent: !!registeredPolicy,
-        gatewayPresent: policyPresence,
-        ...(policyState === "drift" ? { state: "drift" as const } : {}),
-      },
-      adapter: adapterRegistration,
-      ...(toolDiscovery ? { toolDiscovery } : {}),
-      ...(entry?.addedAt ? { addedAt: entry.addedAt } : {}),
-      ...(entry?.updatedAt ? { updatedAt: entry.updatedAt } : {}),
-    };
-  });
+          : {}),
+        ...(entry?.addState ? { addState: entry.addState } : {}),
+        env: {
+          names: entry?.env ?? [],
+          missing: missingEnv,
+          ready:
+            hasCredentialBinding &&
+            !entry?.addState &&
+            (providerInspection.exists ? providerCredentialReady : missingEnv.length === 0),
+        },
+        provider: {
+          name: entry?.providerName,
+          registryPresent: !!entry?.providerName,
+          gatewayPresent: entry?.providerName ? providerInspection.exists : null,
+          attached,
+          credentialReady: entry ? providerCredentialReady : null,
+          ...(providerDetail ? { detail: providerDetail } : {}),
+          ...(credentialResolution ? { credentialResolution } : {}),
+        },
+        policy: {
+          name: entry?.policyName,
+          registryPresent: !!registeredPolicy,
+          gatewayPresent: policyPresence,
+          ...(policyState === "drift" ? { state: "drift" as const } : {}),
+        },
+        adapter: adapterRegistration,
+        ...(toolDiscovery ? { toolDiscovery } : {}),
+        ...(entry?.addedAt ? { addedAt: entry.addedAt } : {}),
+        ...(entry?.updatedAt ? { updatedAt: entry.updatedAt } : {}),
+      };
+    }),
+  );
 }
 
 function getPersistedBridgeSupport(entry: McpBridgeEntry): McpBridgeStatus["support"] {

--- a/src/lib/actions/sandbox/mcp-bridge-status.ts
+++ b/src/lib/actions/sandbox/mcp-bridge-status.ts
@@ -21,8 +21,8 @@ import { getPolicyGatewayState, getRegisteredGeneratedPolicy } from "./mcp-bridg
 import {
   getMcpProviderInspectionRuntimeSelection,
   inspectMcpProvider,
+  inspectMcpProviderAttachments,
   observeMcpCredentialRevision,
-  providerAttached,
   providerMatchesCredential,
   providerShapeDetail,
 } from "./mcp-bridge-provider";
@@ -322,6 +322,10 @@ export async function statusMcpBridge(
     }),
   );
 
+  const attachmentInspection = entries.some(([, entry]) => !!entry?.providerName)
+    ? await inspectMcpProviderAttachments(sandboxName, providerRuntimeSelection)
+    : undefined;
+
   return Promise.all(
     entries.map(async ([name, entry]) => {
       const support = entry ? getPersistedBridgeSupport(entry) : getSupportSummary(agent);
@@ -355,11 +359,13 @@ export async function statusMcpBridge(
         expectedCredential,
         entry?.providerId,
       );
-      const attached = await providerAttached(
-        sandboxName,
-        entry?.providerName,
-        providerRuntimeSelection,
-      );
+      const attached = !entry?.providerName
+        ? null
+        : !attachmentInspection?.attachments
+          ? null
+          : attachmentInspection.attachments.some(
+              (attachment) => attachment.name === entry.providerName,
+            );
       const warnings: string[] = [];
       let credentialWarning: string | undefined;
       if (entry) {

--- a/src/lib/actions/sandbox/mcp-bridge.ts
+++ b/src/lib/actions/sandbox/mcp-bridge.ts
@@ -70,12 +70,8 @@ export {
   MCP_BRIDGE_POLICY_MAX_BODY_BYTES,
 } from "./mcp-bridge-policy";
 export {
-  buildMcpBridgeProviderArgs,
   buildMcpCredentialRevisionObservationCommand,
   detachMissingProviderReference,
-  parseMcpProviderAttachmentNames,
-  parseMcpProviderMetadata,
-  providerDetachChangedState,
 } from "./mcp-bridge-provider";
 export { prepareMcpBridgesForExecUnavailableRebuild } from "./mcp-bridge-rebuild";
 export {
@@ -373,7 +369,9 @@ export async function dispatchMcpBridgeCommand(
         const agent = getSandboxAgent(sandbox);
         const statuses = await statusMcpBridge(sandboxName);
         if (json)
-          process.stdout.write(`${JSON.stringify(buildJsonSummary(sandboxName, agent, statuses), null, 2)}\n`);
+          process.stdout.write(
+            `${JSON.stringify(buildJsonSummary(sandboxName, agent, statuses), null, 2)}\n`,
+          );
         else renderMcpBridgeList(sandboxName, statuses, agent);
         return;
       }

--- a/src/lib/actions/sandbox/mcp-bridge/timing.ts
+++ b/src/lib/actions/sandbox/mcp-bridge/timing.ts
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { sleepMs, waitUntil } from "../../../core/wait";
+import { sleepMs, waitUntil, waitUntilAsync } from "../../../core/wait";
 
 /** Keep MCP synchronization delays behind one domain-owned timing boundary. */
 export const sleepMcpBridgeRetry = sleepMs;
 export const waitForMcpBridgeCondition = waitUntil;
+export const waitForMcpBridgeConditionAsync = waitUntilAsync;

--- a/src/lib/adapters/openshell/provider-adapter-cli-uncertainty.test.ts
+++ b/src/lib/adapters/openshell/provider-adapter-cli-uncertainty.test.ts
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { createCliOpenShellProviderAdapter } from "./provider-adapter-cli";
+import { selectedOpenShellGateway } from "./sandbox-observer";
+
+function captured(status: number | null, stderr: string) {
+  return { status, stdout: "", stderr };
+}
+
+describe("CLI OpenShell provider adapter uncertain mutations", () => {
+  it.each([
+    ["status-less", captured(null, "NotAttached")],
+    [
+      "signaled",
+      { ...captured(null, "provider search-prod is not attached"), signal: "SIGTERM" as const },
+    ],
+  ])("rejects an uncertain idempotent detach result: %s (#9806)", async (_case, result) => {
+    const adapter = createCliOpenShellProviderAdapter({ run: () => result });
+
+    await expect(
+      adapter.detachProvider({
+        target: selectedOpenShellGateway(),
+        providerName: "search-prod",
+        sandboxName: "alpha",
+      }),
+    ).resolves.toMatchObject({ ok: false });
+  });
+
+  it("preserves the provider-not-found compatibility diagnostic on delete (#9806)", async () => {
+    const adapter = createCliOpenShellProviderAdapter({
+      run: () => captured(1, "provider 'search-prod' not found"),
+    });
+
+    await expect(
+      adapter.deleteProvider({
+        target: selectedOpenShellGateway(),
+        providerName: "search-prod",
+      }),
+    ).resolves.toMatchObject({
+      error: { reason: "not_found", message: "OpenShell provider not found: 'search-prod'." },
+    });
+  });
+});

--- a/src/lib/adapters/openshell/provider-adapter-cli.test.ts
+++ b/src/lib/adapters/openshell/provider-adapter-cli.test.ts
@@ -133,7 +133,7 @@ describe("CLI OpenShell provider adapter", () => {
       expectedFailure,
       expectedFailure,
       expectedFailure,
-      expectedFailure,
+      { ...expectedFailure, operation: "inspect" },
       expectedFailure,
       expectedFailure,
       expectedFailure,
@@ -1037,6 +1037,7 @@ describe("CLI OpenShell provider adapter", () => {
         message:
           "The OpenShell provider profile does not match the checked-in credential boundary.",
       },
+      operation: "verify",
     });
     expect(run).toHaveBeenCalledTimes(1);
   });
@@ -1105,6 +1106,7 @@ describe("CLI OpenShell provider adapter", () => {
         kind: "validation",
         message: "The checked-in OpenShell provider profile is invalid or unreadable.",
       },
+      operation: "read",
     });
     expect(run).not.toHaveBeenCalled();
   });
@@ -1198,7 +1200,7 @@ describe("CLI OpenShell provider adapter", () => {
         providerName: "search-prod",
         sandboxName: "alpha",
       }),
-    ).resolves.toEqual({ ok: true });
+    ).resolves.toEqual({ ok: true, value: { changed: true } });
     expect(run.mock.calls[1]?.[0]).toEqual([
       "sandbox",
       "provider",
@@ -1264,7 +1266,7 @@ describe("CLI OpenShell provider adapter", () => {
         providerName: "search-prod",
         sandboxName: "alpha",
       }),
-    ).resolves.toEqual({ ok: true });
+    ).resolves.toEqual({ ok: true, value: { changed: true } });
     expect(run).toHaveBeenCalledWith(
       ["sandbox", "provider", "detach", "-g", "nemoclaw-18080", "alpha", "search-prod"],
       expect.objectContaining({ ignoreError: true, timeout: 30_000 }),
@@ -1284,9 +1286,88 @@ describe("CLI OpenShell provider adapter", () => {
           providerName: "search-prod",
           sandboxName: "alpha",
         }),
-      ).resolves.toEqual({ ok: true });
+      ).resolves.toEqual({ ok: true, value: { changed: false } });
     },
   );
+
+  it("classifies the exact provider-detach resource-version race (#9806)", async () => {
+    const diagnostic =
+      "Failed to detach provider: sandbox was modified by another operation. Please retry the command.";
+    const adapter = createCliOpenShellProviderAdapter({
+      run: () => captured(1, "", diagnostic),
+    });
+
+    await expect(
+      adapter.detachProvider({
+        target: selectedOpenShellGateway(),
+        providerName: "search-prod",
+        sandboxName: "alpha",
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      error: { kind: "command", reason: "conflict", message: diagnostic },
+    });
+  });
+
+  it("returns typed provider attachments from a named gateway (#9806)", async () => {
+    const run = vi.fn(() =>
+      captured(
+        0,
+        [
+          "NAME              TYPE              CREDENTIAL_KEYS   CONFIG_KEYS",
+          "alpha-mcp-github  nemoclaw-mcp-v1  1                 0",
+          "alpha-mcp-slack   nemoclaw-mcp-v1  1                 0",
+        ].join("\n"),
+      ),
+    );
+    const adapter = createCliOpenShellProviderAdapter({ run });
+
+    await expect(
+      adapter.listProviderAttachments({
+        target: namedOpenShellGateway("nemoclaw-18080"),
+        sandboxName: "alpha",
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      value: { names: ["alpha-mcp-github", "alpha-mcp-slack"] },
+    });
+    expect(run).toHaveBeenCalledWith(
+      ["sandbox", "provider", "list", "-g", "nemoclaw-18080", "alpha"],
+      expect.objectContaining({ suppressOutput: true }),
+    );
+  });
+
+  it("returns an empty typed attachment inventory for an unattached sandbox (#9806)", async () => {
+    const adapter = createCliOpenShellProviderAdapter({
+      run: () => captured(0, "No providers attached to sandbox alpha."),
+    });
+
+    await expect(
+      adapter.listProviderAttachments({
+        target: selectedOpenShellGateway(),
+        sandboxName: "alpha",
+      }),
+    ).resolves.toEqual({ ok: true, value: { names: [] } });
+  });
+
+  it("rejects malformed provider attachment output at the CLI adapter boundary (#9806)", async () => {
+    const adapter = createCliOpenShellProviderAdapter({
+      run: () => captured(0, "unexpected output"),
+    });
+
+    await expect(
+      adapter.listProviderAttachments({
+        target: selectedOpenShellGateway(),
+        sandboxName: "alpha",
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      error: {
+        kind: "schema",
+        message: "OpenShell returned invalid provider attachment metadata.",
+      },
+    });
+  });
 
   it.each(["provider search-prod NotFound", "provider search-prod not found"])(
     "does not report a missing provider as detached: %s (#9806)",

--- a/src/lib/adapters/openshell/provider-adapter-cli.test.ts
+++ b/src/lib/adapters/openshell/provider-adapter-cli.test.ts
@@ -83,6 +83,7 @@ describe("CLI OpenShell provider adapter", () => {
     const credentialValue = "host-only-value";
     const operations = [
       adapter.listProviders({ target }),
+      adapter.listProviderAttachments({ target, sandboxName: "alpha" }),
       adapter.createProvider({
         target,
         name: "search-prod",
@@ -129,6 +130,7 @@ describe("CLI OpenShell provider adapter", () => {
       },
     };
     expect(results).toEqual([
+      expectedFailure,
       expectedFailure,
       expectedFailure,
       expectedFailure,

--- a/src/lib/adapters/openshell/provider-adapter-cli.ts
+++ b/src/lib/adapters/openshell/provider-adapter-cli.ts
@@ -642,7 +642,7 @@ export function createCliOpenShellProviderAdapter(
       return failure({
         kind: "command",
         reason: "not_found",
-        message: `OpenShell provider '${request.providerName}' was not found.`,
+        message: `OpenShell provider not found: '${request.providerName}'.`,
       });
     }
     const error = commandError(result);
@@ -667,10 +667,15 @@ export function createCliOpenShellProviderAdapter(
       3,
     );
     const output = commandOutput(result);
-    if (TOLERATED_DETACH_OUTPUT_RE.test(output)) {
+    const error = commandError(result);
+    const confirmedIdempotentDetach =
+      !result.error &&
+      !result.signal &&
+      result.status !== null &&
+      TOLERATED_DETACH_OUTPUT_RE.test(output);
+    if (confirmedIdempotentDetach) {
       return success({ changed: false });
     }
-    const error = commandError(result);
     return error ? failure(error) : success({ changed: true });
   };
 

--- a/src/lib/adapters/openshell/provider-adapter-cli.ts
+++ b/src/lib/adapters/openshell/provider-adapter-cli.ts
@@ -19,9 +19,11 @@ import {
   type GetOpenShellProviderRefreshStatusRequest,
   type ImportOpenShellProviderProfileRequest,
   type InspectOpenShellProviderProfileRequest,
+  type ListOpenShellProviderAttachmentsRequest,
   type OpenShellProviderAdapter,
   type OpenShellProviderError,
   type OpenShellProviderMutationResult,
+  type OpenShellProviderProfileOperation,
   type OpenShellProviderRequest,
   type OpenShellProviderResult,
   type UpdateOpenShellProviderRequest,
@@ -76,10 +78,10 @@ export type CliOpenShellProviderAdapter = Omit<OpenShellProviderAdapter, "import
   Readonly<{
     importProviderProfile(
       request: ImportOpenShellProviderProfileRequest,
-    ): OpenShellProviderMutationResult;
+    ): CliOpenShellProviderProfileResult;
   }>;
 
-export type CliOpenShellProviderProfileOperation = "read" | "inspect" | "import" | "verify";
+export type CliOpenShellProviderProfileOperation = OpenShellProviderProfileOperation;
 
 export type CliOpenShellProviderProfileResult =
   | Readonly<{ ok: true }>
@@ -99,6 +101,9 @@ const ATTACHED_TO_SANDBOX_RE =
 const TOLERATED_DETACH_OUTPUT_RE = /\bNotAttached\b|\bnot\s+attached\b/iu;
 const PROVIDER_GET_DIAGNOSTIC_LIMIT = 64 * 1024;
 const REFRESH_STATUS_PATTERN = /^[a-z][a-z0-9_-]{0,31}$/u;
+const NO_PROVIDER_ATTACHMENTS_RE = /^No providers attached to sandbox\b/mu;
+const PROVIDER_ATTACHMENT_HEADER_RE = /^NAME\s+TYPE\s+CREDENTIAL_KEYS\s+CONFIG_KEYS$/u;
+const PROVIDER_ATTACHMENT_ROW_RE = /^(\S+)\s+(\S+)\s+(\d+)\s+(\d+)$/u;
 
 function success<T>(value: T): OpenShellProviderResult<T> {
   return { ok: true, value };
@@ -240,6 +245,13 @@ function commandError(
   }
   if (/already exists/iu.test(output)) {
     return { kind: "command", reason: "already_exists", message };
+  }
+  if (
+    /Failed to detach provider:\s*sandbox was modified by another operation\.\s*Please retry the command\.?/iu.test(
+      output,
+    )
+  ) {
+    return { kind: "command", reason: "conflict", message };
   }
   const attachedSandboxes = attachedSandboxNames(output);
   if (attachedSandboxes) {
@@ -403,6 +415,25 @@ function parseRefreshStatus(output: string, credentialKey: string): string | nul
   const keyIndex = columns.indexOf(credentialKey);
   const status = keyIndex < 0 ? null : (columns[keyIndex + 2] ?? null);
   return status && REFRESH_STATUS_PATTERN.test(status) ? status : null;
+}
+
+function parseProviderAttachmentNames(output: string): string[] | null {
+  const clean = commandOutput({ status: 0, output });
+  if (NO_PROVIDER_ATTACHMENTS_RE.test(clean)) return [];
+  const lines = clean
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const headerIndex = lines.findIndex((line) => PROVIDER_ATTACHMENT_HEADER_RE.test(line));
+  if (headerIndex < 0) return null;
+  const names: string[] = [];
+  for (const line of lines.slice(headerIndex + 1)) {
+    const match = line.match(PROVIDER_ATTACHMENT_ROW_RE);
+    const name = match?.[1];
+    if (!name || !isValidCliOpenShellProviderIdentifier(name)) return null;
+    names.push(name);
+  }
+  return names;
 }
 
 export function createCliOpenShellProviderAdapter(
@@ -572,8 +603,7 @@ export function createCliOpenShellProviderAdapter(
   };
 
   const importProviderProfile: CliOpenShellProviderAdapter["importProviderProfile"] = (request) => {
-    const result = importCliOpenShellProviderProfile(request, { ...deps, environment, run });
-    return result.ok ? result : { ok: false, error: result.error };
+    return importCliOpenShellProviderProfile(request, { ...deps, environment, run });
   };
 
   const inspectProviderProfile: OpenShellProviderAdapter["inspectProviderProfile"] = async (
@@ -602,8 +632,27 @@ export function createCliOpenShellProviderAdapter(
     const targetError = namedGatewayEndpointOverrideError(request.target, environment);
     if (targetError) return failure(targetError);
     const result = invoke(["provider", "delete", request.providerName], request);
+    const output = commandOutput(result);
+    if (
+      !result.error &&
+      !result.signal &&
+      result.status === 1 &&
+      reportsExactProviderNotFound(output, request.providerName, PROVIDER_GET_DIAGNOSTIC_LIMIT)
+    ) {
+      return failure({
+        kind: "command",
+        reason: "not_found",
+        message: `OpenShell provider '${request.providerName}' was not found.`,
+      });
+    }
     const error = commandError(result);
-    return error ? failure(error) : mutationSuccess();
+    return error
+      ? failure(
+          error.kind === "command" && error.reason === "not_found"
+            ? { ...error, reason: "failed" }
+            : error,
+        )
+      : mutationSuccess();
   };
 
   const detachProvider: OpenShellProviderAdapter["detachProvider"] = async (
@@ -618,11 +667,11 @@ export function createCliOpenShellProviderAdapter(
       3,
     );
     const output = commandOutput(result);
-    if (result.status !== 0 && TOLERATED_DETACH_OUTPUT_RE.test(output)) {
-      return mutationSuccess();
+    if (TOLERATED_DETACH_OUTPUT_RE.test(output)) {
+      return success({ changed: false });
     }
     const error = commandError(result);
-    return error ? failure(error) : mutationSuccess();
+    return error ? failure(error) : success({ changed: true });
   };
 
   const attachProvider: OpenShellProviderAdapter["attachProvider"] = async (
@@ -644,6 +693,33 @@ export function createCliOpenShellProviderAdapter(
     );
     const error = commandError(result);
     return error ? failure(error) : mutationSuccess();
+  };
+
+  const listProviderAttachments: OpenShellProviderAdapter["listProviderAttachments"] = async (
+    request: ListOpenShellProviderAttachmentsRequest,
+  ) => {
+    const targetError = namedGatewayEndpointOverrideError(request.target, environment);
+    if (targetError) return failure(targetError);
+    if (!isValidCliOpenShellProviderIdentifier(request.sandboxName)) {
+      return failure({ kind: "validation", message: "Provider attachment input is invalid." });
+    }
+    const result = invoke(
+      ["sandbox", "provider", "list", request.sandboxName],
+      request,
+      undefined,
+      3,
+      true,
+      PROVIDER_GET_DIAGNOSTIC_LIMIT,
+    );
+    const error = commandError(result);
+    if (error) return failure(error);
+    const names = parseProviderAttachmentNames(rawCommandOutput(result));
+    return names
+      ? success({ names })
+      : failure({
+          kind: "schema",
+          message: "OpenShell returned invalid provider attachment metadata.",
+        });
   };
 
   const configureProviderRefresh: OpenShellProviderAdapter["configureProviderRefresh"] = async (
@@ -730,6 +806,7 @@ export function createCliOpenShellProviderAdapter(
     deleteProvider,
     detachProvider,
     attachProvider,
+    listProviderAttachments,
     configureProviderRefresh,
     getProviderRefreshStatus,
   };

--- a/src/lib/adapters/openshell/provider-adapter.ts
+++ b/src/lib/adapters/openshell/provider-adapter.ts
@@ -6,6 +6,7 @@ import type { OpenShellGatewayTarget } from "./sandbox-observer";
 export type OpenShellProviderCommandReason =
   | "already_exists"
   | "attached"
+  | "conflict"
   | "failed"
   | "invalid_request"
   | "not_found"
@@ -43,6 +44,16 @@ export type OpenShellProviderMutationResult =
   | Readonly<{ ok: true }>
   | Readonly<{ ok: false; error: OpenShellProviderError }>;
 
+export type OpenShellProviderProfileOperation = "read" | "inspect" | "import" | "verify";
+
+export type OpenShellProviderProfileMutationResult =
+  | Readonly<{ ok: true }>
+  | Readonly<{
+      ok: false;
+      error: OpenShellProviderError;
+      operation?: OpenShellProviderProfileOperation;
+    }>;
+
 export type OpenShellProviderRequest = Readonly<{
   target: OpenShellGatewayTarget;
   timeoutMs?: number;
@@ -50,6 +61,14 @@ export type OpenShellProviderRequest = Readonly<{
 
 export type OpenShellProviderInventory = Readonly<{
   names: readonly string[];
+}>;
+
+export type OpenShellProviderAttachmentInventory = Readonly<{
+  names: readonly string[];
+}>;
+
+export type OpenShellProviderDetach = Readonly<{
+  changed: boolean;
 }>;
 
 export type OpenShellProviderMetadata = Readonly<{
@@ -109,6 +128,11 @@ export type DetachOpenShellProviderRequest = DeleteOpenShellProviderRequest &
 
 export type AttachOpenShellProviderRequest = DetachOpenShellProviderRequest;
 
+export type ListOpenShellProviderAttachmentsRequest = OpenShellProviderRequest &
+  Readonly<{
+    sandboxName: string;
+  }>;
+
 export type ConfigureOpenShellProviderRefreshRequest = GetOpenShellProviderRequest &
   Readonly<{
     credentialKey: string;
@@ -142,7 +166,7 @@ export interface OpenShellProviderAdapter {
 
   importProviderProfile(
     request: ImportOpenShellProviderProfileRequest,
-  ): OpenShellProviderMutationResult | Promise<OpenShellProviderMutationResult>;
+  ): OpenShellProviderProfileMutationResult | Promise<OpenShellProviderProfileMutationResult>;
 
   inspectProviderProfile(
     request: InspectOpenShellProviderProfileRequest,
@@ -150,9 +174,15 @@ export interface OpenShellProviderAdapter {
 
   deleteProvider(request: DeleteOpenShellProviderRequest): Promise<OpenShellProviderMutationResult>;
 
-  detachProvider(request: DetachOpenShellProviderRequest): Promise<OpenShellProviderMutationResult>;
+  detachProvider(
+    request: DetachOpenShellProviderRequest,
+  ): Promise<OpenShellProviderResult<OpenShellProviderDetach>>;
 
   attachProvider(request: AttachOpenShellProviderRequest): Promise<OpenShellProviderMutationResult>;
+
+  listProviderAttachments(
+    request: ListOpenShellProviderAttachmentsRequest,
+  ): Promise<OpenShellProviderResult<OpenShellProviderAttachmentInventory>>;
 
   configureProviderRefresh(
     request: ConfigureOpenShellProviderRefreshRequest,

--- a/src/lib/messaging/applier/openshell-provider.test.ts
+++ b/src/lib/messaging/applier/openshell-provider.test.ts
@@ -91,10 +91,13 @@ function providerAdapter(
       .mockResolvedValue({ ok: true }),
     detachProvider: vi
       .fn<OpenShellProviderAdapter["detachProvider"]>()
-      .mockResolvedValue({ ok: true }),
+      .mockResolvedValue({ ok: true, value: { changed: true } }),
     attachProvider: vi
       .fn<OpenShellProviderAdapter["attachProvider"]>()
       .mockResolvedValue({ ok: true }),
+    listProviderAttachments: vi
+      .fn<OpenShellProviderAdapter["listProviderAttachments"]>()
+      .mockResolvedValue({ ok: true, value: { names: [] } }),
     configureProviderRefresh: vi
       .fn<OpenShellProviderAdapter["configureProviderRefresh"]>()
       .mockResolvedValue({ ok: true }),
@@ -235,19 +238,23 @@ describe("messaging OpenShell provider application", () => {
       },
     ];
     const warnings: string[] = [];
-    const acceptedKeys = registerExtraPlaceholderProviders(tokenDefs, (message) => {
-      warnings.push(message);
-    }, {
-      env: {
-        [EXTRA_PLACEHOLDER_KEYS_ENV]:
-          "TELEGRAM_BOT_TOKEN_AGENT_A TELEGRAM_BOT_TOKEN_AGENT_MISSING GITHUB_TOKEN",
-        TELEGRAM_BOT_TOKEN_AGENT_A: "telegram-agent-a-secret",
-        TELEGRAM_BOT_TOKEN_AGENT_MISSING: undefined,
-        GITHUB_TOKEN: "arbitrary-host-secret",
+    const acceptedKeys = registerExtraPlaceholderProviders(
+      tokenDefs,
+      (message) => {
+        warnings.push(message);
       },
-      getCredential: () => null,
-      normalizeCredentialValue: (value) => value?.trim() ?? "",
-    });
+      {
+        env: {
+          [EXTRA_PLACEHOLDER_KEYS_ENV]:
+            "TELEGRAM_BOT_TOKEN_AGENT_A TELEGRAM_BOT_TOKEN_AGENT_MISSING GITHUB_TOKEN",
+          TELEGRAM_BOT_TOKEN_AGENT_A: "telegram-agent-a-secret",
+          TELEGRAM_BOT_TOKEN_AGENT_MISSING: undefined,
+          GITHUB_TOKEN: "arbitrary-host-secret",
+        },
+        getCredential: () => null,
+        normalizeCredentialValue: (value) => value?.trim() ?? "",
+      },
+    );
     const application = buildMessagingProviderApplication({
       tokenDefs,
       root: "/repo",

--- a/src/lib/onboard/sandbox-create/provider-publication.test.ts
+++ b/src/lib/onboard/sandbox-create/provider-publication.test.ts
@@ -40,8 +40,9 @@ function typedProviderAdapter(
       value: { credentialKeys: [] },
     })),
     deleteProvider: vi.fn(async () => ({ ok: true as const })),
-    detachProvider: vi.fn(async () => ({ ok: true as const })),
+    detachProvider: vi.fn(async () => ({ ok: true as const, value: { changed: true } })),
     attachProvider: vi.fn(async () => ({ ok: true as const })),
+    listProviderAttachments: vi.fn(async () => ({ ok: true as const, value: { names: [] } })),
     configureProviderRefresh: vi.fn(async () => ({ ok: true as const })),
     getProviderRefreshStatus: vi.fn(async () => ({
       ok: true as const,

--- a/test/agents/deepagents/deepagents-mcp-legacy-lifecycle.test.ts
+++ b/test/agents/deepagents/deepagents-mcp-legacy-lifecycle.test.ts
@@ -148,7 +148,7 @@ beforeEach(() => {
         return providerExists
           ? {
               status: 0,
-              stdout: `Id: ${providerId}\nType: ${providerType}\nResource version: ${providerResourceVersion}\nCredential keys: GITHUB_TOKEN\n`,
+              stdout: `Name: alpha-mcp-github\nId: ${providerId}\nType: ${providerType}\nResource version: ${providerResourceVersion}\nCredential keys: GITHUB_TOKEN\nConfig keys: <none>\n`,
               stderr: "",
             }
           : { status: 1, stdout: "", stderr: "Provider not found" };

--- a/test/agents/hermes/hermes-mcp-startup-probe.test.ts
+++ b/test/agents/hermes/hermes-mcp-startup-probe.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   runOpenshellProviderCommand: vi.fn(),
   sleepMs: vi.fn(),
   waitUntil: vi.fn(),
+  waitUntilAsync: vi.fn(),
 }));
 
 vi.mock("../../../src/lib/adapters/openshell/provider-command", () => ({
@@ -23,6 +24,7 @@ vi.mock("../../../src/lib/actions/sandbox/process-recovery", () => ({
 vi.mock("../../../src/lib/core/wait", () => ({
   sleepMs: mocks.sleepMs,
   waitUntil: mocks.waitUntil,
+  waitUntilAsync: mocks.waitUntilAsync,
 }));
 
 import { assertAgentMcpMutationRuntimeCapability } from "../../../src/lib/actions/sandbox/mcp-bridge-adapters";

--- a/test/mcp/mcp-add-crash-consistency.test.ts
+++ b/test/mcp/mcp-add-crash-consistency.test.ts
@@ -136,14 +136,14 @@ providerCommands.runOpenshellProviderCommand = (args) => {
   }
   if (args[0] === "provider" && args[1] === "get") {
     if (args[2] === "foreign-attached" || args[2] === "foreign-registered") {
-      return { status: 0, stdout: "Id: " + foreignProviderId + "\nType: nemoclaw-mcp-v1\nResource version: 1\nCredential keys: FAKE_MCP_SECRET\n", stderr: "" };
+      return { status: 0, stdout: "Name: " + args[2] + "\nId: " + foreignProviderId + "\nType: nemoclaw-mcp-v1\nResource version: 1\nCredential keys: FAKE_MCP_SECRET\nConfig keys: <none>\n", stderr: "" };
     }
     observedProviderName = args[2];
     providerGetCount += 1;
     if (crashAfter === "race" && providerGetCount === 2) mark("provider");
     if (crashAfter === "late-race" && providerGetCount === 3) mark("provider");
     return marked("provider")
-      ? { status: 0, stdout: "Id: " + (marked("foreign-provider") ? foreignProviderId : providerId) + "\nType: nemoclaw-mcp-v1\nResource version: " + providerVersion() + "\nCredential keys: FAKE_MCP_SECRET\n", stderr: "" }
+      ? { status: 0, stdout: "Name: " + args[2] + "\nId: " + (marked("foreign-provider") ? foreignProviderId : providerId) + "\nType: nemoclaw-mcp-v1\nResource version: " + providerVersion() + "\nCredential keys: FAKE_MCP_SECRET\nConfig keys: <none>\n", stderr: "" }
       : { status: 1, stdout: "", stderr: "provider '" + args[2] + "' not found" };
   }
   if (args[0] === "provider" && (args[1] === "create" || args[1] === "update")) {
@@ -578,7 +578,7 @@ providerCommands.runOpenshellProviderCommand = (args) => {
   if (args[0] === "provider" && args[1] === "get") {
     observedProviderName = args[2];
     return marked("provider")
-      ? { status: 0, stdout: "Id: " + providerId + "\nType: nemoclaw-mcp-v1\nResource version: 1\nCredential keys: FAKE_MCP_SECRET\n", stderr: "" }
+      ? { status: 0, stdout: "Name: " + args[2] + "\nId: " + providerId + "\nType: nemoclaw-mcp-v1\nResource version: 1\nCredential keys: FAKE_MCP_SECRET\nConfig keys: <none>\n", stderr: "" }
       : { status: 1, stdout: "", stderr: "provider '" + args[2] + "' not found" };
   }
   if (args[0] === "sandbox" && args[1] === "provider" && args[2] === "detach") {
@@ -680,7 +680,7 @@ providerCommands.runOpenshellProviderCommand = (args) => {
   if (args[0] === "provider" && args[1] === "get") {
     return {
       status: 0,
-      stdout: "Type: nemoclaw-mcp-v1\nCredential keys: FAKE_MCP_SECRET\n",
+      stdout: "Name: alpha-mcp-fake\nType: nemoclaw-mcp-v1\nCredential keys: FAKE_MCP_SECRET\nConfig keys: <none>\n",
       stderr: "",
     };
   }

--- a/test/mcp/mcp-bridge-destroy-marker-recovery.test.ts
+++ b/test/mcp/mcp-bridge-destroy-marker-recovery.test.ts
@@ -245,7 +245,7 @@ providerCommands.runOpenshellProviderCommand = (args) => {
     return providerExists
       ? {
           status: 0,
-          stdout: "Id: " + expectedId + "\nType: nemoclaw-mcp-v1\nResource version: 4\nCredential keys: EXPECTED_TOKEN\n",
+          stdout: "Name: " + providerName + "\nId: " + expectedId + "\nType: nemoclaw-mcp-v1\nResource version: 4\nCredential keys: EXPECTED_TOKEN\nConfig keys: <none>\n",
           stderr: "",
         }
       : { status: 1, stdout: "", stderr: "provider '" + args[2] + "' not found" };

--- a/test/mcp/mcp-destroy-lifecycle.test.ts
+++ b/test/mcp/mcp-destroy-lifecycle.test.ts
@@ -65,15 +65,12 @@ vi.mock("../../src/lib/adapters/dns/resolve", () => ({
   resolveHostAddresses: testState.resolveHostAddresses,
 }));
 
-vi.mock(
-  "../../src/lib/actions/sandbox/mcp-bridge-provider-inspection",
-  async (importOriginal) => ({
-    ...(await importOriginal<
-      typeof import("../../src/lib/actions/sandbox/mcp-bridge-provider-inspection")
-    >()),
-    getMcpProviderInspectionRuntimeSelection: () => testState.runtimeSelection,
-  }),
-);
+vi.mock("../../src/lib/actions/sandbox/mcp-bridge-provider-inspection", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("../../src/lib/actions/sandbox/mcp-bridge-provider-inspection")
+  >()),
+  getMcpProviderInspectionRuntimeSelection: () => testState.runtimeSelection,
+}));
 
 vi.mock("../../src/lib/adapters/openshell/runtime", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../src/lib/adapters/openshell/runtime")>()),
@@ -290,7 +287,7 @@ beforeEach(() => {
         return provider
           ? {
               status: 0,
-              stdout: `Id: ${provider.id}\nType: nemoclaw-mcp-v1\nResource version: ${provider.resourceVersion ?? 1}\nCredential keys: ${provider.credential}\n`,
+              stdout: `Name: ${args[2]}\nId: ${provider.id}\nType: nemoclaw-mcp-v1\nResource version: ${provider.resourceVersion ?? 1}\nCredential keys: ${provider.credential}\nConfig keys: <none>\n`,
               stderr: "",
             }
           : { status: 1, stdout: "", stderr: "Provider not found" };

--- a/test/mcp/mcp-provider-detach-retry.test.ts
+++ b/test/mcp/mcp-provider-detach-retry.test.ts
@@ -32,7 +32,7 @@ providerCommands.runOpenshellProviderCommand = (args, options) => {
   if (args[0] === "provider" && args[1] === "get") {
     return {
       status: 0,
-      stdout: "Id: " + liveId + "\nType: nemoclaw-mcp-v1\nResource version: 4\nCredential keys: EXPECTED_TOKEN\n",
+      stdout: "Name: " + args[2] + "\nId: " + liveId + "\nType: nemoclaw-mcp-v1\nResource version: 4\nCredential keys: EXPECTED_TOKEN\nConfig keys: <none>\n",
       stderr: "",
     };
   }
@@ -68,12 +68,17 @@ const entry = {
 };
 let outcome = null;
 let message = null;
-try {
-  outcome = providerActions.detachProvider("alpha", entry, { runtimeSelection });
-} catch (error) {
-  message = error.message;
-}
-process.stdout.write(JSON.stringify({ outcome, message, detachCalls, attached, liveId }));
+(async () => {
+  try {
+    outcome = await providerActions.detachProvider("alpha", entry, { runtimeSelection });
+  } catch (error) {
+    message = error.message;
+  }
+  process.stdout.write(JSON.stringify({ outcome, message, detachCalls, attached, liveId }));
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
 `;
   const result = spawnSync(process.execPath, ["-e", script], {
     cwd: process.cwd(),
@@ -118,7 +123,7 @@ describe("MCP provider detach retry", () => {
   it("does not retry unrelated detach failures", () => {
     const result = runDetachScenario("other-error");
     expect(result.outcome).toBeNull();
-    expect(result.message).toContain("permission denied");
+    expect(result.message).toBe("OpenShell could not authenticate the provider operation.");
     expect(result.detachCalls).toBe(1);
     expect(result.attached).toBe(true);
   });

--- a/test/mcp/mcp-provider-ownership.test.ts
+++ b/test/mcp/mcp-provider-ownership.test.ts
@@ -45,7 +45,7 @@ providerCommands.runOpenshellProviderCommand = (args) => {
   if (args[0] === "provider" && args[1] === "get") {
     return {
       status: 0,
-      stdout: "Id: " + liveId + "\\nType: nemoclaw-mcp-v1\\nResource version: 4\\nCredential keys: EXPECTED_TOKEN\\n",
+      stdout: "Name: " + args[2] + "\\nId: " + liveId + "\\nType: nemoclaw-mcp-v1\\nResource version: 4\\nCredential keys: EXPECTED_TOKEN\\nConfig keys: <none>\\n",
       stderr: "",
     };
   }
@@ -146,7 +146,7 @@ providerCommands.runOpenshellProviderCommand = (args) => {
     return providerExists
       ? {
           status: 0,
-          stdout: "Id: " + expectedId + "\nType: nemoclaw-mcp-v1\nResource version: 4\nCredential keys: LD_PRELOAD\n",
+          stdout: "Name: " + args[2] + "\nId: " + expectedId + "\nType: nemoclaw-mcp-v1\nResource version: 4\nCredential keys: LD_PRELOAD\nConfig keys: <none>\n",
           stderr: "",
         }
       : { status: 1, stdout: "", stderr: "provider '" + args[2] + "' not found" };
@@ -307,7 +307,7 @@ providerCommands.runOpenshellProviderCommand = (args) => {
   if (args[0] === "provider" && args[1] === "get") {
     return {
       status: 0,
-      stdout: "Id: 99999999-8888-4777-8666-555555555555\nType: nemoclaw-mcp-v1\nResource version: 4\nCredential keys: EXPECTED_TOKEN\n",
+      stdout: "Name: " + args[2] + "\nId: 99999999-8888-4777-8666-555555555555\nType: nemoclaw-mcp-v1\nResource version: 4\nCredential keys: EXPECTED_TOKEN\nConfig keys: <none>\n",
       stderr: "",
     };
   }
@@ -407,18 +407,23 @@ const entry = {
   adapter: "mcporter",
   addedAt: "2026-06-01T00:00:00.000Z",
 };
-const before = providerActions.inspectMcpProviderAttachments("alpha", runtimeSelection);
-const firstOutcome = providerActions.detachMissingProviderReference("alpha", entry, runtimeSelection);
-const afterFirst = providerActions.inspectMcpProviderAttachments("alpha", runtimeSelection);
-const secondOutcome = providerActions.detachMissingProviderReference("alpha", {
-  ...entry,
-  server: "second",
-  providerName: "alpha-mcp-second",
-  providerId: "22222222-3333-4444-8555-666666666666",
-  policyName: "mcp-bridge-second",
-}, runtimeSelection);
-const after = providerActions.inspectMcpProviderAttachments("alpha", runtimeSelection);
-process.stdout.write(JSON.stringify({ before, firstOutcome, afterFirst, secondOutcome, after, calls }));
+(async () => {
+  const before = await providerActions.inspectMcpProviderAttachments("alpha", runtimeSelection);
+  const firstOutcome = await providerActions.detachMissingProviderReference("alpha", entry, runtimeSelection);
+  const afterFirst = await providerActions.inspectMcpProviderAttachments("alpha", runtimeSelection);
+  const secondOutcome = await providerActions.detachMissingProviderReference("alpha", {
+    ...entry,
+    server: "second",
+    providerName: "alpha-mcp-second",
+    providerId: "22222222-3333-4444-8555-666666666666",
+    policyName: "mcp-bridge-second",
+  }, runtimeSelection);
+  const after = await providerActions.inspectMcpProviderAttachments("alpha", runtimeSelection);
+  process.stdout.write(JSON.stringify({ before, firstOutcome, afterFirst, secondOutcome, after, calls }));
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
 `;
     const result = spawnSync(process.execPath, ["-e", script], {
       cwd: process.cwd(),
@@ -470,7 +475,7 @@ providerCommands.runOpenshellProviderCommand = (args) => {
   if (args[0] === "provider" && args[1] === "get") {
     return {
       status: 0,
-      stdout: "Id: 11111111-2222-4333-8444-555555555555\nType: nemoclaw-mcp-v1\nResource version: " + resourceVersion + "\nCredential keys: EXPECTED_TOKEN\n",
+      stdout: "Name: " + args[2] + "\nId: 11111111-2222-4333-8444-555555555555\nType: nemoclaw-mcp-v1\nResource version: " + resourceVersion + "\nCredential keys: EXPECTED_TOKEN\nConfig keys: <none>\n",
       stderr: "",
     };
   }
@@ -486,20 +491,25 @@ providerCommands.runOpenshellProviderCommand = (args) => {
 };
 const providerActions = require("./src/lib/actions/sandbox/mcp-bridge-provider.js");
 let message = "";
-try {
-  providerActions.upsertMcpProvider(
-    "alpha-mcp-fake",
-    [{ name: "EXPECTED_TOKEN" }],
-    {
-      allowExisting: true,
-      expectedProviderId: "11111111-2222-4333-8444-555555555555",
-      runtimeSelection,
-    },
-  );
-} catch (error) {
-  message = error.message;
-}
-process.stdout.write(JSON.stringify({ message, resourceVersion, calls }));
+(async () => {
+  try {
+    await providerActions.upsertMcpProvider(
+      "alpha-mcp-fake",
+      [{ name: "EXPECTED_TOKEN" }],
+      {
+        allowExisting: true,
+        expectedProviderId: "11111111-2222-4333-8444-555555555555",
+        runtimeSelection,
+      },
+    );
+  } catch (error) {
+    message = error.message;
+  }
+  process.stdout.write(JSON.stringify({ message, resourceVersion, calls }));
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
 `;
     const result = spawnSync(process.execPath, ["-e", script], {
       cwd: process.cwd(),
@@ -541,21 +551,26 @@ providerCommands.runOpenshellProviderCommand = (args) => {
 };
 const providerActions = require("./src/lib/actions/sandbox/mcp-bridge-provider.js");
 let message = "";
-try {
-  providerActions.upsertMcpProvider(
-    "alpha-mcp-fake",
-    [{ name: "EXPECTED_TOKEN" }],
-    {
-      allowExisting: true,
-      expectedProviderId: "11111111-2222-4333-8444-555555555555",
-      requireExisting: true,
-      runtimeSelection,
-    },
-  );
-} catch (error) {
-  message = error.message;
-}
-process.stdout.write(JSON.stringify({ message, calls }));
+(async () => {
+  try {
+    await providerActions.upsertMcpProvider(
+      "alpha-mcp-fake",
+      [{ name: "EXPECTED_TOKEN" }],
+      {
+        allowExisting: true,
+        expectedProviderId: "11111111-2222-4333-8444-555555555555",
+        requireExisting: true,
+        runtimeSelection,
+      },
+    );
+  } catch (error) {
+    message = error.message;
+  }
+  process.stdout.write(JSON.stringify({ message, calls }));
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
 `;
     const result = spawnSync(process.execPath, ["-e", script], {
       cwd: process.cwd(),
@@ -608,7 +623,7 @@ providerCommands.runOpenshellProviderCommand = (args) => {
   if (args[0] === "provider" && args[1] === "get") {
     return {
       status: 0,
-      stdout: "Id: 99999999-8888-4777-8666-555555555555\\nType: nemoclaw-mcp-v1\\nResource version: 4\\nCredential keys: EXPECTED_TOKEN\\n",
+      stdout: "Name: " + args[2] + "\\nId: 99999999-8888-4777-8666-555555555555\\nType: nemoclaw-mcp-v1\\nResource version: 4\\nCredential keys: EXPECTED_TOKEN\\nConfig keys: <none>\\n",
       stderr: "",
     };
   }

--- a/test/mcp/mcp-restart-policy-order.test.ts
+++ b/test/mcp/mcp-restart-policy-order.test.ts
@@ -83,7 +83,7 @@ providerCommands.runOpenshellProviderCommand = (args) => {
       return {
         status: 0,
         stdout:
-          "Id: 99999999-8888-4777-8666-555555555555\nType: nemoclaw-mcp-v1\nResource version: 1\nCredential keys: SECOND_MCP_TOKEN\n",
+          "Name: foreign-attached\nId: 99999999-8888-4777-8666-555555555555\nType: nemoclaw-mcp-v1\nResource version: 1\nCredential keys: SECOND_MCP_TOKEN\nConfig keys: <none>\n",
         stderr: "",
       };
     }
@@ -91,7 +91,7 @@ providerCommands.runOpenshellProviderCommand = (args) => {
     if (!entry) return { status: 1, stdout: "", stderr: "NotFound: provider" };
     return {
       status: 0,
-      stdout: "Id: " + entry.providerId + "\nType: nemoclaw-mcp-v1\nResource version: " + (updatedProviders.has(entry.providerName) ? "2" : "1") + "\nCredential keys: " + entry.env[0] + "\n",
+      stdout: "Name: " + entry.providerName + "\nId: " + entry.providerId + "\nType: nemoclaw-mcp-v1\nResource version: " + (updatedProviders.has(entry.providerName) ? "2" : "1") + "\nCredential keys: " + entry.env[0] + "\nConfig keys: <none>\n",
       stderr: "",
     };
   }
@@ -229,13 +229,13 @@ providerCommands.runOpenshellProviderCommand = (args) => {
       registeredProviderGets += 1;
       return {
         status: 0,
-        stdout: "Id: 99999999-8888-4777-8666-555555555555\nType: nemoclaw-mcp-v1\nResource version: 1\nCredential keys: OTHER_TOKEN\n",
+        stdout: "Name: foreign-registered\nId: 99999999-8888-4777-8666-555555555555\nType: nemoclaw-mcp-v1\nResource version: 1\nCredential keys: OTHER_TOKEN\nConfig keys: <none>\n",
         stderr: "",
       };
     }
     return {
       status: 0,
-      stdout: "Id: " + entry.providerId + "\nType: nemoclaw-mcp-v1\nResource version: " + resourceVersion + "\nCredential keys: MCP_TOKEN\n",
+      stdout: "Name: " + entry.providerName + "\nId: " + entry.providerId + "\nType: nemoclaw-mcp-v1\nResource version: " + resourceVersion + "\nCredential keys: MCP_TOKEN\nConfig keys: <none>\n",
       stderr: "",
     };
   }
@@ -416,7 +416,7 @@ providerCommands.runOpenshellProviderCommand = (args) => {
   if (args[0] === "provider" && args[1] === "get") {
     return {
       status: 0,
-      stdout: "Id: " + entry.providerId + "\nType: nemoclaw-mcp-v1\nResource version: " + resourceVersion + "\nCredential keys: MCP_TOKEN\n",
+      stdout: "Name: " + entry.providerName + "\nId: " + entry.providerId + "\nType: nemoclaw-mcp-v1\nResource version: " + resourceVersion + "\nCredential keys: MCP_TOKEN\nConfig keys: <none>\n",
       stderr: "",
     };
   }


### PR DESCRIPTION
## Outcome

Model Context Protocol (MCP) provider lifecycle operations now use the typed OpenShell provider adapter. MCP action code no longer constructs provider commands or parses provider command output.

## Reason

Issue #9806 requires one typed provider boundary before the remaining onboarding, recovery, and cleanup consumers can migrate.

### Related issues

Part of #9806

## Changes

- Route MCP provider profile, inspection, create, update, delete, attachment, detachment, readiness, and recovery operations through `OpenShellProviderAdapter`.
- Add typed attachment inventory and detach-state results. The MCP lifecycle needs these results to preserve ownership checks and bounded conflict retries. CLI adapter tests protect command construction, output parsing, and failure mapping.
- Preserve provider identity checks before mutation and state verification after mutation. MCP lifecycle and integration tests protect rollback and fail-closed behavior.
- Reduce the `client.ts` fan-in budget from 21 to 18 after this change removes three direct parser imports.

## Verification

- `npm run typecheck:cli` passed.
- Focused CLI source tests passed: 119 tests across four files.
- Focused MCP and agent integration tests passed: 63 tests across three files.
- Compiled credentials package-contract tests passed: 26 tests.
- The full MCP integration run passed every non-binding case. Its seven local-server cases were classified as a sandbox `listen EPERM`; the unchanged fixture file passed 12 of 12 outside the sandbox.
- `npm run validate:pr` passed for the committed range against canonical `main` at `3e605bc55b4a660b03bf1e132bdd9725078e346c`.
- `git diff --check`, repository checks, growth guardrails, source-shape budgets, and Gitleaks passed.

## Review notes

Sensitive paths include tests under `src/lib/messaging/**` and `src/lib/onboard/**`.

The complete first PR Review Advisor and CodeRabbit results were reviewed at commit `e64592087831aed9306bf23356460a1c47d2fec1`. The valid findings were repaired together in `40ae1ee9dba6c4b697ba3b702aacdcfe39a68f85`: asynchronous lifecycle inspection is now awaited, uncertain detach results fail closed, the compatibility diagnostic is preserved, attachment inventory is inspected once per status read, and stale test fixtures use current provider metadata. CodeRabbit's docstring coverage note did not require a change because these are existing internal functions and repository policy does not require docstrings for them.

The complete second Advisor pass was reviewed at `40ae1ee9dba6c4b697ba3b702aacdcfe39a68f85`. Eight specialists found no issue. Verification found one valid regression-evidence gap, repaired in `444ab180140d579b706a8382629580823bb0ab85` by adding attachment inventory to the existing ambient-endpoint rejection matrix. CodeRabbit's incremental review completed without a new finding. A fresh automated review is required for the current test-only commit.

`npm run review:local` could not start its temporary OpenShell gateway after dependencies were available. It produced no review findings and reported a temporary-file cleanup permission error.

The candidate changes `ci/source-architecture-budget.json`, which is a validation input. The validator code, hooks, manifests, lockfiles, package-manager configuration, and resolved executables match canonical `main`. The maintainer authorized publication. Validation ran in the isolated feature worktree with GitHub and SSH credential variables removed.

---
Signed-off-by: Rebecca Sliter <571084+rsliter@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved MCP provider lifecycle operations, including creation, attachment, detachment, removal, restart, rebuild, and recovery.
  - Improved handling of credential refreshes, missing credentials, attachment conflicts, already-detached providers, and provider-not-found conditions.
  - Improved validation and error reporting for malformed provider and attachment data.
  - MCP bridge status checks now process multiple entries concurrently and reuse attachment information efficiently.

- **Reliability**
  - Added stronger synchronization so provider and credential changes complete before subsequent operations continue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
