### PR TITLE
fix(hermes): preserve invalid dashboard URL diagnostics

### DIFF
--- a/agents/hermes/start.sh
+++ b/agents/hermes/start.sh
@@ -104,49 +104,6 @@ if [ -f /opt/hermes/ui-tui/dist/entry.js ]; then
   export HERMES_TUI_DIR="/opt/hermes/ui-tui"
 fi
 
-# ── Early stderr/stdout capture ──────────────────────────────────
-# Capture all entrypoint output to /tmp/nemoclaw-start.log so startup
-# failures before /tmp/gateway.log exists are still diagnosable.
-prepare_restricted_log() {
-  local path="$1"
-  local owner="${2:-}"
-  local mode="${3:-600}"
-  local dir base tmp
-
-  dir="$(dirname "$path")"
-  base="$(basename "$path")"
-  tmp="$(mktemp "${dir}/.${base}.tmp.XXXXXX")" || return 1
-  : >"$tmp" || {
-    rm -f "$tmp"
-    return 1
-  }
-  if [ "$(id -u)" -eq 0 ] && [ -n "$owner" ] && ! chown "$owner" "$tmp"; then
-    rm -f "$tmp"
-    return 1
-  fi
-  if ! chmod "$mode" "$tmp"; then
-    rm -f "$tmp"
-    return 1
-  fi
-  if ! mv -f "$tmp" "$path"; then
-    rm -f "$tmp"
-    return 1
-  fi
-}
-
-_START_LOG="/tmp/nemoclaw-start.log"
-if [ "$(id -u)" -eq 0 ]; then
-  prepare_restricted_log "$_START_LOG" root:root 600
-else
-  prepare_restricted_log "$_START_LOG" "" 600
-fi
-exec > >(tee -a "$_START_LOG") 2> >(tee -a "$_START_LOG" >&2)
-
-# ── Drop unnecessary Linux capabilities (shared) ────────────────
-drop_capabilities /usr/local/bin/nemoclaw-start "$@"
-
-NEMOCLAW_CMD=("$@")
-
 _chat_ui_url_dashboard_settings() {
   [ -n "${CHAT_UI_URL:-}" ] || return 2
   python3 -I - "$CHAT_UI_URL" <<'PYPORT'
@@ -199,6 +156,8 @@ print(f"{dashboard_port}|{external_host}")
 PYPORT
 }
 
+# Reject invalid dashboard URLs before asynchronous startup-log capture. A
+# short-lived container can exit before tee forwards its final stderr line.
 HERMES_DASHBOARD_EXTERNAL_HOST=""
 _chat_ui_port=""
 if [ -n "${CHAT_UI_URL:-}" ]; then
@@ -212,6 +171,49 @@ if [ -n "${CHAT_UI_URL:-}" ]; then
   fi
 fi
 unset _chat_ui_settings
+
+# ── Early stderr/stdout capture ──────────────────────────────────
+# Capture entrypoint output after fail-fast input validation so later failures
+# remain diagnosable before /tmp/gateway.log exists.
+prepare_restricted_log() {
+  local path="$1"
+  local owner="${2:-}"
+  local mode="${3:-600}"
+  local dir base tmp
+
+  dir="$(dirname "$path")"
+  base="$(basename "$path")"
+  tmp="$(mktemp "${dir}/.${base}.tmp.XXXXXX")" || return 1
+  : >"$tmp" || {
+    rm -f "$tmp"
+    return 1
+  }
+  if [ "$(id -u)" -eq 0 ] && [ -n "$owner" ] && ! chown "$owner" "$tmp"; then
+    rm -f "$tmp"
+    return 1
+  fi
+  if ! chmod "$mode" "$tmp"; then
+    rm -f "$tmp"
+    return 1
+  fi
+  if ! mv -f "$tmp" "$path"; then
+    rm -f "$tmp"
+    return 1
+  fi
+}
+
+_START_LOG="/tmp/nemoclaw-start.log"
+if [ "$(id -u)" -eq 0 ]; then
+  prepare_restricted_log "$_START_LOG" root:root 600
+else
+  prepare_restricted_log "$_START_LOG" "" 600
+fi
+exec > >(tee -a "$_START_LOG") 2> >(tee -a "$_START_LOG" >&2)
+
+# ── Drop unnecessary Linux capabilities (shared) ────────────────
+drop_capabilities /usr/local/bin/nemoclaw-start "$@"
+
+NEMOCLAW_CMD=("$@")
 
 _dashboard_port_raw="${NEMOCLAW_DASHBOARD_PORT:-}"
 if [ -z "$_dashboard_port_raw" ]; then

--- a/test/agents/hermes/hermes-start-ports.test.ts
+++ b/test/agents/hermes/hermes-start-ports.test.ts
@@ -22,10 +22,15 @@ const {
 } = process.env;
 
 function extractDashboardPortBootstrap(source: string): string {
-  const start = source.indexOf('NEMOCLAW_CMD=("$@")');
-  const end = source.indexOf('\nHERMES="$(command -v hermes)"', start);
-  assert(start >= 0 && end > start, "Hermes dashboard port bootstrap markers not found");
-  return source.slice(start, end).trimEnd();
+  const chatUiStart = source.indexOf("_chat_ui_url_dashboard_settings() {");
+  const captureStart = source.indexOf("\n# ── Early stderr/stdout capture", chatUiStart);
+  const portStart = source.indexOf('_dashboard_port_raw="${NEMOCLAW_DASHBOARD_PORT:-}"');
+  const end = source.indexOf('\nHERMES="$(command -v hermes)"', portStart);
+  assert(
+    chatUiStart >= 0 && captureStart > chatUiStart && portStart > captureStart && end > portStart,
+    "Hermes dashboard port bootstrap markers not found",
+  );
+  return [source.slice(chatUiStart, captureStart), source.slice(portStart, end)].join("\n");
 }
 
 function runHermesDashboardPortBootstrap(env: Record<string, string>) {
@@ -107,6 +112,14 @@ describe("agents/hermes/start.sh port bootstrap", () => {
     expect(run.stdout).toContain("DASHBOARD_PUBLIC_PORT=29443");
     expect(run.stdout).toContain("PUBLIC_PORT=8642");
     expect(run.pythonImportSentinelExists).toBe(false);
+  });
+
+  it("rejects an invalid CHAT_UI_URL without exposing its value (#10872)", () => {
+    const invalidUrl = "https://dashboard.example.test:invalid";
+    const invalidChatUiUrl = runHermesDashboardPortBootstrap({ CHAT_UI_URL: invalidUrl });
+    expect(invalidChatUiUrl.status).toBe(1);
+    expect(invalidChatUiUrl.stderr).toContain("Invalid CHAT_UI_URL for the Hermes dashboard");
+    expect(invalidChatUiUrl.stderr).not.toContain(invalidUrl);
   });
 
   it("rejects invalid and API-colliding dashboard ports", () => {


### PR DESCRIPTION
## Outcome

Hermes now rejects an invalid `CHAT_UI_URL` before asynchronous startup-log capture begins. Short-lived containers receive the existing redacted diagnostic instead of exiting before `tee` forwards it.

## Reason

The rootless Linux run for PR #10872 exited with the expected failure status but lost the `Invalid CHAT_UI_URL` diagnostic. The invalid-port path exits quickly, while the previous ordering sent its final stderr line through an asynchronous `tee` process.

### Related issues

Refs #10872

## Changes

- Move the existing Hermes dashboard URL parser and rejection path before asynchronous log capture.
- Keep the accepted URL behavior, failure status, and redacted diagnostic unchanged.
- Extend the Hermes port bootstrap test with the invalid-port input from the failed rootless run and verify that the input value is not exposed.

## Verification

- `npx vitest run --project integration test/agents/hermes/hermes-start-ports.test.ts` — 5 tests passed.
- `npx vitest run --project integration test/agents/hermes/hermes-start.test.ts test/agents/hermes/hermes-start-ports.test.ts` — 56 tests passed before the final test-title-only edit; the focused 5-test file passed after it.
- `npx vitest run --project e2e-support test/e2e/support/portable-profile-rootless-runtime-workflow.test.ts` — 4 tests passed.
- `npm run test:changed` — 45 growth-guardrail tests passed; no changed CLI, plugin, or E2E-support source tests were selected.
- `npm run source-shape:check` — passed with no new source-shape tests.
- `npx prek run shellcheck --files agents/hermes/start.sh` — passed.
- `npm run validate:pr` — passed.
- The diff contains no secrets, API keys, or credentials.

## Review notes

`agents/hermes/start.sh` is a contributor-sensitive runtime path. Self-review covered exact commit `ce7d901df24115399da1f42c270b766f0112b50a` in `NVIDIA/NemoClaw`: invalid inputs still fail, accepted inputs retain the same parser, the diagnostic does not expose the URL, and no later startup operation runs after rejection. No independent pre-publication review exists; the draft awaits repository review and the rootless Linux E2E boundary.

---

Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid dashboard URLs now fail immediately during startup, before logging begins.
  - Invalid URL values are no longer exposed in error output.
  - Startup validation now occurs consistently before asynchronous logging and capability setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->