### PR TITLE
test(hermes): repair API port bootstrap harness

### DIFF
--- a/test/agents/hermes/hermes-api-port-startup.test.ts
+++ b/test/agents/hermes/hermes-api-port-startup.test.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
@@ -14,14 +15,16 @@ function runHermesApiPortBootstrap(apiPort: string) {
   try {
     const scriptPath = path.join(tmpDir, "run.sh");
     const source = fs.readFileSync(START_SCRIPT, "utf-8");
-    const start = source.indexOf('NEMOCLAW_CMD=("$@")');
+    const start = source.indexOf('_dashboard_port_raw="${NEMOCLAW_DASHBOARD_PORT:-}"');
     const end = source.indexOf('\nHERMES="$(command -v hermes)"', start);
+    assert(start >= 0 && end > start, "Hermes API port bootstrap markers not found");
     fs.writeFileSync(
       scriptPath,
       [
         "#!/usr/bin/env bash",
         "set -euo pipefail",
         "set -- true",
+        '_chat_ui_port=""',
         source.slice(start, end).trimEnd(),
         'printf "PUBLIC_PORT=%s\\n" "$PUBLIC_PORT"',
       ].join("\n"),


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

Hermes API port startup coverage passes again after dashboard URL validation moved earlier in start.sh.

## Reason

Main CI failed because the API port test harness extracted from NEMOCLAW_CMD onward, while the moved dashboard parser now defines _chat_ui_port before that marker. The harness exited on an unbound variable before exercising API port validation.

## Changes

- Start the isolated API-port harness at the dashboard-port bootstrap it exercises.
- Initialize the earlier parser output at the extraction boundary and assert that both source markers exist.

## Verification

- Contributor validation: Signed commit hooks and npm run validate:pr passed.
- Tests: npx vitest run --project integration test/agents/hermes/hermes-api-port-startup.test.ts test/agents/hermes/hermes-start-ports.test.ts — 2 files and 9 tests passed. npm run validate:pr — passed after building the required CLI and plugin artifacts.
- Secrets review: The diff contains no secrets, API keys, or credentials

---

Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Hermes API startup validation to ensure required startup markers are present before creating the temporary script.
  - Updated generated startup scripts to initialize the chat UI port correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->