### PR TITLE
test(hermes): harden root entrypoint smoke

### DIFF
--- a/test/agents/hermes/hermes-start.test.ts
+++ b/test/agents/hermes/hermes-start.test.ts
@@ -15,6 +15,26 @@ import {
 } from "../../support/hermes-shell-harness";
 
 const START_SCRIPT = path.join(import.meta.dirname, "../../..", "agents", "hermes", "start.sh");
+const ROOT_ENTRYPOINT_SMOKE = path.join(
+  import.meta.dirname,
+  "../..",
+  "e2e",
+  "live",
+  "hermes-root-entrypoint-smoke.test.ts",
+);
+
+describe("Hermes root-entrypoint smoke process boundaries", () => {
+  it("keeps startup as PID 1 while bounding refusal scenarios externally", () => {
+    const source = fs.readFileSync(ROOT_ENTRYPOINT_SMOKE, "utf-8");
+
+    expect(source).not.toContain(
+      "/usr/bin/timeout 30s /usr/local/bin/nemoclaw-start /usr/local/bin/nemoclaw-start",
+    );
+    expect(source).not.toContain(
+      "exec /usr/bin/timeout 30s /usr/bin/setpriv --reuid=sandbox",
+    );
+  });
+});
 const ENV_WRAPPER = path.join(
   import.meta.dirname,
   "../../../scripts/lib/entrypoint-env-wrapper.sh",

--- a/test/e2e/live/hermes-root-entrypoint-smoke.test.ts
+++ b/test/e2e/live/hermes-root-entrypoint-smoke.test.ts
@@ -228,7 +228,7 @@ for dir in sessions gateway runtime; do
 done
 history=/sandbox/.hermes/.hermes_history
 stat -c '%U:%G %a' "$history" | grep -Fx 'gateway:sandbox 660'
-/usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- sh -lc 'printf "sandbox history probe\n" >>/sandbox/.hermes/.hermes_history'
+/usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- python3 -I -c 'import os; fd = os.open("/sandbox/.hermes/.hermes_history", os.O_WRONLY | os.O_APPEND); os.write(fd, b"sandbox history probe\n"); os.close(fd)'
 ! /usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- rm -f "$history"
 stat -c '%F' "$history" | grep -Fx 'regular file'
 token="$(python3 -I -c 'from pathlib import Path; lines=(line.strip().removeprefix("export ").lstrip() for line in Path("/sandbox/.hermes/.env").read_text(encoding="utf-8").splitlines()); print(next(line.split("=", 1)[1].strip().strip("\\\"'\"'\"'") for line in lines if line.startswith("API_SERVER_KEY=")))')"
@@ -326,7 +326,7 @@ async function assertGatewayProcess(
   const dispatcherProbe =
     expectedDispatcher === undefined
       ? ":"
-      : `pid="$(ps -eo pid=,user=,args= | awk '$2 == "gateway" && (index($0, "hermes gateway run") || index($0, "hermes.real gateway run")) { print $1; exit }')" && printf '%s\\n' "$pid" | grep -Ex '[0-9]+' && tr '\\0' '\\n' <"/proc/$pid/environ" | grep -Fx 'HERMES_KANBAN_DISPATCH_IN_GATEWAY=${expectedDispatcher}'`;
+      : `pid="$(ps -eo pid=,user=,args= | awk '$2 == "gateway" && (index($0, "hermes gateway run") || index($0, "hermes.real gateway run")) { print $1; exit }')" && printf '%s\\n' "$pid" | grep -Ex '[0-9]+' && /usr/bin/setpriv --reuid=gateway --regid=gateway --init-groups -- sh -c 'tr "\\0" "\\n" <"/proc/$1/environ"' sh "$pid" | grep -Fx 'HERMES_KANBAN_DISPATCH_IN_GATEWAY=${expectedDispatcher}'`;
   await expectContainerSh(
     probe,
     container,
@@ -436,7 +436,7 @@ ${setup}
 stat -c '%U:%G %a' ${target} >/tmp/nemoclaw-protected-file.stat
 sha256sum ${target} >/tmp/nemoclaw-protected-file.sha256
 set +e
-/usr/bin/timeout 30s /usr/local/bin/nemoclaw-start /usr/local/bin/nemoclaw-start >/tmp/nemoclaw-hardlink-start.log 2>&1
+/usr/local/bin/nemoclaw-start /usr/local/bin/nemoclaw-start >/tmp/nemoclaw-hardlink-start.log 2>&1
 startup_status=$?
 set -e
 test "$startup_status" -ne 0
@@ -499,7 +499,7 @@ export NEMOCLAW_TEST_REAL_PYTHON="$real_python"
 stat -c '%U:%G %a %s' /tmp/nemoclaw-layout-external /tmp/nemoclaw-layout-external/sentinel.txt >/tmp/nemoclaw-layout-external.stat
 sha256sum /tmp/nemoclaw-layout-external/sentinel.txt >/tmp/nemoclaw-layout-external.sha256
 set +e
-/usr/bin/timeout 30s /usr/local/bin/nemoclaw-start /usr/local/bin/nemoclaw-start >/tmp/nemoclaw-layout-swap-start.log 2>&1
+/usr/local/bin/nemoclaw-start /usr/local/bin/nemoclaw-start >/tmp/nemoclaw-layout-swap-start.log 2>&1
 startup_status=$?
 set -e
 test "$startup_status" -ne 0
@@ -534,7 +534,7 @@ async function runNonRootHistoryOwnershipRefusalVariant(
       "/bin/bash",
       image,
       "-lc",
-      "chown sandbox:root /sandbox/.hermes/.hermes_history && chmod 660 /sandbox/.hermes/.hermes_history && exec /usr/bin/timeout 30s /usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- /usr/local/bin/nemoclaw-start /usr/local/bin/nemoclaw-start",
+      "chown sandbox:root /sandbox/.hermes/.hermes_history && chmod 660 /sandbox/.hermes/.hermes_history && exec /usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- /usr/local/bin/nemoclaw-start /usr/local/bin/nemoclaw-start",
     ],
     { artifactName: "start-nonroot-history-owner-refusal-container", timeoutMs: RUN_TIMEOUT_MS },
   );


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

Hermes root-entrypoint smoke probes remain valid on the updated GitHub-hosted Ubuntu kernel while preserving the production startup security contract.

## Reason

Main run 34279066411 exposed kernel-sensitive test mechanics rather than product failures. Root could no longer read the gateway process environment, shell redirection could not append to the protected history file, and timeout wrappers changed PID 1 so startup correctly rejected the synthetic process tree as foreign.

## Changes

- Read the gateway environment as the gateway UID and append history through an explicit descriptor opened as the sandbox UID.
- Remove timeout wrappers that interposed a foreign PID 1 around startup refusal scenarios; the Docker probe still provides the bounded 60-second outer timeout.

## Verification

- Contributor validation: commit hooks and npm run validate:pr passed against canonical main 730b6550558460081458fa83d5b1ad937428d05a.
- Tests: repository checks, Vitest project membership, formatting, and E2E semantic phase validation passed. The changed live Docker boundary is left to CI because the available local image architecture differs from this arm64 host.
- Secrets review: The diff contains no secrets, API keys, or credentials.

---

Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved startup smoke-test reliability for sandbox history handling and gateway environment checks.
  - Added coverage to verify startup processes retain expected process behavior.
  - Preserved command-level safeguards while simplifying startup test execution.
  - No changes to exported or public functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->