### PR TITLE
test(hermes): observe root entrypoint process

### DIFF
--- a/test/agents/hermes/hermes-start.test.ts
+++ b/test/agents/hermes/hermes-start.test.ts
@@ -15,26 +15,6 @@ import {
 } from "../../support/hermes-shell-harness";
 
 const START_SCRIPT = path.join(import.meta.dirname, "../../..", "agents", "hermes", "start.sh");
-const ROOT_ENTRYPOINT_SMOKE = path.join(
-  import.meta.dirname,
-  "../..",
-  "e2e",
-  "live",
-  "hermes-root-entrypoint-smoke.test.ts",
-);
-
-describe("Hermes root-entrypoint smoke process boundaries", () => {
-  it("keeps startup as PID 1 while bounding refusal scenarios externally", () => {
-    const source = fs.readFileSync(ROOT_ENTRYPOINT_SMOKE, "utf-8");
-
-    expect(source).not.toContain(
-      "/usr/bin/timeout 30s /usr/local/bin/nemoclaw-start /usr/local/bin/nemoclaw-start",
-    );
-    expect(source).not.toContain(
-      "exec /usr/bin/timeout 30s /usr/bin/setpriv --reuid=sandbox",
-    );
-  });
-});
 const ENV_WRAPPER = path.join(
   import.meta.dirname,
   "../../../scripts/lib/entrypoint-env-wrapper.sh",

--- a/test/e2e/live/hermes-root-entrypoint-smoke.test.ts
+++ b/test/e2e/live/hermes-root-entrypoint-smoke.test.ts
@@ -331,7 +331,7 @@ async function assertGatewayProcess(
     probe,
     container,
     "Hermes gateway process does not preserve its user, launch, or dispatcher contract",
-    `ps -eo user=,args= | awk '$1 == "gateway" && (index($0, "hermes gateway run") || index($0, "hermes.real gateway run")) { found = 1 } END { exit found ? 0 : 1 }' && grep -F "hermes gateway launched as 'gateway' user" /tmp/nemoclaw-start.log && ${dispatcherProbe}`,
+    `ps -o user=,pid=,ppid=,args= -p 1 | awk '$1 == "root" && $2 == 1 && $3 == 0 && index($0, "/usr/local/bin/nemoclaw-start") { found = 1 } END { exit found ? 0 : 1 }' && ps -eo user=,args= | awk '$1 == "gateway" && (index($0, "hermes gateway run") || index($0, "hermes.real gateway run")) { found = 1 } END { exit found ? 0 : 1 }' && grep -F "hermes gateway launched as 'gateway' user" /tmp/nemoclaw-start.log && ${dispatcherProbe}`,
   );
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

Hermes root-entrypoint coverage now proves the production process boundary through the running container instead of inspecting test source text.

## Reason

Follow-up to the non-blocking review on #11238: the mapped fast test asserted exact source strings and could pass after an indirect wrapper changed PID 1. The owning live Docker boundary can observe the actual PID, parent PID, UID, and command.

## Changes

- Remove the cross-test literal assertions from the Hermes integration suite.
- Extend the existing live gateway process probe to require the root-owned NemoClaw startup process at PID 1 with parent PID 0.
- Keep refusal scenarios bounded by DockerProbe's existing 60-second process supervisor and their existing non-timeout status checks.

## Verification

- Contributor validation: signed commit hooks and npm run validate:pr passed against canonical main c8bd71cfe69a86f9c79c0b9cbfd1cba6359984f6.
- Tests: npx vitest run --project integration test/agents/hermes/hermes-start.test.ts — 51 passed; E2E mock/live parity passed; repository checks passed.
- Secrets review: The diff contains no secrets, API keys, or credentials.

Relates to #11238

---

Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed the Hermes root-entrypoint smoke test.
  * Updated end-to-end validation to confirm the gateway runs under the expected user and entrypoint configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->