### PR TITLE
chore(security): defer js-yaml remediation until September 10

### DIFF
--- a/ci/npm-audit-exceptions.json
+++ b/ci/npm-audit-exceptions.json
@@ -1,4 +1,21 @@
 {
   "schemaVersion": 1,
-  "exceptions": []
+  "exceptions": [
+    {
+      "advisory": "GHSA-2883-xcg3-v3hh",
+      "compensatingControls": [
+        "The identified production consumer reads agent manifests from the installed repository, not a remote request endpoint.",
+        "Keep agent manifest files under maintainer control during the exception period."
+      ],
+      "decision": "temporary-risk-acceptance",
+      "expires": "2026-09-10",
+      "graph": "nemoclaw-cli",
+      "installedVersion": "4.3.1",
+      "owner": "Rebecca Sliter",
+      "package": "js-yaml",
+      "rationale": "Rebecca Sliter approved deferring the js-yaml 4.3.2 upgrade from v0.0.121 until September 10, 2026. This accepts the identified merge-work denial-of-service risk temporarily; it does not establish that all callers are unaffected.",
+      "severity": "high",
+      "trackingIssue": "https://github.com/NVIDIA/NemoClaw/issues/11252"
+    }
+  ]
 }

--- a/test/automation/releases/reviewed-npm-audit.test.ts
+++ b/test/automation/releases/reviewed-npm-audit.test.ts
@@ -129,7 +129,9 @@ function exceptionPolicy(
 
 describe("reviewed npm audit gate", () => {
   it("removes the checked-in brace-expansion exception after remediation (#8116)", () => {
-    expect(CHECKED_IN_POLICY).toEqual(EMPTY_POLICY);
+    expect(CHECKED_IN_POLICY.exceptions).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ package: "brace-expansion" })]),
+    );
   });
 
   it("fails at high or critical findings while retaining lower severities", () => {


### PR DESCRIPTION
## Outcome

Temporarily accept GHSA-2883-xcg3-v3hh for js-yaml 4.3.1 in the CLI production graph through September 10, 2026 UTC. Keep the dependency upgrade deferred from v0.0.121.

## Reason

The refreshed release image audit blocks on this advisory. The maintainer accepted the risk temporarily while the upgrade remains tracked separately.

### Related issues

Refs #11252.

## Changes

- Scope the existing audit exception mechanism to one advisory, package, installed version, severity, and production graph.
- Record the owner, expiry, rationale, and manifest-control precautions.
- Narrow the brace-expansion regression to prohibit its old exception without prohibiting unrelated exceptions.

## Verification

- `npm run validate:pr`: passed against canonical main 7c54bc084 after building CLI and plugin prerequisites.
- Focused reviewed-npm-audit integration suite: 42 tests passed.
- Live production audit through runReviewedNpmAudit: accepted-exceptions for only GHSA-2883-xcg3-v3hh; no unaccepted blocking advisories.
- Expiry boundary: accepted at 2026-09-10T23:59:59Z and rejected at 2026-09-11T00:00:00Z.
- No dependency versions, runtime code, audit thresholds, secrets, API keys, or credentials changed.

## Review notes

Maintainer risk acceptance: https://github.com/NVIDIA/NemoClaw/issues/11252#issuecomment-5594527324. The authenticated author rsliter had MAINTAIN permission when this record was created. This exception does not waive image publication, E2E decisions, or release confirmation. Independent PR review remains pending.

---
Signed-off-by: Rebecca Sliter <571084+rsliter@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Updated security audit tracking with a temporary, documented exception and compensating controls for a known high-severity advisory.
  - Included an expiration date, ownership, rationale, and remediation tracking to support follow-up.

- **Tests**
  - Updated automated validation to confirm that resolved audit exceptions are no longer listed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->