### PR TITLE
fix(ci): publish base images after root dependency changes

### DIFF
--- a/.github/workflows/base-image.yaml
+++ b/.github/workflows/base-image.yaml
@@ -30,6 +30,8 @@ on:
       - ".github/actions/build-base-image-platform/**"
       - ".github/actions/publish-base-image-manifest/**"
       - ".dockerignore"
+      - "package.json"
+      - "package-lock.json"
       # Complete managed-image inputs. Keep these reviewed families synchronized
       # with tools/e2e/base-image-publication.mts.
       - "Dockerfile"

--- a/test/e2e/support/base-image-publication.test.ts
+++ b/test/e2e/support/base-image-publication.test.ts
@@ -9,6 +9,7 @@ import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  baseImageInputsChanged,
   collectPaginated,
   expandBaseImagePushPaths,
   type FirstParentHistory,
@@ -163,6 +164,18 @@ function successfulJobs(overrides: { runAttempt?: number } = {}): Record<string,
 }
 
 describe("base-image publication evidence", () => {
+  it("publishes after a root package manifest changes", () => {
+    const workflowSource = fs.readFileSync(
+      path.resolve(import.meta.dirname, "../../../.github/workflows/base-image.yaml"),
+      "utf8",
+    );
+    const reviewedPaths = parseBaseImagePushPaths(workflowSource);
+
+    expect(reviewedPaths).toEqual(expect.arrayContaining(["package.json", "package-lock.json"]));
+    expect(baseImageInputsChanged(["package.json"], reviewedPaths)).toBe(true);
+    expect(baseImageInputsChanged(["package-lock.json"], reviewedPaths)).toBe(true);
+  });
+
   it.each(["push", "workflow_dispatch"])("accepts %s publication preflight events", (eventName) => {
     expect(isBaseImagePublicationEvent(eventName)).toBe(true);
   });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

Publish base and managed images after the root package manifest or lockfile changes. Downstream PR gates can then use publication evidence built from the dependency graph on `main`.

## Reason

PR #11264 updated the root dependency graph, but the base-image workflow did not run because its `push.paths` list omitted the root package files. As a result, PR #11098 still sees the earlier failed publication instead of a new audited publication from `main`.

### Related issues

Unblocks #11098.
Relates to #11264.

## Changes

- Add `package.json` and `package-lock.json` to the base-image workflow's exact push paths.
- Add a regression test that reads the checked-in workflow and proves that either root package file selects publication.
- Keep the existing push-only publication evidence boundary unchanged. A manual dispatch is insufficient because the downstream verifier accepts trusted `push` runs from `main`.

## Verification

- `npx vitest run --project e2e-support test/e2e/support/base-image-publication.test.ts --reporter=dot` — passed, 62 tests.
- `npm run format:check` — passed.
- `npm run test:titles:check` — passed.
- `npm run build:cli` — passed.
- `npm --prefix nemoclaw run build` — passed.
- `npm run validate:pr` — passed.
- `git diff --check` and manual diff review — passed; the diff contains no secrets, API keys, or credentials.

## Review notes

This changes the sensitive workflow path `.github/workflows/base-image.yaml` in `NVIDIA/NemoClaw` at commit `efd8d768676feeac545b6ab4140590e16cfacf6e`. Author self-review and the focused workflow contract test found no change to permissions, credentials, job code, or publication trust boundaries. No independent pre-publication review is verified; this draft awaits independent review.

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Base image publication workflows now trigger when the root package manifest or lockfile changes.

* **Tests**
  * Added coverage to verify that changes to these package files correctly trigger base image publication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->