### PR TITLE
ci(images): document push-only E2E publication evidence

### DIFF
--- a/.github/workflows/base-image.yaml
+++ b/.github/workflows/base-image.yaml
@@ -6,6 +6,7 @@
 # Triggers:
 #   - Push to main when a base- or managed-image input changes
 #   - Manual dispatch for ad-hoc rebuilds
+# E2E publication verification accepts push builds, not manual rebuilds.
 #
 # Base images contain the expensive, rarely-changing layers. Complete image
 # publication consumes exact base digests from the same trusted workflow run.


### PR DESCRIPTION
## Outcome

Merging this comment-only change starts a push-triggered image publication for the v0.0.121 release candidate. Workflow configuration and runtime behavior remain unchanged.

## Reason

The E2E publication verifier accepts only push-triggered image builds. A successful manual rebuild cannot satisfy that prerequisite. This workflow already lists itself as a push trigger.

## Changes

- Add one comment documenting the verifier's push-only publication requirement.
- Leave triggers, permissions, jobs, dependencies, and verification rules unchanged.

## Verification

- Parsed the candidate and canonical-base workflows with js-yaml and compared them with strict deep equality: passed. Confirmed the workflow remains in its own push-path list.
- `npx vitest run --project e2e-support test/e2e/support/base-image-publication.test.ts --reporter=dot`: 61 tests passed.
- `npm run validate:pr`: passed, including YAML validation, secret scanning, and growth guardrails. Prek reported an invalid cached hook entry, but all applicable checks completed successfully.
- `git diff --check`: passed. The complete diff is one added comment and contains no secrets, API keys, or credentials.
- GitHub verified signed commit `606d9cd998aedd1ef65fcb8a0b8bae55df1b69d4`.

## Review notes

Sensitive path: `.github/workflows/base-image.yaml` in NVIDIA/NemoClaw. Agent self-review of commit `606d9cd998aedd1ef65fcb8a0b8bae55df1b69d4` against base `de7f565dd062b6f5affe12218ad825c97efee042` confirmed a comment-only diff and identical parsed configuration. No controls or credentials change. Independent review is pending; this PR is opened as a draft. No CI waiver is requested.

---
Signed-off-by: Rebecca Sliter <571084+rsliter@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that end-to-end publication verification supports push-triggered builds but not manually rebuilt images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->