### PR TITLE
fix(hermes): isolate startup Python and repair root entrypoint smoke

### DIFF
--- a/ci/e2e-assertion-budget.json
+++ b/ci/e2e-assertion-budget.json
@@ -24,7 +24,7 @@
       "objectFieldAssertions": 245,
       "assertionPoints": 2820,
       "generatedProbeBlocks": 124,
-      "generatedProbeConditions": 332
+      "generatedProbeConditions": 328
     },
     "unique": {
       "expectCalls": 2300,
@@ -36,7 +36,7 @@
       "objectFieldAssertions": 344,
       "assertionPoints": 4305,
       "generatedProbeBlocks": 279,
-      "generatedProbeConditions": 954
+      "generatedProbeConditions": 950
     },
     "fileMetricOrder": [
       "directExpectCalls",

--- a/scripts/lib/sandbox-init.sh
+++ b/scripts/lib/sandbox-init.sh
@@ -520,7 +520,7 @@ lock_rc_files() {
       continue
     fi
     if [ -f "$rc_file" ]; then
-      if ! python3 - "$rc_file" "$(id -u)" <<'PY' 2>/dev/null; then
+      if ! python3 -I - "$rc_file" "$(id -u)" <<'PY' 2>/dev/null; then
 import errno
 import os
 import stat
@@ -645,7 +645,7 @@ EOF
 }
 
 read_messaging_plan_channels() {
-  python3 - <<'PY'
+  python3 -I - <<'PY'
 import base64
 import json
 import os

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -210,6 +210,24 @@ The 90-minute `test-hermes-sandbox-image` job downloads and loads that artifact 
 rebuilding the image.
 Within that job, the secret-boundary and root-entrypoint steps have 45- and 30-minute budgets respectively.
 
+To reproduce root-entrypoint failures locally, load the run's `hermes-isolation-image` artifact into Docker and run:
+
+```bash
+NEMOCLAW_HERMES_TEST_IMAGE=nemoclaw-hermes-production NEMOCLAW_RUN_LIVE_E2E=1 \
+  npx vitest run --project e2e-live test/e2e/live/hermes-root-entrypoint-smoke.test.ts
+```
+
+For Rancher Desktop, also set `DOCKER_HOST=unix://$HOME/.rd/docker.sock`.
+Use a native image for process-identity checks; QEMU can cause the startup guard to reject a valid PID 1.
+To build a native image from the checkout with its pinned published base, run `docker build -f agents/hermes/Dockerfile -t nemoclaw-hermes-local .`.
+Then set `NEMOCLAW_HERMES_TEST_IMAGE=nemoclaw-hermes-local` in the test command.
+Refusal scenarios execute startup as PID 1.
+They require exit code 1 for root preparation or 78 for non-root layout repair.
+They then start the retained container with a verification script to check the refusal reason and filesystem state.
+This second pass does not launch Hermes again.
+The sandbox user owns the config directory and can remove its history file.
+Sticky-bit protection prevents the gateway user from removing sandbox-owned config files.
+
 The former root-level `test/e2e-test.sh` and `test/e2e-gateway-isolation.sh` suites have been
 removed. Their production-image security coverage now belongs to
 `test/e2e-runtime/managed-image-openclaw-security.test.ts` and the

--- a/test/e2e/live/hermes-root-entrypoint-smoke.test.ts
+++ b/test/e2e/live/hermes-root-entrypoint-smoke.test.ts
@@ -80,7 +80,20 @@ async function dockerExecSh(
   script: string,
   artifactName: string,
 ): Promise<DockerCommandResult> {
-  return probe.run(["exec", container, "sh", "-lc", script], { artifactName });
+  return probe.run(
+    [
+      "exec",
+      container,
+      "bash",
+      "-Eeuo",
+      "pipefail",
+      "-c",
+      `
+trap 'printf "Probe failed at line %s\\n" "$LINENO" >&2' ERR
+${script}`,
+    ],
+    { artifactName },
+  );
 }
 
 async function expectContainerSh(
@@ -101,7 +114,7 @@ async function expectContainerShFails(
   script: string,
 ): Promise<void> {
   const result = await dockerExecSh(probe, container, script, message);
-  expect(result.exitCode, `${container}: ${message}\n${resultText(result)}`).not.toBe(0);
+  expect(result.exitCode, `${container}: ${message}\n${resultText(result)}`).toBe(1);
 }
 
 async function dumpContainerDiagnostics(probe: DockerProbe, container: string): Promise<void> {
@@ -220,7 +233,7 @@ async function assertRuntimeLayout(probe: DockerProbe, container: string): Promi
     container,
     "Hermes runtime, API authorization, or dashboard credential-boundary contract failed",
     String.raw`set -eu
-/usr/bin/setpriv --reuid=gateway --regid=gateway --init-groups -- sh -lc 'for dir in hooks image_cache audio_cache logs/curator; do p="/sandbox/.hermes/$dir/.nemoclaw-write-test"; : >"$p" && rm -f "$p"; done'
+/usr/bin/setpriv --reuid=gateway --regid=gateway --init-groups -- sh -euc 'for dir in hooks image_cache audio_cache logs/curator; do p="/sandbox/.hermes/$dir/.nemoclaw-write-test"; : >"$p"; rm -f "$p"; done'
 for dir in sessions gateway runtime; do
   stat -c '%U:%G %a' "/sandbox/.hermes/$dir" | grep -Fx 'gateway:sandbox 2770'
   /usr/bin/setpriv --reuid=gateway --regid=gateway --init-groups -- sh -lc ": > /sandbox/.hermes/$dir/.nemoclaw-gateway-write-test && rm -f /sandbox/.hermes/$dir/.nemoclaw-gateway-write-test"
@@ -229,9 +242,18 @@ done
 history=/sandbox/.hermes/.hermes_history
 stat -c '%U:%G %a' "$history" | grep -Fx 'gateway:sandbox 660'
 /usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- python3 -I -c 'import os; fd = os.open("/sandbox/.hermes/.hermes_history", os.O_WRONLY | os.O_APPEND); os.write(fd, b"sandbox history probe\n"); os.close(fd)'
-! /usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- rm -f "$history"
 stat -c '%F' "$history" | grep -Fx 'regular file'
-token="$(python3 -I -c 'from pathlib import Path; lines=(line.strip().removeprefix("export ").lstrip() for line in Path("/sandbox/.hermes/.env").read_text(encoding="utf-8").splitlines()); print(next(line.split("=", 1)[1].strip().strip("\\\"'\"'\"'") for line in lines if line.startswith("API_SERVER_KEY=")))')"
+token="$(python3 -I - <<'PYTOKEN'
+from pathlib import Path
+
+lines = (
+    line.strip().removeprefix("export ").lstrip()
+    for line in Path("/sandbox/.hermes/.env").read_text(encoding="utf-8").splitlines()
+)
+value = next(line.split("=", 1)[1] for line in lines if line.startswith("API_SERVER_KEY="))
+print(value.strip().strip("\"'"))
+PYTOKEN
+)"
 printf '%s\n' "$token" | grep -Eq '^[[:xdigit:]]{64}$'
 curl -sS -o /dev/null -w '%{http_code}\n' --max-time 15 http://127.0.0.1:8642/v1/models | grep -Fx 401
 printf 'header = "Authorization: Bearer %s"\n' wrong-token | curl -sS -o /dev/null -w '%{http_code}\n' --max-time 15 --config - http://127.0.0.1:8642/v1/models | grep -Fx 401
@@ -242,7 +264,7 @@ stat -c '%U:%G %a' "$dashboard" | grep -Fx 'sandbox:sandbox 700'
 stat -c '%U:%G %a' "$dashboard/config.yaml" | grep -Fx 'sandbox:sandbox 600'
 stat -c '%U:%G %a' "$dashboard/.env" | grep -Fx 'sandbox:sandbox 600'
 sed -e '/^[[:space:]]*#/d' -e '/^[[:space:]]*$/d' -e 's/^[[:space:]]*export[[:space:]]*//' "$dashboard/.env" | cut -d= -f1 | sort > /tmp/nemoclaw-dashboard-env-keys
-printf '%s\n' API_SERVER_HOST API_SERVER_PORT NEMOCLAW_HERMES_TOOL_GATEWAY_BROKER FIRECRAWL_GATEWAY_URL OPENAI_AUDIO_GATEWAY_URL BROWSER_USE_GATEWAY_URL FAL_QUEUE_GATEWAY_URL MODAL_GATEWAY_URL | sort > /tmp/nemoclaw-dashboard-env-keys.expected
+printf '%s\n' API_SERVER_HOST API_SERVER_PORT | sort > /tmp/nemoclaw-dashboard-env-keys.expected
 cmp /tmp/nemoclaw-dashboard-env-keys.expected /tmp/nemoclaw-dashboard-env-keys
 grep -Eq '^[[:space:]]*(export[[:space:]]+)?API_SERVER_KEY=' "$dashboard/.env" && exit 1 || :
 grep -F 'model:' "$dashboard/config.yaml" >/dev/null
@@ -342,6 +364,7 @@ async function runCleanVariant(
   containers: string[],
 ): Promise<void> {
   const container = `nemoclaw-hermes-root-clean-${runId}`;
+  containers.push(container);
   await probe.expect(
     [
       "run",
@@ -355,8 +378,6 @@ async function runCleanVariant(
     ],
     { artifactName: "start-clean-root-entrypoint-container", timeoutMs: RUN_TIMEOUT_MS },
   );
-  containers.push(container);
-
   await waitForHealth(probe, container);
   await assertGatewayProcess(probe, container, "1");
   await assertGatewayLogClean(probe, container);
@@ -390,12 +411,11 @@ chmod 444 /tmp/nemoclaw-hostile-python/sitecustomize.py
 export PYTHONPATH=/tmp/nemoclaw-hostile-python
 exec /usr/local/bin/nemoclaw-start /usr/local/bin/nemoclaw-start`;
 
+  containers.push(container);
   await probe.expect(
     ["run", "-d", "--name", container, "--entrypoint", "/bin/bash", image, "-lc", legacyBootstrap],
     { artifactName: "start-legacy-layout-root-entrypoint-container", timeoutMs: RUN_TIMEOUT_MS },
   );
-  containers.push(container);
-
   await waitForHealth(probe, container);
   await assertGatewayProcess(probe, container);
   await assertGatewayLogClean(probe, container);
@@ -407,6 +427,37 @@ exec /usr/local/bin/nemoclaw-start /usr/local/bin/nemoclaw-start`;
     "legacy recovery or root Python isolation evidence was missing",
     "grep -F 'Removing unsafe stale Hermes legacy PID file symlink' /tmp/nemoclaw-start.log && test ! -e /tmp/nemoclaw-root-sitecustomize-ran",
   );
+}
+
+async function runRefusalVariant(
+  probe: DockerProbe,
+  image: string,
+  container: string,
+  containers: string[],
+  scenario: string,
+  entrypoint = "/usr/local/bin/nemoclaw-start /usr/local/bin/nemoclaw-start",
+  expectedExitCode: 1 | 78 = 1,
+): Promise<void> {
+  // Each scenario defines setup and verify. Claim startup once; subsequent starts
+  // only verify the retained filesystem. No startup mutation is retried.
+  const bootstrap = `set -euo pipefail
+${scenario}
+mkdir /tmp/nemoclaw-refusal-started 2>/dev/null || { cat /tmp/nemoclaw-refusal.log; verify; exit; }
+setup
+exec ${entrypoint} >/tmp/nemoclaw-refusal.log 2>&1`;
+
+  containers.push(container);
+  const result = await probe.run(
+    ["run", "--name", container, "--entrypoint", "/bin/bash", image, "-lc", bootstrap],
+    { artifactName: `start-${container}`, timeoutMs: RUN_TIMEOUT_MS },
+  );
+  // Establish the expected exit before restarting; an interrupted Docker client
+  // does not prove that production startup stopped.
+  expect(result.exitCode, resultText(result)).toBe(expectedExitCode);
+  await probe.expect(["start", "--attach", container], {
+    artifactName: `verify-${container}`,
+    timeoutMs: RUN_TIMEOUT_MS,
+  });
 }
 
 async function runHardLinkRefusalVariant(
@@ -427,30 +478,22 @@ ln /sandbox/.hermes/config.yaml /sandbox/.hermes/.hermes_history`
 install -d -m 2770 -o sandbox -g sandbox /sandbox/.hermes/logs/curator
 rm -f /sandbox/.hermes/logs/curator/hardlink.log
 ln /sandbox/.hermes/config.yaml /sandbox/.hermes/logs/curator/hardlink.log`;
-  const expectedEvent =
-    kind === "history"
-      ? "Hermes pre-launch layout repair failed at history file"
-      : "Hermes pre-launch layout repair failed at logs directory";
-  const bootstrap = `set -euo pipefail
+  await runRefusalVariant(
+    probe,
+    image,
+    container,
+    containers,
+    `
+setup() {
 ${setup}
 stat -c '%U:%G %a' ${target} >/tmp/nemoclaw-protected-file.stat
 sha256sum ${target} >/tmp/nemoclaw-protected-file.sha256
-set +e
-/usr/local/bin/nemoclaw-start /usr/local/bin/nemoclaw-start >/tmp/nemoclaw-hardlink-start.log 2>&1
-startup_status=$?
-set -e
-test "$startup_status" -ne 0
-test "$startup_status" -ne 124
+}
+verify() {
 test "$(stat -c '%U:%G %a' ${target})" = "$(cat /tmp/nemoclaw-protected-file.stat)"
 sha256sum -c /tmp/nemoclaw-protected-file.sha256
-grep -F 'has hard-link count' /tmp/nemoclaw-hardlink-start.log
-grep -F ${JSON.stringify(expectedEvent)} /tmp/nemoclaw-hardlink-start.log
-cat /tmp/nemoclaw-hardlink-start.log`;
-
-  containers.push(container);
-  await probe.expect(
-    ["run", "--name", container, "--entrypoint", "/bin/bash", image, "-lc", bootstrap],
-    { artifactName: `start-${kind}-hardlink-refusal-container`, timeoutMs: RUN_TIMEOUT_MS },
+grep -F 'refusing hardlinked runtime config path: ${target}' /tmp/nemoclaw-refusal.log
+}`,
   );
 }
 
@@ -461,7 +504,8 @@ async function runMutableLayoutSwapRefusalVariant(
   containers: string[],
 ): Promise<void> {
   const container = `nemoclaw-hermes-root-layout-swap-${runId}`;
-  const bootstrap = String.raw`set -euo pipefail
+  const scenario = String.raw`
+setup() {
 startup_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 python_path="$(PATH="$startup_path" command -v python3)"
 real_python="$python_path.nemoclaw-test-real"
@@ -478,13 +522,18 @@ fi
 tee /tmp/nemoclaw-layout-repair.py >/dev/null
 exec "$NEMOCLAW_TEST_REAL_PYTHON" -I -c '
 import os
+import subprocess
 
 real_fchown = os.fchown
 
 
 def swap_then_fchown(fd, uid, gid):
-    os.rename("/sandbox/.hermes", "/tmp/nemoclaw-original-hermes-root")
-    os.symlink("/tmp/nemoclaw-layout-external", "/sandbox/.hermes")
+    # The sandbox owner can replace this directory after root drops DAC_OVERRIDE.
+    subprocess.run([
+        "/usr/bin/setpriv", "--reuid=sandbox", "--regid=sandbox", "--init-groups", "--",
+        "/bin/sh", "-eu", "-c",
+        "mv /sandbox/.hermes /tmp/nemoclaw-original-hermes-root; ln -s /tmp/nemoclaw-layout-external /sandbox/.hermes",
+    ], check=True)
     return real_fchown(fd, uid, gid)
 
 
@@ -498,24 +547,15 @@ chmod 755 "$python_path"
 export NEMOCLAW_TEST_REAL_PYTHON="$real_python"
 stat -c '%U:%G %a %s' /tmp/nemoclaw-layout-external /tmp/nemoclaw-layout-external/sentinel.txt >/tmp/nemoclaw-layout-external.stat
 sha256sum /tmp/nemoclaw-layout-external/sentinel.txt >/tmp/nemoclaw-layout-external.sha256
-set +e
-/usr/local/bin/nemoclaw-start /usr/local/bin/nemoclaw-start >/tmp/nemoclaw-layout-swap-start.log 2>&1
-startup_status=$?
-set -e
-test "$startup_status" -ne 0
-test "$startup_status" -ne 124
+}
+verify() {
 test -L /sandbox/.hermes
 test "$(readlink /sandbox/.hermes)" = "/tmp/nemoclaw-layout-external"
 test "$(stat -c '%U:%G %a %s' /tmp/nemoclaw-layout-external /tmp/nemoclaw-layout-external/sentinel.txt)" = "$(cat /tmp/nemoclaw-layout-external.stat)"
 sha256sum -c /tmp/nemoclaw-layout-external.sha256
-grep -F '/sandbox/.hermes changed during repair' /tmp/nemoclaw-layout-swap-start.log
-cat /tmp/nemoclaw-layout-swap-start.log`;
-
-  containers.push(container);
-  await probe.expect(
-    ["run", "--name", container, "--entrypoint", "/bin/bash", image, "-lc", bootstrap],
-    { artifactName: "start-root-layout-swap-refusal-container", timeoutMs: RUN_TIMEOUT_MS },
-  );
+grep -F '/sandbox/.hermes changed during repair' /tmp/nemoclaw-refusal.log
+}`;
+  await runRefusalVariant(probe, image, container, containers, scenario);
 }
 
 async function runNonRootHistoryOwnershipRefusalVariant(
@@ -525,21 +565,22 @@ async function runNonRootHistoryOwnershipRefusalVariant(
   containers: string[],
 ): Promise<void> {
   const container = `nemoclaw-hermes-nonroot-history-owner-${runId}`;
-  const result = await probe.run(
-    [
-      "run",
-      "--name",
-      container,
-      "--entrypoint",
-      "/bin/bash",
-      image,
-      "-lc",
-      "chown sandbox:root /sandbox/.hermes/.hermes_history && chmod 660 /sandbox/.hermes/.hermes_history && exec /usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- /usr/local/bin/nemoclaw-start /usr/local/bin/nemoclaw-start",
-    ],
-    { artifactName: "start-nonroot-history-owner-refusal-container", timeoutMs: RUN_TIMEOUT_MS },
+  await runRefusalVariant(
+    probe,
+    image,
+    container,
+    containers,
+    `
+setup() {
+chown sandbox:root /sandbox/.hermes/.hermes_history
+chmod 660 /sandbox/.hermes/.hermes_history
+}
+verify() {
+grep -F '.hermes_history has group gid 0, expected sandbox gid' /tmp/nemoclaw-refusal.log
+}`,
+    "/usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- /usr/local/bin/nemoclaw-start /usr/local/bin/nemoclaw-start",
+    78,
   );
-  containers.push(container);
-  expect(result.exitCode, resultText(result)).toBe(78);
 }
 
 type RootEntrypointTestContext = Pick<
@@ -568,13 +609,13 @@ async function runRootEntrypointScenario(
   scenario: RootEntrypointScenario,
   runVariant: (variant: RootEntrypointVariant) => Promise<void>,
 ): Promise<void> {
-  const { artifacts, cleanup, progress, secrets, signal, skip } = context;
+  const { artifacts, cleanup, progress, secrets, skip } = context;
   const probe = new DockerProbe(
     artifacts,
     (text, extraValues) => secrets.redact(text, extraValues),
     undefined,
     progress,
-    signal,
+    () => cleanup.currentSignal(),
   );
   const containers: string[] = [];
 
@@ -589,7 +630,7 @@ async function runRootEntrypointScenario(
   cleanup.add(`remove Hermes ${scenario.id} containers`, async () => {
     await Promise.all(
       containers.map((container) =>
-        probe.run(["rm", "-f", container], {
+        probe.expect(["rm", "-f", container], {
           artifactName: `cleanup-${container}`,
           timeoutMs: 30_000,
         }),

--- a/test/e2e/mock-parity.json
+++ b/test/e2e/mock-parity.json
@@ -909,6 +909,7 @@
       "live": "test/e2e/live/hermes-root-entrypoint-smoke.test.ts",
       "fast": [
         "test/agents/hermes/hermes-start.test.ts",
+        "test/runtime/sandbox/sandbox-init.test.ts",
         "test/e2e/support/e2e-progress-fixture.test.ts",
         "test/e2e/support/e2e-progress-outcome.test.ts",
         "test/e2e/support/e2e-semantic-phase-check.test.ts",

--- a/test/helpers/vitest-watch-triggers.ts
+++ b/test/helpers/vitest-watch-triggers.ts
@@ -45,6 +45,10 @@ function runTests(...tests: string[]): () => string[] {
 
 export const vitestWatchTriggerPatterns: VitestWatchTriggerPattern[] = [
   {
+    pattern: /(?:^|\/)scripts\/lib\/sandbox-init\.sh$/,
+    testsToRun: runTests("test/runtime/sandbox/sandbox-init.test.ts"),
+  },
+  {
     pattern: /(?:^|\/)\.github\/workflows\/[^/]+\.ya?ml$/,
     testsToRun: runTests("test/repository/github-actions-workflow-names.test.ts"),
   },

--- a/test/runtime/sandbox/sandbox-init.test.ts
+++ b/test/runtime/sandbox/sandbox-init.test.ts
@@ -128,6 +128,49 @@ function restoreTmpArtifacts(paths: string[], backups: Record<string, string>): 
 }
 
 describe("scripts/lib/sandbox-init.sh", () => {
+  describe("Python startup isolation", () => {
+    it.each([
+      {
+        operation: "lock_rc_files",
+        observe: (rcFile: string, _stdout: string) => lstatSync(rcFile).mode & 0o777,
+        expected: 0o444,
+      },
+      {
+        operation: "read_messaging_plan_channels",
+        observe: (_rcFile: string, stdout: string) => stdout,
+        expected: "telegram",
+      },
+    ])(
+      "ignores inherited PYTHONPATH in $operation",
+      ({ operation, observe, expected }) => {
+        const workDir = mkdtempSync(join(tmpdir(), "sandbox-init-python-"));
+        const sentinel = join(workDir, "sitecustomize-ran");
+        const rcFile = join(workDir, ".bashrc");
+        writeFileSync(rcFile, "# fixture\n", { mode: 0o600 });
+        writeFileSync(
+          join(workDir, "sitecustomize.py"),
+          'import os\nfrom pathlib import Path\nPath(os.environ["TEST_PYTHON_SENTINEL"]).write_text("executed")\n',
+        );
+        try {
+          const result = runWithLib(`${operation} "$TEST_PYTHON_HOME"`, {
+            env: {
+              PYTHONPATH: workDir,
+              TEST_PYTHON_HOME: workDir,
+              TEST_PYTHON_SENTINEL: sentinel,
+              NEMOCLAW_MESSAGING_PLAN_B64: Buffer.from(
+                JSON.stringify({ channels: [{ channelId: "telegram", active: true }] }),
+              ).toString("base64"),
+            },
+          });
+          expect(existsSync(sentinel)).toBe(false);
+          expect(observe(rcFile, result.stdout)).toBe(expected);
+        } finally {
+          rmSync(workDir, { recursive: true, force: true });
+        }
+      },
+    );
+  });
+
   describe("emit_sandbox_sourced_file", () => {
     let workDir: string;
 


### PR DESCRIPTION
## Outcome

Hermes root-entrypoint smoke reproduces the five reported failures locally and passes all six scenarios after these changes. Shared startup Python helpers now ignore inherited Python module paths, preventing startup customization code from running with the helper's privileges.

## Reason

The [reported CI job](https://github.com/NVIDIA/NemoClaw/actions/runs/34306361371/job/102325481937) still failed after earlier repairs. Several test assumptions stopped execution before later security checks. Correcting those assumptions exposed two production Python calls that lacked isolated mode.

## Changes

- Add `-I` to the Python calls in `lock_rc_files` and `read_messaging_plan_channels`. Two regression cases demonstrate the previous environment injection and check the intended helper behavior after the fix.
- Execute refusal scenarios as PID 1 and inspect their retained filesystem in a separate verification pass. This is necessary because production startup must replace PID 1; the second pass runs only the verifier. Existing hardlink, directory-swap, and non-root ownership scenarios exercise this behavior.
- Correct the history ownership expectation, token parsing, stock dashboard environment expectation, and directory-swap attack identity. Preserve refusal reasons, file integrity, permission, API authorization, and credential-boundary checks.
- Propagate shell probe failures, register containers before launch, and use the cleanup signal for removal.
- Add local reproduction guidance and the shared shell dependency's watch mapping. Keep four generated probe blocks and 27 assertion points, and lower the conditions census. Each refusal scenario defines setup and verification together; a startup marker prevents repeated fixture mutations.

## Verification

- Follow-up commit `dedb503778ecbda0c65d4b4ca92f4af205c80946`: `npm run validate:pr` passed in isolated Linux ARM64 with Node 24.18.0 against canonical main `673f815e04c1a4ad0548fac63b5f25cf22d47e47`. Canonical validation entrypoints and the current installer trust helper were used without host credentials. Native tool hashes were recorded; fixers left all seven candidate paths unchanged.

- Parity follow-up: `node --import tsx scripts/checks/e2e-mock-parity.mts --base origin/main --head HEAD` passed after mapping the smoke to `test/runtime/sandbox/sandbox-init.test.ts`. The focused parity-validator and shared startup tests passed: 63 passed, one platform skip.

- Native ARM64 production image from unchanged `de7f565dd062b6f5affe12218ad825c97efee042`: original smoke reproduced five failures and one pass.
- Corrected smoke against unchanged production: five passed; the root Python isolation check failed.
- `NEMOCLAW_HERMES_TEST_IMAGE=nemoclaw-hermes-local-fixed NEMOCLAW_RUN_LIVE_E2E=1 npx vitest run --project e2e-live test/e2e/live/hermes-root-entrypoint-smoke.test.ts` — all six passed against the rebuilt native image; no test containers remained.
- `npx vitest run --project integration test/runtime/sandbox/sandbox-init.test.ts test/agents/hermes/hermes-start.test.ts test/agents/hermes/seed-hermes-dashboard-config.test.ts --project e2e-support test/e2e/support/docker-probe.test.ts` — 155 passed in Linux.
- `npx vitest run --project integration test/repository/vitest-watch-triggers.test.ts` — 74 passed.
- Both new Python isolation regressions failed before the production fix and passed afterward.
- `npm run checks:repository`, `npm run test:e2e-phases:check`, focused Oxlint, ShellCheck, Vitest project membership, and `git diff --check` — passed during implementation.
- Diff inspected for secrets, API keys, and credentials; none added.
- `npx vitest run --project integration test/automation/pull-requests/growth-guardrails.test.ts` — 45 passed after repairing both review findings.
- `npm run validate:pr` — passed in disposable Linux ARM64 with Node 22.23.2, both locked dependency sets, and CLI/plugin builds. All applicable pre-commit, commit-message, and pre-push gates passed; fixers left the six candidate files unchanged.
- Final shared-helper regression run in Linux — all 49 passed, including both Python isolation cases.

## Review notes

Parity repair candidate: `dedb503778ecbda0c65d4b4ca92f4af205c80946`. The [failed parity job](https://github.com/NVIDIA/NemoClaw/actions/runs/34314208626/job/102347221499) omitted the existing shared startup regression tests from this smoke's mapping. The follow-up adds that relationship.

CodeRabbit review `5150198893` completed on `99ce3fdd52c669873b8274d6b9bcd8d28fad6c2f`. Its sole inline finding (`3965016356`) claims the final OR branch suppresses Bash `errexit` in `verify`. The supplied reproduction exited 1 without reaching its success message in the tested Hermes image. This is a false positive; the shell code is unchanged. The review thread remains open.

Repository: NVIDIA/NemoClaw. Source baseline: `de7f565dd062b6f5affe12218ad825c97efee042`. Current canonical comparison base: `1b3cd3668c0530969de8a24e941587793a0ea7c4`. Reviewed candidate: `99ce3fdd52c669873b8274d6b9bcd8d28fad6c2f`.

Sensitive path: `scripts/lib/sandbox-init.sh`. Self-review traced both privileged Python calls and observed the before/after regression results and live security sentinel. Independent security review remains pending. No approval or CI waiver is claimed. Publication validation used canonical main (`1b3cd3668c0530969de8a24e941587793a0ea7c4`) package/hook entry points and its current installer trust helper in an isolated container without host credentials. The candidate census and watch mapping were reviewed validation inputs; actual native validator executable hashes were recorded locally.

Local process-identity evidence uses native ARM64 images built from the pinned published base. The AMD64 CI image artifact executes under QEMU on this host, but emulated process identity is unsuitable for these PID 1 checks. Linux AMD64 CI remains to be evaluated.

The smoke retains six scenarios, four generated probe blocks, and 27 assertion points. The final harness repair passed all six live cases again, with cleanup passing. The invalid owner-unlink denial had no distinct quality value because the sandbox user owns the parent directory. Generic status checks are replaced with the expected exit status. Hardlink refusal is checked at the earlier config guard; lower-level layout tests retain layout-repair coverage. Both review findings are repaired and the complete growth-guardrail suite passes. No budget exception is requested.

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added local troubleshooting instructions for reproducing and verifying Hermes root-entrypoint failures, including container setup and filesystem checks.

- **Bug Fixes**
  - Improved validation of refusal scenarios, startup probes, dashboard configuration, and restart behavior.
  - Isolated Python helper execution during sandbox initialization.

- **Tests**
  - Added cross-platform coverage for Python startup isolation and file-permission behavior.
  - Updated automated test triggers, smoke-test coverage, and assertion limits to reflect the current test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->