### PR TITLE
fix(ci): hand trusted audit evidence to protected builds

### DIFF
--- a/.github/actions/ci-reviewed-npm-audit/action.yaml
+++ b/.github/actions/ci-reviewed-npm-audit/action.yaml
@@ -18,6 +18,10 @@ inputs:
     description: Whether this trusted caller may publish reusable audit records.
     required: false
     default: "false"
+  locked-graph:
+    description: Optional configured locked graph to audit instead of every reviewed graph.
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -101,6 +105,7 @@ runs:
     - name: Materialize and audit reviewed npm graphs
       shell: bash
       env:
+        NEMOCLAW_REVIEWED_NPM_AUDIT_LOCKED_GRAPH: ${{ inputs.locked-graph }}
         NEMOCLAW_REVIEWED_NPM_AUDIT_TARGET_ROOT: ${{ inputs.target-root }}
         NEMOCLAW_REVIEWED_NPM_AUDIT_REPORT_DIR: ${{ inputs.report-dir }}
         NEMOCLAW_REVIEWED_NPM_AUDIT_CACHE_DIR: ${{ inputs.cache-directory }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -4224,6 +4224,49 @@ jobs:
         run: bash .github/scripts/docker-auth-cleanup.sh
 
   # Manual PR qualification also requires the exact candidate activation contract.
+  managed-image-protected-audit:
+    name: Produce trusted protected mcporter audit evidence
+    needs: generate-matrix
+    if: ${{ github.repository == 'NVIDIA/NemoClaw' && (github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && contains(fromJSON(needs.generate-matrix.outputs.selected_jobs), 'managed-image-protected-runtime') }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout trusted reviewed npm audit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ inputs.workflow_sha || github.workflow_sha }}
+          persist-credentials: false
+          sparse-checkout: |
+            .github/actions/ci-reviewed-npm-audit
+            ci/npm-audit-exceptions.json
+            ci/reviewed-npm-audit.json
+            scripts/audit-reviewed-npm-graph.mts
+            scripts/lib/npm-audit-receipt.mts
+            scripts/lib/repository-input-path.mts
+            scripts/lib/openclaw-npm-remediation.mts
+            scripts/lib/reviewed-npm-archive.mts
+            scripts/lib/reviewed-npm-audit.mts
+          sparse-checkout-cone-mode: false
+
+      - name: Checkout exact protected audit target
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ${{ inputs.checkout_repository || github.repository }}
+          ref: ${{ inputs.checkout_sha || github.sha }}
+          path: .candidate-audit
+          persist-credentials: false
+
+      - name: Audit exact candidate mcporter graph from trusted code
+        uses: ./.github/actions/ci-reviewed-npm-audit
+        with:
+          target-root: ${{ github.workspace }}/.candidate-audit
+          report-dir: artifacts/reviewed-npm-audit
+          cache-directory: ${{ runner.temp }}/reviewed-npm-audit-cache
+          locked-graph: mcporter-runtime
+
   managed-image-multiarch-startup:
     name: Protected managed-image startup (${{ matrix.platform }})
     needs: [base-image-publication, generate-matrix]
@@ -4956,8 +4999,14 @@ jobs:
   # assertions without the hosted cache.
   managed-image-protected-runtime:
     name: Protected managed-image GPU and local inference
-    needs: [base-image-publication, generate-matrix, managed-image-multiarch-startup]
-    if: ${{ always() && github.repository == 'NVIDIA/NemoClaw' && (github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && needs['base-image-publication'].result == 'success' && needs['generate-matrix'].result == 'success' && needs['managed-image-multiarch-startup'].result == 'success' && contains(fromJSON(needs.generate-matrix.outputs.selected_jobs), 'managed-image-protected-runtime') }}
+    needs:
+      [
+        base-image-publication,
+        generate-matrix,
+        managed-image-multiarch-startup,
+        managed-image-protected-audit,
+      ]
+    if: ${{ always() && github.repository == 'NVIDIA/NemoClaw' && (github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && needs['base-image-publication'].result == 'success' && needs['generate-matrix'].result == 'success' && needs['managed-image-multiarch-startup'].result == 'success' && needs['managed-image-protected-audit'].result == 'success' && contains(fromJSON(needs.generate-matrix.outputs.selected_jobs), 'managed-image-protected-runtime') }}
     runs-on: linux-amd64-gpu-rtxpro6000-latest-1
     timeout-minutes: 300
     permissions:
@@ -5041,6 +5090,12 @@ jobs:
           path: ${{ env.NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE }}
 
       - *dockerhub-auth
+
+      - name: Download trusted protected mcporter audit evidence
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: reviewed-npm-audit
+          path: ${{ runner.temp }}/protected-reviewed-npm-audit
 
       - name: Set up protected runtime Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
@@ -5191,6 +5246,7 @@ jobs:
             --platform linux/amd64 \
             --source-root "$GITHUB_WORKSPACE/.candidate-runtime" \
             --cache-from "$NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE" \
+            --audit-evidence-from "$RUNNER_TEMP/protected-reviewed-npm-audit" \
             --openclaw-base "$BASE_OPENCLAW" \
             --hermes-base "$BASE_HERMES" \
             --dcode-base "$BASE_DCODE"
@@ -6069,6 +6125,7 @@ jobs:
         openshell-dev-artifact,
         mcp-bridge-dev,
         managed-image-multiarch-startup,
+        managed-image-protected-audit,
         llama-cpp-dgx-spark-plan,
         llama-cpp-dgx-spark-qualification,
         managed-image-protected-runtime,

--- a/scripts/audit-reviewed-npm-graph.mts
+++ b/scripts/audit-reviewed-npm-graph.mts
@@ -73,6 +73,16 @@ type ReviewedAuditReport = Readonly<{
   threshold?: Severity;
 }>;
 
+export function selectLockedGraph(
+  config: Readonly<{ lockedGraphs: readonly LockedGraph[] }>,
+  graphId: string | undefined,
+): Readonly<{ graph: LockedGraph; index: number }> | undefined {
+  if (!graphId) return undefined;
+  const index = config.lockedGraphs.findIndex((graph) => graph.id === graphId);
+  if (index < 0) throw new Error("reviewed npm audit locked graph is not configured");
+  return { graph: config.lockedGraphs[index]!, index };
+}
+
 const TRUSTED_REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const TARGET_REPO_ROOT = fs.realpathSync(
   path.resolve(process.env.NEMOCLAW_REVIEWED_NPM_AUDIT_TARGET_ROOT ?? TRUSTED_REPO_ROOT),
@@ -900,6 +910,10 @@ export function assertReviewedAuditReportsPass(
 
 function main(): void {
   const config = readConfig();
+  const selectedLockedGraph = selectLockedGraph(
+    config,
+    process.env.NEMOCLAW_REVIEWED_NPM_AUDIT_LOCKED_GRAPH,
+  );
   const expectedNode = `v${config.nodeVersion}`;
   if (process.version !== expectedNode) {
     throw new Error(`reviewed npm audit requires Node ${expectedNode}; running ${process.version}`);
@@ -928,6 +942,43 @@ function main(): void {
   }
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-reviewed-npm-audit-"));
   try {
+    if (selectedLockedGraph) {
+      const { graph, index } = selectedLockedGraph;
+      const result = auditLockedGraph(
+        graph,
+        index,
+        config,
+        tempRoot,
+        exceptionFile,
+        artifactDirectory,
+        npmVersion,
+      );
+      assertReviewedAuditReportsPass(
+        [{ label: graph.label, threshold: graph.severityThreshold, result }],
+        config.severityThreshold,
+      );
+      emitAuditReceipt({
+        artifactDirectory,
+        graphId: graph.id,
+        npmVersion,
+        packageJsonFile: targetRepositoryPath(
+          path.join(graph.directory, "package.json"),
+          `${graph.label} package manifest`,
+        ),
+        packageLockFile: targetRepositoryPath(
+          path.join(graph.directory, "package-lock.json"),
+          `${graph.label} lockfile`,
+        ),
+        rawReportFile: path.join(
+          artifactDirectory,
+          `locked-graph-${index + 1}.json`,
+        ),
+        registryOrigin: NPM_AUDIT_REGISTRY,
+        result,
+        threshold: graph.severityThreshold ?? config.severityThreshold,
+      });
+      return;
+    }
     const sourceResult = auditSourceGraph(
       config,
       tempRoot,

--- a/scripts/checks/build-protected-managed-images.sh
+++ b/scripts/checks/build-protected-managed-images.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 usage() {
-  echo "usage: $0 --output <json> --revision <sha> --cohort <id> --platform <linux/amd64|linux/arm64> --openclaw-base <exact-ref> --hermes-base <exact-ref> --dcode-base <exact-ref> [--source-root <absolute-dir>] [--cache-to <absolute-dir>] [--cache-from <absolute-dir>]" >&2
+  echo "usage: $0 --output <json> --revision <sha> --cohort <id> --platform <linux/amd64|linux/arm64> --openclaw-base <exact-ref> --hermes-base <exact-ref> --dcode-base <exact-ref> [--source-root <absolute-dir>] [--cache-to <absolute-dir>] [--cache-from <absolute-dir> --audit-evidence-from <absolute-dir>]" >&2
   exit 2
 }
 
@@ -19,8 +19,14 @@ dcode_base=""
 source_root="$PWD"
 cache_to=""
 cache_from=""
+audit_evidence_from=""
 while (($# > 0)); do
   case "$1" in
+    --audit-evidence-from)
+      (($# >= 2)) || usage
+      audit_evidence_from="$2"
+      shift 2
+      ;;
     --cache-to)
       (($# >= 2)) || usage
       cache_to="$2"
@@ -93,6 +99,13 @@ npm_target_libc="glibc"
 [[ "$dcode_base" =~ ^ghcr[.]io/nvidia/nemoclaw/langchain-deepagents-code-sandbox-base@sha256:[a-f0-9]{64}$ ]] || usage
 [[ "$source_root" == /* && "$source_root" != *$'\n'* && -d "$source_root" && ! -L "$source_root" ]] || usage
 source_root="$(cd -- "$source_root" && pwd -P)"
+controller_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+trusted_audit_config="$controller_root/ci/reviewed-npm-audit.json"
+trusted_audit_exceptions="$controller_root/ci/npm-audit-exceptions.json"
+trusted_receipt_verifier="$controller_root/scripts/lib/npm-audit-receipt.mts"
+[[ -f "$trusted_audit_config" && ! -L "$trusted_audit_config" ]] || usage
+[[ -f "$trusted_audit_exceptions" && ! -L "$trusted_audit_exceptions" ]] || usage
+[[ -f "$trusted_receipt_verifier" && ! -L "$trusted_receipt_verifier" ]] || usage
 seed_helper="$source_root/scripts/checks/materialize-locked-npm-cache-seed.mts"
 source_lockfile="$source_root/nemoclaw/package-lock.json"
 source_seed_dir="$source_root/tools/mcp-tool-discovery-runtime/npm-cache-seed"
@@ -159,6 +172,12 @@ if [[ -n "$cache_from" ]]; then
     exit 1
   }
 fi
+if [[ -n "$audit_evidence_from" ]]; then
+  [[ -n "$cache_from" && "$audit_evidence_from" == /* && "$audit_evidence_from" != *$'\n'* && -d "$audit_evidence_from" && ! -L "$audit_evidence_from" ]] || usage
+  audit_evidence_from="$(cd -- "$audit_evidence_from" && pwd -P)"
+elif [[ -n "$cache_from" ]]; then
+  usage
+fi
 
 for command in curl docker jq node sha256sum; do
   command -v "$command" >/dev/null 2>&1 || {
@@ -168,6 +187,7 @@ for command in curl docker jq node sha256sum; do
 done
 
 work_dir="$(mktemp -d "${RUNNER_TEMP:-/tmp}/nemoclaw-protected-images.XXXXXX")"
+cache_export_complete=0
 seed_overlay_active=0
 seed_backup="$work_dir/npm-cache-seed-original"
 mcp_seed_overlay_active=0
@@ -187,11 +207,47 @@ restore_worktree() {
     rm -rf -- "$source_messaging_seed_dir"
     cp -pR -- "$messaging_seed_backup" "$source_messaging_seed_dir"
   fi
+  if [[ -n "$cache_to" && "$cache_export_complete" != 1 && -d "$cache_to" ]]; then
+    find "$cache_to" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
+  fi
   rm -rf -- "$work_dir"
 }
 trap restore_worktree EXIT
 trap 'exit 130' INT
 trap 'exit 143' TERM
+
+audit_receipt=""
+audit_raw_report=""
+audit_receipt_sha256=""
+validate_audit_evidence() {
+  local directory="$1"
+  [[ -d "$directory" && ! -L "$directory" && -z "$(find "$directory" -type l -print -quit)" ]] || {
+    echo "ERROR: protected managed-image reviewed audit evidence is missing or unsafe" >&2
+    exit 1
+  }
+  audit_receipt="$directory/mcporter-runtime.receipt.json"
+  audit_raw_report="$directory/mcporter-runtime.raw.json"
+  [[ -f "$audit_receipt" && -s "$audit_receipt" && -f "$audit_raw_report" && -s "$audit_raw_report" ]] || {
+    echo "ERROR: protected managed-image reviewed audit evidence is incomplete" >&2
+    exit 1
+  }
+  audit_receipt_sha256="$(sha256sum "$audit_receipt" | awk '{print $1}')"
+  node --experimental-strip-types --no-warnings "$trusted_receipt_verifier" \
+    --receipt "$audit_receipt" \
+    --package-json "$source_root/agents/openclaw/mcporter-runtime/package.json" \
+    --package-lock "$source_root/agents/openclaw/mcporter-runtime/package-lock.json" \
+    --raw-report "$audit_raw_report" \
+    --exceptions "$trusted_audit_exceptions" \
+    --graph mcporter-runtime \
+    --audit-config "$trusted_audit_config" \
+    --registry https://registry.yarnpkg.com \
+    --threshold high \
+    --legacy-npmjs true
+}
+
+if [[ -n "$cache_from" ]]; then
+  validate_audit_evidence "$audit_evidence_from"
+fi
 
 if [[ -n "$cache_from" ]]; then
   imported_seed="$work_dir/npm-cache-seed-import"
@@ -363,6 +419,13 @@ build_agent() {
       cache_args+=(--cache-from "type=local,src=${cache_source}")
     fi
   fi
+  if [[ "$agent" == "openclaw" && -n "$audit_receipt" ]]; then
+    cache_args+=(
+      --secret "id=nemoclaw-mcporter-audit-receipt,src=${audit_receipt}"
+      --secret "id=nemoclaw-mcporter-audit-raw-report,src=${audit_raw_report}"
+      --build-arg "NEMOCLAW_MCPORTER_AUDIT_RECEIPT_SHA256=${audit_receipt_sha256}"
+    )
+  fi
 
   local base_digest="${base_reference##*@}"
   docker buildx imagetools inspect "$base_reference" --raw >"$exact_base_raw"
@@ -517,3 +580,4 @@ jq -se \
   end
 ' "$contracts" >"${output}.tmp"
 mv "${output}.tmp" "$output"
+cache_export_complete=1

--- a/test/automation/releases/reviewed-npm-audit.test.ts
+++ b/test/automation/releases/reviewed-npm-audit.test.ts
@@ -30,6 +30,10 @@ import {
   vulnerabilityCounts,
 } from "../../../scripts/lib/reviewed-npm-audit.mts";
 import { reviewedNpmAuditWorkflowDeadlines } from "../../helpers/reviewed-npm-audit-workflow";
+import {
+  parseAuditConfig,
+  selectLockedGraph,
+} from "../../../scripts/audit-reviewed-npm-graph.mts";
 
 const REPO_ROOT = path.join(import.meta.dirname, "../../..");
 const CONFIG = JSON.parse(
@@ -128,6 +132,21 @@ function exceptionPolicy(
 }
 
 describe("reviewed npm audit gate", () => {
+  it("selects only a configured locked graph for dedicated evidence production (#11088)", () => {
+    const auditConfig = parseAuditConfig(
+      fs.readFileSync(path.join(REPO_ROOT, "ci", "reviewed-npm-audit.json"), "utf8"),
+    );
+
+    expect(selectLockedGraph(auditConfig, "mcporter-runtime")).toMatchObject({
+      graph: { id: "mcporter-runtime" },
+      index: auditConfig.lockedGraphs.findIndex(({ id }) => id === "mcporter-runtime"),
+    });
+    expect(selectLockedGraph(auditConfig, undefined)).toBeUndefined();
+    expect(() => selectLockedGraph(auditConfig, "unknown-graph")).toThrow(
+      "reviewed npm audit locked graph is not configured",
+    );
+  });
+
   it("removes the checked-in brace-expansion exception after remediation (#8116)", () => {
     expect(CHECKED_IN_POLICY).toEqual(EMPTY_POLICY);
   });
@@ -266,8 +285,7 @@ describe("reviewed npm audit gate", () => {
       path.join(REPO_ROOT, ".github", "workflows"),
     );
 
-    expect(callers).toHaveLength(5);
-    expect(callers.map(({ timeoutMinutes }) => timeoutMinutes)).toEqual([25, 25, 25, 25, 25]);
+    expect(callers).toHaveLength(6);
     expect(Math.min(...callers.map(({ timeoutMinutes }) => timeoutMinutes))).toBeGreaterThanOrEqual(
       minimumJobTimeoutMinutes,
     );

--- a/test/e2e/support/managed-image-protected-runtime-workflow.test.ts
+++ b/test/e2e/support/managed-image-protected-runtime-workflow.test.ts
@@ -348,7 +348,31 @@ describe("protected managed-image runtime workflow", () => {
     runtimeJob(value).needs = ["generate-matrix"];
 
     expect(validateManagedImageProtectedRuntimeWorkflow(value)).toContain(
-      "managed-image-protected-runtime must depend on base-image-publication, generate-matrix, and managed-image-multiarch-startup",
+      "managed-image-protected-runtime must depend on base-image-publication, generate-matrix, managed-image-multiarch-startup, and managed-image-protected-audit",
+    );
+  });
+
+  it("keeps protected audit production in trusted workflow code", () => {
+    const value = workflow();
+    const audit = namedJobStep(
+      value,
+      "managed-image-protected-audit",
+      "Audit exact candidate mcporter graph from trusted code",
+    );
+    audit.uses = "./.candidate-audit/.github/actions/ci-reviewed-npm-audit";
+
+    expect(validateManagedImageProtectedRuntimeWorkflow(value)).toContain(
+      "managed-image-protected-audit must execute the trusted reviewed npm audit action",
+    );
+  });
+
+  it("requires the trusted audit artifact at the protected consumer", () => {
+    const value = workflow();
+    const download = namedStep(value, "Download trusted protected mcporter audit evidence");
+    (download.with as Record<string, unknown>).path = ".candidate-runtime/reviewed-npm-audit";
+
+    expect(validateManagedImageProtectedRuntimeWorkflow(value)).toContain(
+      "managed-image-protected-runtime audit evidence download must bind path to ${{ runner.temp }}/protected-reviewed-npm-audit",
     );
   });
 
@@ -409,6 +433,19 @@ describe("protected managed-image runtime workflow", () => {
 
     expect(validateManagedImageProtectedRuntimeWorkflow(value)).toContain(
       "managed-image-protected-runtime step 'Build exact all-agent protected runtime images' must include --cache-from \"$NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE\"",
+    );
+  });
+
+  it("keeps the protected build controller in the trusted checkout", () => {
+    const value = workflow();
+    const build = namedStep(value, "Build exact all-agent protected runtime images");
+    build.run = String(build.run).replace(
+      "scripts/checks/build-protected-managed-images.sh",
+      '"$GITHUB_WORKSPACE/.candidate-runtime/scripts/checks/build-protected-managed-images.sh"',
+    );
+
+    expect(validateManagedImageProtectedRuntimeWorkflow(value)).toContain(
+      "managed-image-protected-runtime build controller must execute trusted workflow code",
     );
   });
 

--- a/test/platform/images/protected-managed-image-build-script.test.ts
+++ b/test/platform/images/protected-managed-image-build-script.test.ts
@@ -30,6 +30,7 @@ let stubBin = "";
 let dockerLog = "";
 let dockerBuildCount = "";
 let dockerBuildFailureMode = "";
+let receiptVerifyStatus = "";
 let seedLog = "";
 let registryCurlExit = "";
 let registryLog = "";
@@ -101,6 +102,9 @@ esac
     `#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >>"$NEMOCLAW_TEST_SEED_LOG"
+if [[ "$*" == *"/scripts/lib/npm-audit-receipt.mts"* ]]; then
+  exit "$NEMOCLAW_TEST_RECEIPT_VERIFY_STATUS"
+fi
 mode="$4"
 shift 4
 output=""
@@ -158,6 +162,12 @@ function completeImportedCache(cacheRoot: string): void {
   writeFileSync(path.join(cacheRoot, "messaging-npm-cache-seed", "manifest.json"), "{}\n", "utf8");
 }
 
+function completeAuditEvidence(auditDirectory: string): void {
+  mkdirSync(auditDirectory, { recursive: true });
+  writeFileSync(path.join(auditDirectory, "mcporter-runtime.receipt.json"), '{"result":"pass"}\n');
+  writeFileSync(path.join(auditDirectory, "mcporter-runtime.raw.json"), '{"metadata":{}}\n');
+}
+
 function completeSourceBoundary(sourceRoot: string): void {
   mkdirSync(path.join(sourceRoot, "nemoclaw"), { recursive: true });
   mkdirSync(path.join(sourceRoot, "scripts", "checks"), { recursive: true });
@@ -205,7 +215,9 @@ function completeSourceBoundary(sourceRoot: string): void {
 function recordedBuildInvocations(): string[] {
   return readFileSync(dockerLog, "utf8")
     .split("\n")
-    .filter((line) => line.startsWith("buildx build "));
+    .filter(
+      (line) => line.startsWith("buildx build ") && line.includes("io.nvidia.nemoclaw.agent="),
+    );
 }
 
 function recordedBuildInvocation(agent: string): string {
@@ -216,11 +228,7 @@ function recordedBuildInvocation(agent: string): string {
   return invocation!;
 }
 
-function runBuild(
-  sourceRoot: string,
-  extraArgs: readonly string[] = [],
-  platform = "linux/amd64",
-) {
+function runBuild(sourceRoot: string, extraArgs: readonly string[] = [], platform = "linux/amd64") {
   const output = path.join(testRoot, "contracts.json");
   return spawnSync(
     "bash",
@@ -256,6 +264,7 @@ function runBuild(
         NEMOCLAW_TEST_REGISTRY_LOG: registryLog,
         NEMOCLAW_TEST_REGISTRY_STATUS: registryStatus,
         NEMOCLAW_TEST_REAL_PATH: process.env.PATH ?? "",
+        NEMOCLAW_TEST_RECEIPT_VERIFY_STATUS: receiptVerifyStatus,
         NEMOCLAW_TEST_SEED_LOG: seedLog,
         NEMOCLAW_TEST_TEE_FAILURE_MODE: teeFailureMode,
         PATH: `${stubBin}:${process.env.PATH ?? ""}`,
@@ -271,6 +280,7 @@ beforeEach(() => {
   dockerLog = path.join(testRoot, "docker.log");
   dockerBuildCount = path.join(testRoot, "docker-build-count");
   dockerBuildFailureMode = "";
+  receiptVerifyStatus = "0";
   seedLog = path.join(testRoot, "seed.log");
   registryCurlExit = "0";
   registryLog = path.join(testRoot, "registry.log");
@@ -333,7 +343,9 @@ describe("protected managed-image build-cache boundary", () => {
     expect(recordedBuildInvocation("openclaw")).toContain("--build-arg TARGETARCH=arm64");
     expect(recordedBuildInvocation("hermes")).toContain("--platform linux/arm64");
     expect(recordedBuildInvocation("hermes")).toContain("--build-arg TARGETARCH=arm64");
-    expect(recordedBuildInvocation("langchain-deepagents-code")).toContain("--platform linux/arm64");
+    expect(recordedBuildInvocation("langchain-deepagents-code")).toContain(
+      "--platform linux/arm64",
+    );
     expect(recordedBuildInvocation("langchain-deepagents-code")).toContain(
       "--build-arg TARGETARCH=arm64",
     );
@@ -371,8 +383,12 @@ describe("protected managed-image build-cache boundary", () => {
     expect(recordedBuildInvocation("openclaw")).toContain("--build-arg TARGETARCH=arm64");
     expect(recordedBuildInvocation("hermes")).toContain("--platform linux/arm64");
     expect(recordedBuildInvocation("hermes")).toContain("--build-arg TARGETARCH=arm64");
-    expect(recordedBuildInvocation("langchain-deepagents-code")).toContain("--platform linux/arm64");
-    expect(recordedBuildInvocation("langchain-deepagents-code")).toContain("--build-arg TARGETARCH=arm64");
+    expect(recordedBuildInvocation("langchain-deepagents-code")).toContain(
+      "--platform linux/arm64",
+    );
+    expect(recordedBuildInvocation("langchain-deepagents-code")).toContain(
+      "--build-arg TARGETARCH=arm64",
+    );
   });
 
   it("passes each agent one empty absolute cache export root", () => {
@@ -384,6 +400,7 @@ describe("protected managed-image build-cache boundary", () => {
     expect(result.status, result.stderr).toBe(0);
     expect(existsSync(cacheRoot)).toBe(true);
     expect(recordedBuildInvocations()).toHaveLength(3);
+    expect(existsSync(path.join(cacheRoot, "reviewed-npm-audit"))).toBe(false);
 
     expect({
       openclaw: recordedBuildInvocation("openclaw"),
@@ -417,6 +434,27 @@ describe("protected managed-image build-cache boundary", () => {
     expect(existsSync(path.join(cacheRoot, "messaging-npm-cache-seed", "manifest.json"))).toBe(
       true,
     );
+    expect(recordedBuildInvocation("openclaw")).not.toContain("nemoclaw-mcporter-audit");
+    expect(recordedBuildInvocation("hermes")).not.toContain("nemoclaw-mcporter-audit");
+    expect(recordedBuildInvocation("langchain-deepagents-code")).not.toContain(
+      "nemoclaw-mcporter-audit",
+    );
+  });
+
+  it("cleans an incomplete cache export after a protected build fails", () => {
+    const cacheRoot = path.join(testRoot, "export-cache");
+    stubBuildInvocation();
+    dockerBuildFailureMode = "near-match";
+
+    const failed = runBuild(REPO_ROOT, ["--cache-to", cacheRoot]);
+
+    expect(failed.status, failed.stderr).toBe(42);
+    expect(readdirSync(cacheRoot)).toEqual([]);
+
+    dockerBuildFailureMode = "";
+    const retried = runBuild(REPO_ROOT, ["--cache-to", cacheRoot]);
+
+    expect(retried.status, retried.stderr).toBe(0);
   });
 
   it.each([
@@ -496,6 +534,51 @@ describe("protected managed-image build-cache boundary", () => {
     expect(existsSync(dockerLog)).toBe(false);
   });
 
+  it("rejects incomplete reviewed audit evidence before invoking Docker (#11088)", () => {
+    const cacheRoot = path.join(testRoot, "imported-cache");
+    const auditRoot = path.join(testRoot, "audit-evidence");
+    completeImportedCache(cacheRoot);
+    mkdirSync(auditRoot);
+    writeFileSync(path.join(auditRoot, "mcporter-runtime.receipt.json"), "", "utf8");
+    stubBuildInvocation();
+
+    const result = runBuild(REPO_ROOT, [
+      "--cache-from",
+      cacheRoot,
+      "--audit-evidence-from",
+      auditRoot,
+    ]);
+
+    expect(result.status, result.stderr).toBe(1);
+    expect(result.stderr).toContain("reviewed audit evidence is incomplete");
+    expect(existsSync(dockerLog)).toBe(false);
+  });
+
+  it("binds external evidence to the trusted verifier and candidate graph (#11088)", () => {
+    const cacheRoot = path.join(testRoot, "imported-cache");
+    const auditRoot = path.join(testRoot, "audit-evidence");
+    completeImportedCache(cacheRoot);
+    completeAuditEvidence(auditRoot);
+    stubBuildInvocation();
+    receiptVerifyStatus = "42";
+
+    const result = runBuild(REPO_ROOT, [
+      "--cache-from",
+      cacheRoot,
+      "--audit-evidence-from",
+      auditRoot,
+    ]);
+    const verification = readFileSync(seedLog, "utf8");
+
+    expect(result.status, result.stderr).toBe(42);
+    expect(verification).toContain(`${REPO_ROOT}/scripts/lib/npm-audit-receipt.mts`);
+    expect(verification).toContain(
+      `--package-json ${REPO_ROOT}/agents/openclaw/mcporter-runtime/package.json`,
+    );
+    expect(verification).toContain(`--audit-config ${REPO_ROOT}/ci/reviewed-npm-audit.json`);
+    expect(existsSync(dockerLog)).toBe(false);
+  });
+
   it("imports locked seeds, reuses safe agent caches, and disables RUN network access", () => {
     const cacheRoot = path.join(testRoot, "imported-cache");
     const sourceSeed = path.join(REPO_ROOT, "tools/mcp-tool-discovery-runtime/npm-cache-seed");
@@ -510,10 +593,17 @@ describe("protected managed-image build-cache boundary", () => {
     const originalSeedNames = readdirSync(sourceSeed).sort();
     const originalMcpSeedNames = readdirSync(sourceMcpSeed).sort();
     const originalMessagingSeedNames = readdirSync(sourceMessagingSeed).sort();
+    const auditRoot = path.join(testRoot, "audit-evidence");
     completeImportedCache(cacheRoot);
+    completeAuditEvidence(auditRoot);
     stubBuildInvocation();
 
-    const result = runBuild(REPO_ROOT, ["--cache-from", cacheRoot]);
+    const result = runBuild(REPO_ROOT, [
+      "--cache-from",
+      cacheRoot,
+      "--audit-evidence-from",
+      auditRoot,
+    ]);
 
     expect(result.status, result.stderr).toBe(0);
     expect(recordedBuildInvocations()).toHaveLength(3);
@@ -539,6 +629,12 @@ describe("protected managed-image build-cache boundary", () => {
       ),
     });
     expect(recordedBuildInvocation("openclaw").split(" ")).toContain("--no-cache");
+    expect(recordedBuildInvocation("openclaw")).toContain(
+      `--secret id=nemoclaw-mcporter-audit-receipt,src=${realpathSync(auditRoot)}/mcporter-runtime.receipt.json`,
+    );
+    expect(recordedBuildInvocation("openclaw")).toContain(
+      `--build-arg NEMOCLAW_MCPORTER_AUDIT_RECEIPT_SHA256=${DIGEST}`,
+    );
     expect(recordedBuildInvocation("hermes").split(" ")).not.toContain("--no-cache");
     expect(recordedBuildInvocation("langchain-deepagents-code").split(" ")).not.toContain(
       "--no-cache",

--- a/tools/e2e/managed-image-protected-runtime-workflow-boundary.mts
+++ b/tools/e2e/managed-image-protected-runtime-workflow-boundary.mts
@@ -13,8 +13,11 @@ type WorkflowStep = WorkflowRecord & {
 };
 
 const JOB_ID = "managed-image-protected-runtime";
+const AUDIT_JOB_ID = "managed-image-protected-audit";
 const SELECTOR =
-  "${{ always() && github.repository == 'NVIDIA/NemoClaw' && (github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && needs['base-image-publication'].result == 'success' && needs['generate-matrix'].result == 'success' && needs['managed-image-multiarch-startup'].result == 'success' && contains(fromJSON(needs.generate-matrix.outputs.selected_jobs), 'managed-image-protected-runtime') }}";
+  "${{ always() && github.repository == 'NVIDIA/NemoClaw' && (github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && needs['base-image-publication'].result == 'success' && needs['generate-matrix'].result == 'success' && needs['managed-image-multiarch-startup'].result == 'success' && needs['managed-image-protected-audit'].result == 'success' && contains(fromJSON(needs.generate-matrix.outputs.selected_jobs), 'managed-image-protected-runtime') }}";
+const AUDIT_SELECTOR =
+  "${{ github.repository == 'NVIDIA/NemoClaw' && (github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && contains(fromJSON(needs.generate-matrix.outputs.selected_jobs), 'managed-image-protected-runtime') }}";
 const ACTIVATION_PATH = "ci/protected-managed-image-runtime-activation-v1.json";
 const LIVE_TEST_PATH = "test/e2e/live/managed-image-protected-runtime.test.ts";
 const REGISTRY_IMAGE =
@@ -91,6 +94,77 @@ function requireOrderedSteps(
 
 export function validateManagedImageProtectedRuntimeWorkflow(workflow: WorkflowRecord): string[] {
   const errors: string[] = [];
+  const auditJob = record(record(workflow.jobs)[AUDIT_JOB_ID]);
+  if (Object.keys(auditJob).length === 0) {
+    errors.push(`workflow missing ${AUDIT_JOB_ID} job`);
+  } else {
+    if (auditJob.needs !== "generate-matrix") {
+      errors.push(`${AUDIT_JOB_ID} must depend on generate-matrix`);
+    }
+    if (auditJob.if !== AUDIT_SELECTOR) {
+      errors.push(`${AUDIT_JOB_ID} must use the protected runtime execution plan`);
+    }
+    if (auditJob["runs-on"] !== "ubuntu-24.04" || auditJob["timeout-minutes"] !== 25) {
+      errors.push(`${AUDIT_JOB_ID} must keep its reviewed hosted runner and timeout`);
+    }
+    if (!isDeepStrictEqual(auditJob.permissions, { contents: "read" })) {
+      errors.push(`${AUDIT_JOB_ID} permissions must be exactly contents: read`);
+    }
+    const auditSteps = steps(auditJob.steps);
+    const trustedAuditCheckout = auditSteps.find(
+      (step) => step.name === "Checkout trusted reviewed npm audit",
+    );
+    const candidateAuditCheckout = auditSteps.find(
+      (step) => step.name === "Checkout exact protected audit target",
+    );
+    const trustedAudit = auditSteps.find(
+      (step) => step.name === "Audit exact candidate mcporter graph from trusted code",
+    );
+    const checkoutAction = "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1";
+    if (
+      trustedAuditCheckout?.uses !== checkoutAction ||
+      candidateAuditCheckout?.uses !== checkoutAction
+    ) {
+      errors.push(`${AUDIT_JOB_ID} must pin both trusted and candidate checkouts`);
+    }
+    requireValues(errors, `${AUDIT_JOB_ID} trusted checkout`, record(trustedAuditCheckout?.with), {
+      repository: "${{ github.repository }}",
+      ref: "${{ inputs.workflow_sha || github.workflow_sha }}",
+      "persist-credentials": false,
+    });
+    const trustedSparseCheckout = text(record(trustedAuditCheckout?.with)["sparse-checkout"]);
+    for (const trustedPath of [
+      ".github/actions/ci-reviewed-npm-audit",
+      "ci/npm-audit-exceptions.json",
+      "ci/reviewed-npm-audit.json",
+      "scripts/audit-reviewed-npm-graph.mts",
+      "scripts/lib/npm-audit-receipt.mts",
+    ]) {
+      if (!trustedSparseCheckout.split("\n").includes(trustedPath)) {
+        errors.push(`${AUDIT_JOB_ID} trusted checkout must include ${trustedPath}`);
+      }
+    }
+    requireValues(
+      errors,
+      `${AUDIT_JOB_ID} candidate checkout`,
+      record(candidateAuditCheckout?.with),
+      {
+        repository: "${{ inputs.checkout_repository || github.repository }}",
+        ref: "${{ inputs.checkout_sha || github.sha }}",
+        path: ".candidate-audit",
+        "persist-credentials": false,
+      },
+    );
+    if (trustedAudit?.uses !== "./.github/actions/ci-reviewed-npm-audit") {
+      errors.push(`${AUDIT_JOB_ID} must execute the trusted reviewed npm audit action`);
+    }
+    requireValues(errors, `${AUDIT_JOB_ID} action`, record(trustedAudit?.with), {
+      "target-root": "${{ github.workspace }}/.candidate-audit",
+      "report-dir": "artifacts/reviewed-npm-audit",
+      "cache-directory": "${{ runner.temp }}/reviewed-npm-audit-cache",
+      "locked-graph": "mcporter-runtime",
+    });
+  }
   const job = record(record(workflow.jobs)[JOB_ID]);
   if (Object.keys(job).length === 0) return [`workflow missing ${JOB_ID} job`];
 
@@ -99,10 +173,11 @@ export function validateManagedImageProtectedRuntimeWorkflow(workflow: WorkflowR
       "base-image-publication",
       "generate-matrix",
       "managed-image-multiarch-startup",
+      "managed-image-protected-audit",
     ])
   ) {
     errors.push(
-      `${JOB_ID} must depend on base-image-publication, generate-matrix, and managed-image-multiarch-startup`,
+      `${JOB_ID} must depend on base-image-publication, generate-matrix, managed-image-multiarch-startup, and managed-image-protected-audit`,
     );
   }
   if (job.if !== SELECTOR) errors.push(`${JOB_ID} must use the trusted execution plan`);
@@ -221,6 +296,20 @@ export function validateManagedImageProtectedRuntimeWorkflow(workflow: WorkflowR
     name: "${{ env.NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE_ARTIFACT }}",
     path: "${{ env.NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE }}",
   });
+  const auditDownload = requireStep(
+    errors,
+    workflowSteps,
+    "Download trusted protected mcporter audit evidence",
+  );
+  if (
+    auditDownload?.uses !== "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c"
+  ) {
+    errors.push(`${JOB_ID} must pin the reviewed audit evidence download action`);
+  }
+  requireValues(errors, `${JOB_ID} audit evidence download`, record(auditDownload?.with), {
+    name: "reviewed-npm-audit",
+    path: "${{ runner.temp }}/protected-reviewed-npm-audit",
+  });
 
   const buildx = requireStep(errors, workflowSteps, "Set up protected runtime Buildx");
   if (buildx?.uses !== "docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c") {
@@ -317,10 +406,16 @@ export function validateManagedImageProtectedRuntimeWorkflow(workflow: WorkflowR
     "--platform linux/amd64",
     '--source-root "$GITHUB_WORKSPACE/.candidate-runtime"',
     '--cache-from "$NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE"',
+    '--audit-evidence-from "$RUNNER_TEMP/protected-reviewed-npm-audit"',
     '--openclaw-base "$BASE_OPENCLAW"',
     '--hermes-base "$BASE_HERMES"',
     '--dcode-base "$BASE_DCODE"',
   ]);
+  if (
+    text(build?.run).includes(".candidate-runtime/scripts/checks/build-protected-managed-images.sh")
+  ) {
+    errors.push(`${JOB_ID} build controller must execute trusted workflow code`);
+  }
   requireValues(errors, `${JOB_ID} protected runtime build bases`, record(build?.env), {
     BASE_HERMES:
       "ghcr.io/nvidia/nemoclaw/hermes-sandbox-base@${{ steps.runtime-hermes-base.outputs.digest }}",
@@ -383,6 +478,7 @@ export function validateManagedImageProtectedRuntimeWorkflow(workflow: WorkflowR
     "Checkout trusted protected runtime qualification",
     "Checkout exact protected runtime candidate source",
     "Download exact protected runtime build cache",
+    "Download trusted protected mcporter audit evidence",
     "Prepare E2E workspace",
     "Validate protected runtime activation contract",
     "Resolve reviewed Hermes runtime base image",

--- a/tools/e2e/operations-workflow-boundary.mts
+++ b/tools/e2e/operations-workflow-boundary.mts
@@ -596,8 +596,10 @@ function validateManualPrDispatch(errors: string[], workflow: OperationsWorkflow
         step.name === "Check out trusted OpenShell SDK package verifier" &&
         step.with?.ref === "${{ github.workflow_sha }}";
       const trustedManagedImageRuntimeCheckout =
-        jobName === "managed-image-protected-runtime" &&
-        step.name === "Checkout trusted protected runtime qualification" &&
+        ((jobName === "managed-image-protected-runtime" &&
+          step.name === "Checkout trusted protected runtime qualification") ||
+          (jobName === "managed-image-protected-audit" &&
+            step.name === "Checkout trusted reviewed npm audit")) &&
         step.with?.repository === "${{ github.repository }}" &&
         step.with?.ref === "${{ inputs.workflow_sha || github.workflow_sha }}";
       const trustedManagedImageMultiarchResolverCheckout =


### PR DESCRIPTION
## Outcome

Provide trusted mcporter audit evidence to the network-disabled protected image build. This is the controller prerequisite extracted from #11156; it must reach `main` before trusted manual PR E2E can exercise the handoff.

## Reason

The protected build runs with `--network none` and no supplied audit receipt. Its live npm audit therefore cannot contact the registry. A candidate-only workflow change cannot fix that path because manual PR E2E executes the controller from trusted `main`.

### Related issues

Refs #11088. Prerequisite for #11156.

## Changes

- Reuse the reviewed audit action in a hosted job to audit only the configured mcporter graph.
- Download the same-run receipt and raw report, verify them against the candidate manifests and trusted policy, and supply them through the existing BuildKit secret mounts.
- Move the existing handoff tests and workflow contracts from #11156. This split adds no new test scenario to the combined change.

The Dockerfiles, audit parser, registry, vulnerability threshold, exceptions, receipt verifier, and retry bounds are unchanged.

## Verification

- Existing audit, receipt, protected-build, and workflow tests: 303 passed across 10 files in a credential-free Linux container, using Node 22.23.2.
- Live mcporter producer with the configured npm 10.9.4: passed; two moderate findings, zero high/critical findings, zero accepted exceptions.
- The unchanged `main` receipt verifier accepted the live result and checked manifest, lockfile, policy, raw-report, and npm identity.
- `npm run validate:pr`: passed, including repository checks, workflow plans, source-shape/growth budgets, secret scanning, and CLI type checking. Commitlint reported one non-blocking blank-line warning.
- CLI/plugin builds and the existing managed-image package contract: passed.
- No secrets, API keys, or credentials are in the diff.

## Review notes

Sensitive paths: the E2E workflow, audit action/producer, protected build controller, and workflow validators. Self-review and isolated regression checks are complete; independent maintainer review is still required.

Repository: NVIDIA/NemoClaw. Candidate: `8e5c018ecb829306faf4262973707efff5b79beb`.
Parent: `5d4ac392c471de5323496a0d1df6d0118851d7d7`. Refreshed canonical comparison: `38b5e3cabdff3efe71663a2bbeeffb39e89bd942`.

Validation uses the canonical command, hook configuration, and dependency locks in an isolated container with no host mounts, host credentials, or Docker socket. The two changed workflow validators remain part of the code under review; their passing checks are not independent security approval.

Protected GPU/local-inference acceptance remains pending until this trusted-controller prerequisite is merged. No merge or broad E2E rerun is requested automatically.

---
Signed-off-by: San Dang <sdang@nvidia.com>
