### PR TITLE
fix(inference): surface real reason for a slow inference invocation probe

### DIFF
--- a/src/lib/actions/sandbox/inference-invocation-probe.test.ts
+++ b/src/lib/actions/sandbox/inference-invocation-probe.test.ts
@@ -3,10 +3,14 @@
 
 import { describe, expect, it, vi } from "vitest";
 
+import type { SandboxExecCommandOptions } from "../../adapters/sandbox/command-transport";
 import {
   buildDcodeSandboxInferenceInvocationArgs,
   buildSandboxInferenceInvocationCommand,
   probeSandboxInferenceInvocation,
+  READINESS_INFERENCE_INVOCATION_TIMEOUT_MS,
+  REBUILD_INFERENCE_INVOCATION_TIMEOUT_MS,
+  resolveInferenceInvocationMaxTimeSeconds,
 } from "./inference-invocation-probe";
 
 const input = {
@@ -76,6 +80,90 @@ describe("sandbox inference invocation probe", () => {
     expect(JSON.stringify(result)).not.toContain("canary-replay-marker");
   });
 
+  it("keeps curl --max-time safely inside the outer exec timeout so a slow endpoint is not killed (#11162)", () => {
+    const readinessCommand = buildSandboxInferenceInvocationCommand(
+      input,
+      READINESS_INFERENCE_INVOCATION_TIMEOUT_MS,
+    );
+    const rebuildCommand = buildSandboxInferenceInvocationCommand(
+      input,
+      REBUILD_INFERENCE_INVOCATION_TIMEOUT_MS,
+    );
+
+    const readinessMaxTime = Number(readinessCommand.match(/--max-time (\d+)/)?.[1]);
+    const rebuildMaxTime = Number(rebuildCommand.match(/--max-time (\d+)/)?.[1]);
+
+    // curl --max-time must finish (clean exit 28) before the outer timeout can
+    // SIGTERM the subprocess and collapse a slow-but-healthy endpoint into a
+    // generic "unavailable" result.
+    expect(readinessMaxTime * 1000).toBeLessThan(READINESS_INFERENCE_INVOCATION_TIMEOUT_MS);
+    expect(rebuildMaxTime * 1000).toBeLessThan(REBUILD_INFERENCE_INVOCATION_TIMEOUT_MS);
+    expect(resolveInferenceInvocationMaxTimeSeconds(READINESS_INFERENCE_INVOCATION_TIMEOUT_MS)).toBe(
+      readinessMaxTime,
+    );
+  });
+
+  it("surfaces a probe timeout when the transport reports the subprocess was killed (#11162)", () => {
+    const execute = vi.fn(
+      (_sandbox: string, _command: string, _timeout?: number, options?: SandboxExecCommandOptions) => {
+        options?.onTransportFailure?.({ kind: "timeout", timeoutMs: 30_000 });
+        return null;
+      },
+    );
+
+    expect(probeSandboxInferenceInvocation(input, { execute }, 30_000)).toEqual({
+      ok: false,
+      detail: "sandbox inference invocation probe timed out after 30s",
+      httpStatus: null,
+    });
+  });
+
+  it("surfaces a subprocess error reason when the transport fails to spawn (#11162)", () => {
+    const execute = vi.fn(
+      (_sandbox: string, _command: string, _timeout?: number, options?: SandboxExecCommandOptions) => {
+        options?.onTransportFailure?.({ kind: "error", detail: "ENOENT" });
+        return null;
+      },
+    );
+
+    expect(probeSandboxInferenceInvocation(input, { execute })).toEqual({
+      ok: false,
+      detail: "sandbox inference invocation probe subprocess failed (ENOENT)",
+      httpStatus: null,
+    });
+  });
+
+  it("keeps the generic unavailable detail when the transport reports no reason (#11162)", () => {
+    const execute = vi.fn(() => null);
+
+    expect(probeSandboxInferenceInvocation(input, { execute })).toEqual({
+      ok: false,
+      detail: "sandbox inference invocation probe was unavailable",
+      httpStatus: null,
+    });
+  });
+
+  it("reports a curl-level endpoint timeout (exit 28) as a timeout, not a generic exit (#11162)", () => {
+    const execute = vi.fn(() => ({ status: 28, stdout: "curl-error:28", stderr: "" }));
+
+    expect(probeSandboxInferenceInvocation(input, { execute })).toEqual({
+      ok: false,
+      detail:
+        "sandbox inference invocation probe timed out waiting for the endpoint (curl exit 28)",
+      httpStatus: null,
+    });
+  });
+
+  it("reports a non-timeout curl exit accurately (#11162)", () => {
+    const execute = vi.fn(() => ({ status: 7, stdout: "curl-error:7", stderr: "" }));
+
+    expect(probeSandboxInferenceInvocation(input, { execute })).toEqual({
+      ok: false,
+      detail: "sandbox inference invocation probe could not complete the request (curl exit 7)",
+      httpStatus: null,
+    });
+  });
+
   it("accepts a successful completion through the stored gateway route (#6195)", () => {
     const execute = vi.fn(() => ({
       status: 0,
@@ -100,7 +188,11 @@ describe("sandbox inference invocation probe", () => {
       "dcode-workspace",
       expect.any(String),
       expect.any(Number),
-      { gatewayName: "recorded-gateway", allowLocalDockerFallback: false },
+      {
+        gatewayName: "recorded-gateway",
+        allowLocalDockerFallback: false,
+        onTransportFailure: expect.any(Function),
+      },
     );
   });
 
@@ -127,7 +219,11 @@ describe("sandbox inference invocation probe", () => {
       "hermes-workspace",
       expect.any(String),
       expect.any(Number),
-      { gatewayName: "nemoclaw-19080", allowLocalDockerFallback: false },
+      {
+        gatewayName: "nemoclaw-19080",
+        allowLocalDockerFallback: false,
+        onTransportFailure: expect.any(Function),
+      },
     );
     expect(execute).toHaveBeenCalledOnce();
     expect(runOpenshell).not.toHaveBeenCalled();
@@ -206,6 +302,44 @@ describe("sandbox inference invocation probe", () => {
     ).toEqual({
       ok: false,
       detail: "sandbox inference invocation probe was unavailable",
+      httpStatus: null,
+    });
+  });
+
+  it("surfaces a probe timeout when the Deep Agents Code launcher subprocess is killed (#11162)", () => {
+    const runOpenshell = vi.fn(() => ({
+      ...openshellResult(0, "", ""),
+      status: null,
+      signal: "SIGTERM" as NodeJS.Signals,
+      error: Object.assign(new Error("ETIMEDOUT"), { code: "ETIMEDOUT" }),
+    }));
+
+    expect(
+      probeSandboxInferenceInvocation(
+        { ...input, agentName: "langchain-deepagents-code" },
+        { runOpenshell },
+        REBUILD_INFERENCE_INVOCATION_TIMEOUT_MS,
+      ),
+    ).toEqual({
+      ok: false,
+      detail: "sandbox inference invocation probe timed out after 100s",
+      httpStatus: null,
+    });
+  });
+
+  it("surfaces a subprocess error when the Deep Agents Code launcher throws (#11162)", () => {
+    const runOpenshell = vi.fn(() => {
+      throw Object.assign(new Error("spawn openshell ENOENT"), { code: "ENOENT" });
+    });
+
+    expect(
+      probeSandboxInferenceInvocation(
+        { ...input, agentName: "langchain-deepagents-code" },
+        { runOpenshell },
+      ),
+    ).toEqual({
+      ok: false,
+      detail: "sandbox inference invocation probe subprocess failed (ENOENT)",
       httpStatus: null,
     });
   });

--- a/src/lib/actions/sandbox/inference-invocation-probe.ts
+++ b/src/lib/actions/sandbox/inference-invocation-probe.ts
@@ -9,6 +9,10 @@ import { MIN_PROBE_REPLY_TOKENS, resolveMaxTokensField } from "../../inference/m
 import { shellQuote } from "../../runner";
 import { DCODE_MANAGED_EXEC_LAUNCHER } from "./connect-inference-route-probe";
 import {
+  classifySandboxCommandTransportFailure,
+  type SandboxCommandTransportFailure,
+} from "../../adapters/sandbox/command-transport";
+import {
   executeSandboxExecCommand,
   type SandboxCommandResult,
   type SandboxExecCommandOptions,
@@ -46,6 +50,31 @@ export type SandboxInferenceInvocationDeps = {
 export const REBUILD_INFERENCE_INVOCATION_TIMEOUT_MS = 100_000;
 export const READINESS_INFERENCE_INVOCATION_TIMEOUT_MS = 30_000;
 const INFERENCE_INVOCATION_MAX_RESPONSE_BYTES = 64 * 1024;
+
+// curl's `--max-time` bounds the whole request (connect + transfer). It must
+// sit safely inside the outer exec timeout so a slow-but-healthy endpoint is
+// bounded by curl (clean exit 28) instead of being SIGTERM-killed by the outer
+// timeout and collapsed into a generic "unavailable" result (#11162). The
+// buffer reserves headroom for `openshell sandbox exec` spawn/attach overhead
+// so curl finishes before the outer kill. Note: an operator override via
+// NEMOCLAW_SANDBOX_EXEC_TIMEOUT_MS shortens only the outer exec timeout, not
+// this derived budget; a genuine timeout there is still reported accurately as
+// a timeout with the effective duration.
+const INFERENCE_INVOCATION_CONNECT_TIMEOUT_SECONDS = 5;
+const INFERENCE_INVOCATION_OUTER_TIMEOUT_BUFFER_MS = 5_000;
+
+/**
+ * Derive curl's `--max-time` (whole seconds) from the outer exec timeout so the
+ * request is always bounded by curl before the outer timeout can SIGTERM the
+ * subprocess. Clamped to at least 1s for a pathologically small outer timeout;
+ * the unit test asserts the derived budget stays strictly below every real
+ * outer timeout the callers use.
+ */
+export function resolveInferenceInvocationMaxTimeSeconds(timeoutMs: number): number {
+  const budgetMs = timeoutMs - INFERENCE_INVOCATION_OUTER_TIMEOUT_BUFFER_MS;
+  const seconds = Math.floor(budgetMs / 1000);
+  return Math.max(1, seconds);
+}
 
 function buildProbeRequest(input: SandboxInferenceInvocationInput): {
   endpoint: string;
@@ -93,6 +122,7 @@ function buildProbeRequest(input: SandboxInferenceInvocationInput): {
 
 export function buildSandboxInferenceInvocationCommand(
   input: SandboxInferenceInvocationInput,
+  timeoutMs: number = REBUILD_INFERENCE_INVOCATION_TIMEOUT_MS,
 ): string {
   const request = buildProbeRequest(input);
   const headerArgs = ["Content-Type: application/json", ...request.headers]
@@ -100,11 +130,12 @@ export function buildSandboxInferenceInvocationCommand(
     .join(" ");
   const payload = shellQuote(JSON.stringify(request.payload));
   const endpoint = shellQuote(request.endpoint);
+  const maxTimeSeconds = resolveInferenceInvocationMaxTimeSeconds(timeoutMs);
   return [
     "umask 077",
     "body=$(mktemp /tmp/nemoclaw-inference-invocation.XXXXXX) || exit 1",
     "trap 'rm -f \"$body\"' EXIT HUP INT TERM",
-    `code=$(curl -sS --connect-timeout 5 --max-time 90 --max-filesize ${INFERENCE_INVOCATION_MAX_RESPONSE_BYTES} -o "$body" -w '%{http_code}' ${headerArgs} --data-binary ${payload} ${endpoint}) || { rc=$?; printf 'curl-error:%s\\n' "$rc"; exit "$rc"; }`,
+    `code=$(curl -sS --connect-timeout ${INFERENCE_INVOCATION_CONNECT_TIMEOUT_SECONDS} --max-time ${maxTimeSeconds} --max-filesize ${INFERENCE_INVOCATION_MAX_RESPONSE_BYTES} -o "$body" -w '%{http_code}' ${headerArgs} --data-binary ${payload} ${endpoint}) || { rc=$?; printf 'curl-error:%s\\n' "$rc"; exit "$rc"; }`,
     "printf '%s\\n' \"$code\"",
     'case "$code" in 2??) cat "$body"; exit 0 ;; *) exit 1 ;; esac',
   ].join("; ");
@@ -112,6 +143,7 @@ export function buildSandboxInferenceInvocationCommand(
 
 export function buildDcodeSandboxInferenceInvocationArgs(
   input: SandboxInferenceInvocationInput,
+  timeoutMs: number = REBUILD_INFERENCE_INVOCATION_TIMEOUT_MS,
 ): string[] {
   return [
     "sandbox",
@@ -130,18 +162,36 @@ export function buildDcodeSandboxInferenceInvocationArgs(
     DCODE_MANAGED_EXEC_LAUNCHER,
     "/bin/sh",
     "-c",
-    buildSandboxInferenceInvocationCommand(input),
+    buildSandboxInferenceInvocationCommand(input, timeoutMs),
   ];
+}
+
+/** Describe why the transport produced no result so the probe surfaces the real reason (#11162). */
+function describeInvocationTransportFailure(
+  failure: SandboxCommandTransportFailure | null,
+): string {
+  if (failure?.kind === "timeout") {
+    const seconds = failure.timeoutMs / 1000;
+    const rendered = seconds >= 1 ? `${Math.round(seconds)}s` : `${failure.timeoutMs}ms`;
+    return `sandbox inference invocation probe timed out after ${rendered}`;
+  }
+  if (failure?.kind === "error") {
+    return failure.detail
+      ? `sandbox inference invocation probe subprocess failed (${failure.detail})`
+      : "sandbox inference invocation probe subprocess failed";
+  }
+  return "sandbox inference invocation probe was unavailable";
 }
 
 function executeDcodeSandboxInferenceInvocation(
   input: SandboxInferenceInvocationInput,
   deps: SandboxInferenceInvocationDeps,
   timeoutMs: number,
+  onTransportFailure: (failure: SandboxCommandTransportFailure) => void,
 ): SandboxCommandResult | null {
   const runOpenshell = deps.runOpenshell ?? runOpenshellProviderCommand;
   try {
-    const result = runOpenshell(buildDcodeSandboxInferenceInvocationArgs(input), {
+    const result = runOpenshell(buildDcodeSandboxInferenceInvocationArgs(input, timeoutMs), {
       ignoreError: true,
       ...(input.runtimeSelection ? { runtimeSelection: input.runtimeSelection } : {}),
       stdio: ["ignore", "pipe", "pipe"],
@@ -153,6 +203,8 @@ function executeDcodeSandboxInferenceInvocation(
       typeof result.stderr !== "string" ||
       result.stderr.trim()
     ) {
+      const failure = classifySandboxCommandTransportFailure(result, timeoutMs);
+      if (failure) onTransportFailure(failure);
       return null;
     }
     return {
@@ -160,7 +212,10 @@ function executeDcodeSandboxInferenceInvocation(
       stdout: result.stdout,
       stderr: result.stderr,
     };
-  } catch {
+  } catch (error) {
+    onTransportFailure(
+      classifySandboxCommandTransportFailure({ error }, timeoutMs) ?? { kind: "error" },
+    );
     return null;
   }
 }
@@ -177,18 +232,23 @@ export function probeSandboxInferenceInvocation(
   timeoutMs: number = REBUILD_INFERENCE_INVOCATION_TIMEOUT_MS,
 ): SandboxInferenceInvocationResult {
   let result: SandboxCommandResult | null;
+  let transportFailure: SandboxCommandTransportFailure | null = null;
+  const onTransportFailure = (failure: SandboxCommandTransportFailure) => {
+    transportFailure = failure;
+  };
   if (input.agentName === DCODE_AGENT_NAME) {
-    result = executeDcodeSandboxInferenceInvocation(input, deps, timeoutMs);
+    result = executeDcodeSandboxInferenceInvocation(input, deps, timeoutMs, onTransportFailure);
   } else {
     const execute = deps.execute ?? executeSandboxExecCommand;
     const execOptions: SandboxExecCommandOptions = {
       ...(input.gatewayName ? { gatewayName: input.gatewayName } : {}),
       ...(input.runtimeSelection ? { runtimeSelection: input.runtimeSelection } : {}),
       allowLocalDockerFallback: false,
+      onTransportFailure,
     };
     result = execute(
       input.sandboxName,
-      buildSandboxInferenceInvocationCommand(input),
+      buildSandboxInferenceInvocationCommand(input, timeoutMs),
       timeoutMs,
       execOptions,
     );
@@ -196,7 +256,7 @@ export function probeSandboxInferenceInvocation(
   if (!result) {
     return {
       ok: false,
-      detail: "sandbox inference invocation probe was unavailable",
+      detail: describeInvocationTransportFailure(transportFailure),
       httpStatus: null,
     };
   }
@@ -220,11 +280,31 @@ export function probeSandboxInferenceInvocation(
     };
   }
   const httpStatus = result.stdout.match(/(?:^|\n)([1-5]\d\d)(?:\n|$)/)?.[1];
+  if (httpStatus) {
+    return {
+      ok: false,
+      detail: `sandbox inference invocation probe returned HTTP ${httpStatus}`,
+      httpStatus: Number.parseInt(httpStatus, 10),
+    };
+  }
+  // curl exits non-zero with `curl-error:<rc>` on stdout when the request could
+  // not complete. Exit 28 is curl's own timeout; surface it as an endpoint
+  // timeout instead of a generic exit code so a slow-but-healthy endpoint that
+  // curl bounded is reported accurately (#11162). Only the curl exit code (never
+  // response content) is read from the output here.
+  const curlExit = result.stdout.match(/(?:^|\n)curl-error:(\d+)(?:\n|$)/)?.[1];
+  if (curlExit === "28") {
+    return {
+      ok: false,
+      detail: "sandbox inference invocation probe timed out waiting for the endpoint (curl exit 28)",
+      httpStatus: null,
+    };
+  }
   return {
     ok: false,
-    detail: httpStatus
-      ? `sandbox inference invocation probe returned HTTP ${httpStatus}`
+    detail: curlExit
+      ? `sandbox inference invocation probe could not complete the request (curl exit ${curlExit})`
       : `sandbox inference invocation probe exited with status ${result.status}`,
-    httpStatus: httpStatus ? Number.parseInt(httpStatus, 10) : null,
+    httpStatus: null,
   };
 }

--- a/src/lib/adapters/sandbox/command-transport.test.ts
+++ b/src/lib/adapters/sandbox/command-transport.test.ts
@@ -157,6 +157,50 @@ describe("sandbox command transport", () => {
     ]);
   });
 
+  it("reports a timeout when the gateway-pinned exec subprocess is SIGTERM-killed (#11162)", () => {
+    const deps = createDependencies({
+      extractSandboxExecCommandStdout: vi.fn(() => null),
+    });
+    mocks.spawnSync.mockReturnValue(
+      spawnResult("", {
+        status: null,
+        signal: "SIGTERM",
+        error: Object.assign(new Error("ETIMEDOUT"), { code: "ETIMEDOUT" }),
+      }),
+    );
+    const failures: unknown[] = [];
+
+    expect(
+      executeSandboxExecCommandTransport(deps, "alpha", "id", 9000, {
+        allowLocalDockerFallback: false,
+        onTransportFailure: (failure) => failures.push(failure),
+      }),
+    ).toBeNull();
+    expect(failures).toEqual([{ kind: "timeout", timeoutMs: 9000 }]);
+  });
+
+  it("reports a subprocess error code when the gateway-pinned exec cannot spawn (#11162)", () => {
+    const deps = createDependencies({
+      extractSandboxExecCommandStdout: vi.fn(() => null),
+    });
+    mocks.spawnSync.mockReturnValue(
+      spawnResult("", {
+        status: null,
+        signal: null,
+        error: Object.assign(new Error("spawn openshell ENOENT"), { code: "ENOENT" }),
+      }),
+    );
+    const failures: unknown[] = [];
+
+    expect(
+      executeSandboxExecCommandTransport(deps, "alpha", "id", 9000, {
+        allowLocalDockerFallback: false,
+        onTransportFailure: (failure) => failures.push(failure),
+      }),
+    ).toBeNull();
+    expect(failures).toEqual([{ kind: "error", detail: "ENOENT" }]);
+  });
+
   it("does not use local Docker fallback for gateway-pinned exec (#9834)", () => {
     const deps = createDependencies({
       extractSandboxExecCommandStdout: vi.fn(() => null),

--- a/src/lib/adapters/sandbox/command-transport.ts
+++ b/src/lib/adapters/sandbox/command-transport.ts
@@ -11,9 +11,22 @@ export type SandboxCommandResult = {
   stderr: string;
 };
 
+/**
+ * Why a sandbox exec transport produced no usable result. A subprocess that is
+ * killed by the outer timeout is a distinct condition from a subprocess that
+ * failed to spawn or exited abnormally; callers such as the inference
+ * invocation probe surface the real reason instead of a generic "unavailable"
+ * message (#11162). The `detail` is limited to a subprocess error code so no
+ * untrusted command output can leak through this boundary.
+ */
+export type SandboxCommandTransportFailure =
+  | { kind: "timeout"; timeoutMs: number }
+  | { kind: "error"; detail?: string };
+
 export type SandboxExecCommandOptions = {
   allowLocalDockerFallback?: boolean;
   gatewayName?: string;
+  onTransportFailure?: (failure: SandboxCommandTransportFailure) => void;
   runtimeEnv?: NodeJS.ProcessEnv;
 };
 
@@ -57,6 +70,30 @@ export const DEFAULT_SANDBOX_EXEC_TIMEOUT_MS = 15000;
 function resolveSandboxExecTimeout(timeout: number): number {
   const timeoutOverride = Number(process.env.NEMOCLAW_SANDBOX_EXEC_TIMEOUT_MS || "");
   return Number.isFinite(timeoutOverride) && timeoutOverride > 0 ? timeoutOverride : timeout;
+}
+
+/**
+ * Classify a subprocess outcome that yielded no usable command result. A
+ * subprocess timeout sets `error.code = "ETIMEDOUT"` and kills the child with
+ * SIGTERM; report that as a timeout so callers can distinguish a slow endpoint
+ * from a genuine subprocess error (#11162). A missing error and signal returns
+ * `null`: the cause is unknown, so the caller keeps its generic message. Only
+ * the error code (never the error message or any captured output) crosses this
+ * boundary. Shared by the OpenShell exec transport and the DCode
+ * `runOpenshell` probe path so both classify identically.
+ */
+export function classifySandboxCommandTransportFailure(
+  outcome: { error?: unknown; signal?: NodeJS.Signals | null },
+  timeoutMs: number,
+): SandboxCommandTransportFailure | null {
+  const error = outcome.error as NodeJS.ErrnoException | undefined;
+  if (error?.code === "ETIMEDOUT" || outcome.signal === "SIGTERM") {
+    return { kind: "timeout", timeoutMs };
+  }
+  if (error) {
+    return error.code ? { kind: "error", detail: error.code } : { kind: "error" };
+  }
+  return null;
 }
 
 export function executeSandboxCommandTransport(
@@ -167,6 +204,7 @@ export function executeSandboxExecCommandTransport(
 ): SandboxCommandResult | null {
   const markedCommand = deps.buildSandboxExecMarkedCommand(command);
   const effectiveTimeout = resolveSandboxExecTimeout(timeout);
+  let pendingFailure: SandboxCommandTransportFailure | null = null;
   try {
     const gatewayArgs = options.gatewayName ? ["-g", options.gatewayName] : [];
     const result = spawnSync(
@@ -192,11 +230,18 @@ export function executeSandboxExecCommandTransport(
     );
     const parsed = parseSandboxCommandResult(deps, result);
     if (parsed !== null) return parsed;
-  } catch {
+    pendingFailure = classifySandboxCommandTransportFailure(result, effectiveTimeout);
+  } catch (error) {
     // OpenShell transport failed; try the trusted direct-container fallback.
+    pendingFailure = classifySandboxCommandTransportFailure({ error }, effectiveTimeout);
   }
-  if (options.allowLocalDockerFallback === false) return null;
+  if (options.allowLocalDockerFallback === false) {
+    if (pendingFailure) options.onTransportFailure?.(pendingFailure);
+    return null;
+  }
   // Keep the fallback outside the OpenShell try/catch so a fail-closed identity
   // refusal cannot be caught and retried against changing container state.
-  return executeLocalSandboxCommand(deps, sandboxName, markedCommand, effectiveTimeout);
+  const fallback = executeLocalSandboxCommand(deps, sandboxName, markedCommand, effectiveTimeout);
+  if (fallback === null && pendingFailure) options.onTransportFailure?.(pendingFailure);
+  return fallback;
 }


### PR DESCRIPTION
## Outcome
The sandbox inference invocation probe no longer reports a false "sandbox inference invocation probe was unavailable" when the route/backend/upstream are healthy but the endpoint is merely slow. Before: a healthy-but-slow endpoint was SIGTERM-killed by the outer status timeout and collapsed into a generic "unavailable" message while Phase, route reachability, and backend all read healthy. After: curl's request budget sits safely inside the outer timeout so a slow-but-healthy endpoint is served, and when the probe genuinely does fail it reports the real reason (timeout vs subprocess error vs curl exit).

## Reason
`curl` ran with a fixed `--max-time 90` while the readiness/status outer exec timeout was `30_000` ms. An endpoint responding in 30–90 s was killed by the outer timeout (`ETIMEDOUT`/`SIGTERM`) before curl returned. The transport returned `null` on that kill, and the probe collapsed any `null` into the generic "was unavailable" with `httpStatus: null`, discarding the real cause. A commenter confirmed a ~35 s endpoint response reproduces exactly this on the current release; the rebuild path used a longer outer timeout but curl's fixed `--max-time 90` could still race it.

### Related issues
Fixes #11162

## Changes
- `src/lib/adapters/sandbox/command-transport.ts`: added `SandboxCommandTransportFailure` and a single exported `classifySandboxCommandTransportFailure` that distinguishes a timeout (`ETIMEDOUT`/`SIGTERM`) from a subprocess error, and reports it through a new optional `onTransportFailure` callback on `SandboxExecCommandOptions`. Only the subprocess error code crosses the boundary (no captured output). The callback fires only when the final result is `null` (including after a failed local fallback), so existing callers that pass no callback are unaffected.
- `src/lib/actions/sandbox/inference-invocation-probe.ts`: on a `null` transport result the probe now surfaces the real reason (`timed out after Ns` / `subprocess failed (<code>)`) instead of the generic message; a curl-level timeout (exit 28) is reported as an endpoint timeout and other curl exits as `curl exit N`. `resolveInferenceInvocationMaxTimeSeconds` derives curl `--max-time` from the outer exec timeout with a 5 s buffer so curl (clean exit 28) always finishes before the outer timeout can SIGTERM the subprocess — readiness 30 s → `--max-time 25`, rebuild 100 s → `--max-time 95`. A genuine timeout still fails; it is only reported accurately, never masked. The same `timeoutMs` threads through both the exec and Deep Agents Code (`runOpenshell`) probe paths and all four consumers (status, start, `inference set-provider`, rebuild preflight).
- Tests: added unit coverage for timeout vs subprocess-error classification (exec and DCode paths), curl exit 28 vs other exits, the generic fallback when no reason is reported, and the `--max-time < outer timeout` alignment for both budgets.

New mechanism justification: the `onTransportFailure` callback is the minimal seam. `executeSandboxExecCommand`/`executeSandboxExecCommandTransport` return `SandboxCommandResult | null` to many callers; widening the return type would ripple across unrelated call sites, so an additive optional callback that only the probe consumes keeps transport semantics unchanged for everyone else. It is protected by the new command-transport and probe unit tests.

## Verification
- `npx vitest run src/lib/actions/sandbox/inference-invocation-probe.test.ts src/lib/adapters/sandbox/command-transport.test.ts` — 49 passed
- `npm run typecheck:cli` — passed for the changed files (two pre-existing plugin-artifact errors unrelated to this diff)
- Local Linux+GPU E2E through the real worktree CLI on host `yimoj-colossus-dev`, sandbox `wt11162-repro` (OpenClaw, local Ollama `llama3.2:1b`, OpenShell 0.0.106), inducing the endpoint-slower-than-outer-timeout condition via the production `NEMOCLAW_SANDBOX_EXEC_TIMEOUT_MS` override:
  - Before fix: `node ./bin/nemoclaw.js wt11162-repro status` → `Inference: unreachable ... sandbox inference invocation probe was unavailable`, exit 1, while route reachability + Ollama backend + auth proxy healthy and Phase Ready (false failure reproduced).
  - After fix (genuine timeout): same command → `... probe timed out after 100ms.`, exit 1 — accurate reason, no masking.
  - After fix (healthy): `node ./bin/nemoclaw.js wt11162-repro status` → `Inference: healthy`, exit 0.
- `npm test` (broad suite) — 148 pre-existing failures in unrelated subsystems (onboarding Dockerfile patch, CI-failure classifier, blueprint runner, messaging QR, npm cache seed, docs generation, dashboard remote-bind). Every failing file fails identically on the clean base with this change stashed and rebuilt; no failing file imports the modified modules. The two modified files' tests pass fully.
- No secrets, API keys, or credentials are in the diff. Surfaced probe detail is limited to a duration, a Node error code, or a curl exit code.

---
Signed-off-by: Yimo Jiang <yimoj@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved inference request timeout handling so requests complete within the available sandbox execution window.
  - Added clearer reporting for transport failures, including timeouts, subprocess errors, curl failures, and HTTP errors.
  - Endpoint timeouts are now identified consistently instead of appearing as generic unavailable or status errors.
  - Improved handling of sandbox execution failures while preserving existing fallback behavior when available.
  - Gateway execution failures now provide more accurate, actionable error details when no fallback result is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->