### PR TITLE
test(e2e): retain Jetson install failure diagnostics

### DIFF
--- a/test/e2e/docs/jetson-dispatch.md
+++ b/test/e2e/docs/jetson-dispatch.md
@@ -199,6 +199,13 @@ The test writes `phase-2-published-managed-image.json` with the registry
 workload receipt, digest-qualified managed-image reference, and inspected image
 labels used to prove its agent, contracts, source revision, and platform.
 
+When installation fails, the test captures `jetson-install-failure.json` before
+cleanup. It includes state and redacted startup logs for at most four Docker
+containers labeled for the test sandbox, the OpenShell sandbox observation,
+and the last 120 lines within 16 KiB of the job-local gateway log. Docker and
+OpenShell probes have two-second timeouts. Unavailable evidence is recorded as
+null or empty; diagnostic failures preserve the installation failure and cleanup.
+
 The test result verifies CPU-only onboarding for the named commit and Jetson
 device. It does not verify CUDA or OpenClaw Jetson device-group preservation.
 It does not establish that `cuInit(0)` works through OpenShell or that issue

--- a/test/e2e/fixtures/jetson-diagnostics.ts
+++ b/test/e2e/fixtures/jetson-diagnostics.ts
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+
+import { dockerRun } from "../../../src/lib/adapters/docker/command.ts";
+import { createDockerGpuDiagnosticRedactor } from "../../../src/lib/onboard/docker-gpu-diagnostic-redaction.ts";
+import { resolveGatewayLogPathForPort } from "../../../src/lib/onboard/gateway/state-dir.ts";
+import { captureDockerContainerFailureEvidence } from "../../../src/lib/onboard/managed-bootstrap/docker-container-failure-evidence.ts";
+
+import type { ArtifactSink } from "./artifacts.ts";
+import type { HostCliClient } from "./clients/host.ts";
+import type { ShellProbeResult } from "./shell-probe.ts";
+
+const MAX_CONTAINERS = 4;
+const MAX_GATEWAY_LOG_BYTES = 16 * 1024;
+
+export async function installJetsonWithDiagnostics(
+  artifacts: ArtifactSink,
+  host: Pick<HostCliClient, "command" | "openshellCommandPath">,
+  sandboxName: string,
+  env: NodeJS.ProcessEnv,
+  cwd: string,
+): Promise<ShellProbeResult> {
+  let result: ShellProbeResult | undefined;
+  try {
+    result = await host.command("bash", ["install.sh", "--non-interactive"], {
+      artifactName: "phase-2-install-jetson-nvmap",
+      cwd,
+      env,
+      timeoutMs: 40 * 60_000,
+    });
+    return result;
+  } finally {
+    if (result?.exitCode !== 0) {
+      await captureJetsonInstallFailureDiagnostics(artifacts, host, sandboxName, env);
+    }
+  }
+}
+
+function gatewayLogTail(env: NodeJS.ProcessEnv): string | null {
+  if (!env.HOME) return null;
+  let fd: number | undefined;
+  try {
+    const logPath = resolveGatewayLogPathForPort({ home: env.HOME, port: 8080 });
+    fd = fs.openSync(
+      logPath,
+      fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW | fs.constants.O_NONBLOCK,
+    );
+    const stat = fs.fstatSync(fd);
+    if (!stat.isFile()) return null;
+    const buffer = Buffer.alloc(Math.min(stat.size, MAX_GATEWAY_LOG_BYTES));
+    const read = fs.readSync(fd, buffer, 0, buffer.length, Math.max(0, stat.size - buffer.length));
+    const lines = buffer.subarray(0, read).toString("utf8").split(/\r?\n/u);
+    if (stat.size > buffer.length) lines.shift();
+    return lines.slice(-120).join("\n");
+  } catch {
+    return null;
+  } finally {
+    if (fd !== undefined) fs.closeSync(fd);
+  }
+}
+
+/** Capture runtime evidence before failed installation releases its test-owned resources. */
+export async function captureJetsonInstallFailureDiagnostics(
+  artifacts: ArtifactSink,
+  host: Pick<HostCliClient, "command" | "openshellCommandPath">,
+  sandboxName: string,
+  env: NodeJS.ProcessEnv,
+): Promise<void> {
+  try {
+    const redactor = createDockerGpuDiagnosticRedactor([env.COMPATIBLE_API_KEY ?? ""]);
+    const capture = (args: readonly string[], includeStderr = false): string | null => {
+      const result = dockerRun(args, {
+        env,
+        replaceEnv: true,
+        ignoreError: true,
+        suppressOutput: true,
+        timeout: 2_000,
+        killSignal: "SIGKILL",
+        maxBuffer: 256 * 1024,
+      });
+      if (result.error || result.status !== 0) return null;
+      const stdout = String(result.stdout ?? "");
+      if (args[0] === "inspect" && args.length === 2) {
+        const inspected = JSON.parse(stdout);
+        if (Array.isArray(inspected) && inspected.length === 1)
+          redactor.rememberInspect(inspected[0]);
+      }
+      return includeStderr ? `${stdout}\n${String(result.stderr ?? "")}` : stdout;
+    };
+    let inventory: string | null = null;
+    try {
+      inventory = capture([
+        "ps",
+        "--all",
+        "--no-trunc",
+        "--filter",
+        "label=openshell.ai/managed-by=openshell",
+        "--filter",
+        `label=openshell.ai/sandbox-name=${sandboxName}`,
+        "--format",
+        "{{.ID}}",
+      ]);
+    } catch {
+      // Gateway evidence remains useful when Docker is unavailable.
+    }
+    const containerIds = [...new Set((inventory ?? "").trim().split(/\s+/u))].filter((id) =>
+      /^[a-f0-9]{64}$/u.test(id),
+    );
+    const containers = containerIds.slice(0, MAX_CONTAINERS).map((id) => ({
+      id,
+      ...captureDockerContainerFailureEvidence(id, {
+        dockerCapture: (args) => capture(args) ?? "",
+        dockerLogs: (containerId, options) =>
+          capture(["logs", "--tail", String(options?.tail ?? 120), containerId], true) ?? "",
+      }),
+    }));
+    let sandbox: { exitCode: number | null; stdout: string; stderr: string } | null = null;
+    try {
+      const result = await host.command(
+        host.openshellCommandPath,
+        ["sandbox", "get", "-g", env.OPENSHELL_GATEWAY ?? "nemoclaw", sandboxName],
+        { env, timeoutMs: 2_000, captureLimitBytes: 16 * 1024, persistArtifacts: false },
+      );
+      sandbox = { exitCode: result.exitCode, stdout: result.stdout, stderr: result.stderr };
+    } catch {
+      // Container evidence remains useful when the gateway cannot answer.
+    }
+    await artifacts.writeJson(
+      "jetson-install-failure.json",
+      redactor.redactValue({
+        schemaVersion: 1,
+        capturedAt: new Date().toISOString(),
+        sandboxName,
+        inventoryAvailable: inventory !== null,
+        containersTruncated: containerIds.length > MAX_CONTAINERS,
+        containers,
+        sandbox,
+        gatewayLogTail: gatewayLogTail(env),
+      }),
+    );
+  } catch {
+    // Diagnostic acquisition and artifact failures must preserve the installation failure.
+  }
+}

--- a/test/e2e/live/jetson-nvmap-gpu.test.ts
+++ b/test/e2e/live/jetson-nvmap-gpu.test.ts
@@ -20,6 +20,7 @@ import { startFakeOpenAiCompatibleServer } from "../fixtures/fake-openai-compati
 import type { FakeOpenAiCompatibleRequest } from "../fixtures/fake-openai-compatible.ts";
 import { REPO_ROOT } from "../fixtures/paths.ts";
 import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
+import { installJetsonWithDiagnostics } from "../fixtures/jetson-diagnostics.ts";
 
 const SANDBOX_NAME = process.env.NEMOCLAW_SANDBOX_NAME ?? "e2e-jetson-nvmap";
 const INFERENCE_API_KEY = "jetson-nvmap-e2e-key";
@@ -277,12 +278,9 @@ fi`,
     // A3: install.sh does not accept --no-gpu. NEMOCLAW_SANDBOX_GPU=0 selects
     // the same CPU-only behavior while #7610 blocks GPU verification through OpenShell.
     progress.phase("install NemoClaw with sandbox GPU access disabled");
-    const install = await host.command("bash", ["install.sh", "--non-interactive"], {
-      artifactName: "phase-2-install-jetson-nvmap",
-      cwd: REPO_ROOT,
-      env: env(inferenceEnv),
-      timeoutMs: 40 * 60_000,
-    });
+    const install = await installJetsonWithDiagnostics(
+      artifacts, host, SANDBOX_NAME, env(inferenceEnv), REPO_ROOT,
+    );
     await artifacts.writeText("install-jetson-nvmap.log", resultText(install));
     expect(install.exitCode, resultText(install)).toBe(0);
 

--- a/test/e2e/mock-parity.json
+++ b/test/e2e/mock-parity.json
@@ -574,6 +574,7 @@
     {
       "live": "test/e2e/live/jetson-nvmap-gpu.test.ts",
       "fast": [
+        "test/e2e/support/jetson-nvmap-gpu-diagnostics.test.ts",
         "test/e2e/support/managed-image-cohort-contract.test.ts",
         "test/e2e/support/managed-image-receipt.test.ts",
         "test/e2e/support/stock-managed-image-workflow-boundary.test.ts",

--- a/test/e2e/support/jetson-nvmap-gpu-diagnostics.test.ts
+++ b/test/e2e/support/jetson-nvmap-gpu-diagnostics.test.ts
@@ -1,0 +1,198 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { dockerRun } from "../../../src/lib/adapters/docker/command.ts";
+import { ArtifactSink } from "../fixtures/artifacts.ts";
+import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
+import {
+  captureJetsonInstallFailureDiagnostics,
+  installJetsonWithDiagnostics,
+} from "../fixtures/jetson-diagnostics.ts";
+
+vi.mock("../../../src/lib/adapters/docker/command.ts", () => ({ dockerRun: vi.fn() }));
+
+const CONTAINER_ID = "a".repeat(64);
+const OPAQUE_SECRET = "x".repeat(32);
+const directories: string[] = [];
+
+function fixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "jetson-diagnostics-"));
+  directories.push(root);
+  const gatewayDirectory = path.join(root, ".local/state/nemoclaw/openshell-docker-gateway");
+  fs.mkdirSync(gatewayDirectory, { recursive: true });
+  const artifacts = new ArtifactSink(path.join(root, "artifacts"));
+  const gatewayLog = path.join(gatewayDirectory, "openshell-gateway.log");
+  const host = {
+    openshellCommandPath: "/job/bin/openshell",
+    command: vi.fn(
+      async () => ({ exitCode: 0, stdout: "phase: Error", stderr: "" }) as ShellProbeResult,
+    ),
+  };
+  const state = {
+    Status: "exited",
+    Running: false,
+    ExitCode: 1,
+    OOMKilled: false,
+    Health: { Status: "unhealthy", Log: [{ Output: `startup failed ${OPAQUE_SECRET}` }] },
+  };
+  const output = (stdout: string, status = 0) => ({
+    stdout,
+    stderr: "",
+    status,
+    signal: null,
+    pid: 1,
+    output: [],
+  });
+  vi.mocked(dockerRun)
+    .mockReturnValue(output("", 1))
+    .mockReturnValueOnce(output(`${CONTAINER_ID}\n`))
+    .mockReturnValueOnce(output(JSON.stringify(state)))
+    .mockReturnValueOnce(
+      output(
+        JSON.stringify([{ State: state, Config: { Env: [`CUSTOM_TOKEN=${OPAQUE_SECRET}`] } }]),
+      ),
+    )
+    .mockReturnValueOnce(output(`Cannot find module /fixture/startup.ts\n${OPAQUE_SECRET}`));
+  const readEvidence = () =>
+    JSON.parse(fs.readFileSync(artifacts.pathFor("jetson-install-failure.json"), "utf8"));
+  return { root, artifacts, gatewayLog, host, readEvidence, output };
+}
+
+afterEach(() => {
+  for (const directory of directories.splice(0))
+    fs.rmSync(directory, { recursive: true, force: true });
+});
+
+describe("Jetson installation failure evidence", () => {
+  it("retains container state and gateway errors while redacting runtime credentials", async () => {
+    const f = fixture();
+    fs.writeFileSync(f.gatewayLog, `supervisor exited: ${OPAQUE_SECRET}\n`);
+
+    await captureJetsonInstallFailureDiagnostics(f.artifacts, f.host, "jetson-test", {
+      HOME: f.root,
+    });
+
+    const evidence = f.readEvidence();
+    expect(evidence.containers).toEqual([
+      expect.objectContaining({
+        id: CONTAINER_ID,
+        state: expect.objectContaining({
+          Status: "exited",
+          ExitCode: 1,
+          Health: expect.objectContaining({ Status: "unhealthy" }),
+        }),
+        redactedLogTail: expect.stringContaining("Cannot find module"),
+      }),
+    ]);
+    expect(evidence.sandbox).toMatchObject({ stdout: "phase: Error" });
+    expect(evidence.gatewayLogTail).toContain("supervisor exited");
+    expect(JSON.stringify(evidence)).not.toContain(OPAQUE_SECRET);
+    expect(f.host.command).toHaveBeenCalledWith(
+      "/job/bin/openshell",
+      ["sandbox", "get", "-g", "nemoclaw", "jetson-test"],
+      expect.objectContaining({ persistArtifacts: false }),
+    );
+    expect(
+      vi
+        .mocked(dockerRun)
+        .mock.calls.every(
+          ([, options]) =>
+            options?.timeout === 2_000 &&
+            options.maxBuffer === 256 * 1024 &&
+            options.suppressOutput === true,
+        ),
+    ).toBe(true);
+  });
+
+  it("bounds container selection and gateway logs before cleanup", async () => {
+    const f = fixture();
+    const ids = ["a", "b", "c", "d", "e"].map((value) => value.repeat(64));
+    vi.mocked(dockerRun)
+      .mockReset()
+      .mockReturnValue(f.output("unavailable", 1))
+      .mockReturnValueOnce(f.output([...ids, ids[0], "invalid;command"].join("\n")));
+    fs.writeFileSync(f.gatewayLog, `old evidence\n${"x".repeat(20_000)}\nlast failure\n`);
+
+    await captureJetsonInstallFailureDiagnostics(f.artifacts, f.host, "jetson-test", {
+      HOME: f.root,
+    });
+
+    expect(f.readEvidence()).toMatchObject({
+      containersTruncated: true,
+      containers: ids.slice(0, 4).map((id) => ({ id, state: null, redactedLogTail: "" })),
+      gatewayLogTail: "last failure\n",
+    });
+    expect(vi.mocked(dockerRun).mock.calls.some(([args]) => args.includes(ids[4]!))).toBe(false);
+    expect(vi.mocked(dockerRun).mock.calls[0]?.[0]).toContain(
+      "label=openshell.ai/sandbox-name=jetson-test",
+    );
+  });
+
+  it("retains gateway evidence when Docker and OpenShell probes fail", async () => {
+    const f = fixture();
+    vi.mocked(dockerRun)
+      .mockReset()
+      .mockImplementation(() => {
+        throw new Error("Docker unavailable");
+      });
+    f.host.command.mockRejectedValue(new Error("OpenShell unavailable"));
+    fs.writeFileSync(f.gatewayLog, "gateway lost supervisor\n");
+
+    await captureJetsonInstallFailureDiagnostics(f.artifacts, f.host, "jetson-test", {
+      HOME: f.root,
+    });
+
+    expect(f.readEvidence()).toMatchObject({
+      inventoryAvailable: false,
+      containers: [],
+      sandbox: null,
+      gatewayLogTail: "gateway lost supervisor\n",
+    });
+  });
+
+  it("rejects a gateway log symlink and preserves installation failure when artifact writing fails", async () => {
+    const f = fixture();
+    const privateFile = path.join(f.root, "private-file");
+    fs.writeFileSync(privateFile, "private contents");
+    fs.symlinkSync(privateFile, f.gatewayLog);
+    await captureJetsonInstallFailureDiagnostics(f.artifacts, f.host, "jetson-test", {
+      HOME: f.root,
+    });
+    expect(f.readEvidence().gatewayLogTail).toBeNull();
+
+    vi.spyOn(f.artifacts, "writeJson").mockRejectedValue(new Error("disk unavailable"));
+    const primaryFailure = new Error("installation failed");
+    f.host.command.mockRejectedValueOnce(primaryFailure);
+    await expect(
+      installJetsonWithDiagnostics(f.artifacts, f.host, "jetson-test", { HOME: f.root }, f.root),
+    ).rejects.toBe(primaryFailure);
+  });
+
+  it.each([0, 1, null])(
+    "returns installation exit code %s after any required diagnostics finish",
+    async (exitCode) => {
+      const f = fixture();
+      const installed = { exitCode, timedOut: exitCode === null } as ShellProbeResult;
+      f.host.command.mockResolvedValueOnce(installed);
+
+      const result = await installJetsonWithDiagnostics(
+        f.artifacts,
+        f.host,
+        "jetson-test",
+        { HOME: f.root },
+        f.root,
+      );
+
+      expect(result).toBe(installed);
+      expect(fs.existsSync(f.artifacts.pathFor("jetson-install-failure.json"))).toBe(
+        exitCode !== 0,
+      );
+      expect(f.host.command).toHaveBeenCalledTimes(exitCode === 0 ? 1 : 2);
+    },
+  );
+});


### PR DESCRIPTION
## Outcome

A failed Jetson installation now retains container state and startup logs, sandbox status, and gateway logs before cleanup. The installer result and cleanup behavior remain unchanged.

## Reason

[Run 34350166888](https://github.com/NVIDIA/NemoClaw/actions/runs/34350166888/job/102462168254) reached a Ready sandbox, then failed configuration sync after the sandbox entered Error. Cleanup succeeded, but the retained artifacts did not include the runtime evidence needed to identify the cause.

## Changes

- Collect `jetson-install-failure.json` only when installation fails or throws. The Jetson fixture needs this evidence before terminal cleanup removes the sandbox; the installer result alone does not explain the runtime exit.
- Reuse the existing Docker failure-evidence collector and redactor. Limit collection to four sandbox-labeled containers, two-second probes, and a bounded gateway log tail.
- Cover failure-only capture, credential redaction, probe failures, output limits, symlink rejection, and preservation of the original installer result in `jetson-nvmap-gpu-diagnostics.test.ts`.
- Document the artifact and register its fast-test coverage.

## Verification

- `npx vitest run --project e2e-support test/e2e/support/jetson-nvmap-gpu-diagnostics.test.ts` — 7 tests passed.
- `npm run validate:pr` — passed against canonical main `091be1634190ce00812a0813fde26f3a7b2b0417`.
- [Trusted Jetson E2E run 34359947536](https://github.com/NVIDIA/NemoClaw/actions/runs/34359947536/job/102495152689) — passed on Jetson AGX Thor. Candidate `e0afd57c` used the published Arm64 image from `091be1634`; CPU-only onboarding and cleanup passed.
- Diff and secret review — no secrets, API keys, or credentials in the diff. The redaction test uses a synthetic value.

## Review notes

Self-review covered all five changed paths, failure propagation, probe limits, resource scope, and redaction. The first dispatch stopped at the image-publication prerequisite before contacting Jetson. After publication succeeded, the approved second dispatch passed. Installation succeeded, so no failure-diagnostic artifact was generated. This change collects evidence; it does not establish the cause of the original crash or claim to fix it.

---
Signed-off-by: San Dang <sdang@nvidia.com>

