### PR TITLE
fix(config): isolate tests and complete export E2E selection

### DIFF
--- a/src/lib/adapters/config/live-export-source.test.ts
+++ b/src/lib/adapters/config/live-export-source.test.ts
@@ -258,6 +258,7 @@ describe("live export snapshot reader", () => {
   });
 
   it("returns a complete non-secret raw snapshot", async () => {
+    vi.stubEnv("NVIDIA_API_KEY", readFailureCanary);
     mockSupportedLiveSource();
     const result = await createLiveExportSnapshotReader().read("alpha");
 
@@ -279,7 +280,6 @@ describe("live export snapshot reader", () => {
     });
     expect(result).not.toHaveProperty("registry.createdAt");
     expect(result).not.toHaveProperty("inference.credential");
-    expect(process.env.NVIDIA_API_KEY).toBeUndefined();
     expect(captureSanitizedResolvedOpenshell).not.toHaveBeenCalled();
     expect(JSON.stringify(result)).not.toContain(readFailureCanary);
   });

--- a/src/lib/adapters/openshell/sandbox-command-sdk.test.ts
+++ b/src/lib/adapters/openshell/sandbox-command-sdk.test.ts
@@ -7,10 +7,8 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { ensureManagedGatewayStateRoot } from "../../onboard/gateway/state-dir";
-import {
-  connectManagedOpenShellSdk,
-  createSdkOpenShellSandboxCommandExecutor,
-} from "./sandbox-command-sdk";
+import { connectManagedOpenShellSdk } from "./sdk";
+import { createSdkOpenShellSandboxCommandExecutor } from "./sandbox-command-sdk";
 
 const roots: string[] = [];
 const request = (timeoutSeconds = 120) =>

--- a/src/lib/adapters/openshell/sandbox-command-sdk.ts
+++ b/src/lib/adapters/openshell/sandbox-command-sdk.ts
@@ -7,7 +7,6 @@ import {
   OpenShellSdkPreflightUnavailableError,
   type OpenShellSdkConnectionDeps,
 } from "./sdk";
-export { connectManagedOpenShellSdk } from "./sdk";
 import { isValidName } from "../../sandbox-name-contract";
 import type {
   OpenShellSandboxCommandCompletion,

--- a/src/lib/adapters/openshell/sdk-read.ts
+++ b/src/lib/adapters/openshell/sdk-read.ts
@@ -70,7 +70,7 @@ function readError(error: unknown): OpenShellReadError {
   return new OpenShellReadError("transport");
 }
 
-/** Bound connection and read time; never return transport details or caught response data. */
+/** Honor the caller's abort/deadline signal; never expose transport details or response data. */
 export async function readOpenShell<T>(
   request: ReadRequest,
   operation: () => Promise<T>,

--- a/test/e2e/support/workflow-plan.test.ts
+++ b/test/e2e/support/workflow-plan.test.ts
@@ -263,6 +263,17 @@ describe("E2E workflow plan", () => {
     expect(selectedWorkflowJobs(plan)).toEqual(["catalogue-nvidia-api"]);
   });
 
+  it.each([
+    "src/commands/config/export.ts",
+    "src/lib/config/canonical.ts",
+    "src/lib/adapters/fs/config-export-file.ts",
+    "src/lib/adapters/openshell/sdk-read-schema.ts",
+  ])("selects live config export coverage when %s changes", (changedFile) => {
+    expect(catalogueTargetsForChangedFiles([changedFile]).map((target) => target.id)).toContain(
+      "network-policy",
+    );
+  });
+
   it("emits required fields and catalogue workflow jobs for migrated targets", () => {
     const plan = buildE2eWorkflowPlan({
       jobs: "gateway-guard-recovery,hermes-slack,network-policy,openclaw-inference-switch,openclaw-tui-chat-correlation,sandbox-operations",

--- a/test/package-contract/cli/public-cli-contracts.test.ts
+++ b/test/package-contract/cli/public-cli-contracts.test.ts
@@ -125,6 +125,8 @@ describe("public compiled CLI contracts", () => {
     const result = spawnSync(process.execPath, [CLI_ENTRYPOINT, "--version"], {
       cwd: REPO_ROOT,
       encoding: "utf-8",
+      // Version output is independent of persisted automatic gateway-port discovery.
+      env: { ...process.env, NEMOCLAW_GATEWAY_PORT: "8080" },
       timeout: 30_000,
     });
 

--- a/tools/e2e/target-catalogue.mts
+++ b/tools/e2e/target-catalogue.mts
@@ -968,13 +968,17 @@ export const E2E_TARGET_CATALOGUE: readonly E2eCatalogueTarget[] = [
     owningPaths: [
       "test/e2e/live/network-policy-transient-provider.ts",
       "test/e2e/live/restricted-onboard-helpers.ts",
+      "src/commands/config/",
       "src/lib/actions/config/",
       "src/lib/adapters/config/",
+      "src/lib/adapters/fs/config-export-file.ts",
+      "src/lib/config/",
       "src/lib/domain/config/",
       "src/lib/adapters/openshell/providers.ts",
       "src/lib/adapters/openshell/sandboxes.ts",
       "src/lib/adapters/openshell/sandbox-config.ts",
       "src/lib/adapters/openshell/sdk-read.ts",
+      "src/lib/adapters/openshell/sdk-read-schema.ts",
       "src/lib/adapters/openshell/sdk.ts",
     ],
     environment: {


### PR DESCRIPTION
## Outcome

Configuration-export tests no longer depend on an absent host API key, and export command, serialization, publisher, and SDK-schema changes select the existing `network-policy` live target. The compiled version-format test uses an explicit gateway port instead of automatic port discovery.

## Reason

These repairs address review findings from #11065. The environment assertion failed with a host API key set, and publisher/schema changes did not select their live coverage. Automatic port discovery also failed locally before the version probe reached the CLI.

### Related issues

Refs #10938. Follow-up to #11065.

## Changes

- Set a dummy API key in the snapshot test and retain assertions that exported evidence omits credential material.
- Add missing E2E owning paths and four deterministic selection cases. Keep the live target and assertion budget unchanged.
- Import the managed SDK connector directly from its owner and clarify that callers supply read deadlines.
- Give the version-format test an explicit gateway port. Preserve its existing timeouts and assertions.

## Verification

373 selected tests passed on the follow-up branch:

- `npx vitest run --project cli src/lib/adapters/config/live-export-source.test.ts src/lib/adapters/openshell/sandbox-command-sdk.test.ts src/lib/adapters/openshell/providers.test.ts` — 72 passed.
- `npx vitest run --project e2e-support test/e2e/support/workflow-plan.test.ts` — 103 passed.
- `npx vitest run --project integration test/automation/pull-requests/pr-risk-plan.test.ts test/automation/pull-requests/growth-guardrails.test.ts` — 197 passed.
- `npx vitest run --project package-contract test/package-contract/cli/public-cli-contracts.test.ts -t 'prints the public NemoClaw version prefix'` — 1 passed.
- `npm run build:cli`, `npm run typecheck:cli`, `npx oxlint . .dsh/tools`, and `git diff --check` — passed.

The missing publisher/schema selections and ambient-key failure were reproduced before repair. The diff contains no secrets, API keys, or credentials. No live E2E run was performed.

## Review notes

`tools/e2e/target-catalogue.mts` is a sensitive enforcement path. Local self-review of NVIDIA/NemoClaw commit `52c7c37fc268bb13d6e906385254eae32d9fef08` checked that selection expands only to the existing export owner and adds no runtime target or assertion budget. The originating [CodeRabbit review](https://github.com/NVIDIA/NemoClaw/pull/11065#pullrequestreview-5153478562) identified the selection and environment issues; this follow-up candidate awaits independent review. Validation uses the listed local checks and normal Git hooks; `npm run validate:pr` was not run.

The [earlier CI failure](https://github.com/NVIDIA/NemoClaw/actions/runs/34370447139/job/102530633186) reported a five-second version-test timeout. Removing port-discovery dependence passed locally; GitHub CI must confirm the result for this candidate.

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that OpenShell read operations honor caller cancellation and deadlines while keeping transport and response details private.

- **Tests**
  - Expanded end-to-end coverage for configuration exports and schema changes.
  - Updated credential-handling tests to continue verifying that sensitive values are excluded from results and serialized output.
  - Improved CLI contract coverage for version checks in configured gateway environments.
  - Refined OpenShell SDK and sandbox integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->