### PR TITLE
fix(ci): authorize stable recovery template

### DIFF
--- a/scripts/checks/extract-installer-pins.mts
+++ b/scripts/checks/extract-installer-pins.mts
@@ -543,6 +543,8 @@ const TRUSTED_OPENSHELL_RELEASES: readonly OpenShellReleaseTrust[] = [
         "593ced09573f8cea5d2323b6d388ebb5d30f6da241d4f511e5364a3057887911",
         // Exact #11251 template after stable supervisor override binding.
         "56c0cdf06734b45b235b7426de260245b03a6806a3d09a328d9bbd9161733d3e",
+        // Exact #11251 template after fail-closed gateway recovery validation.
+        "3d0f00a56ecb90e4077b6a1c455df8a659818cf8949b58e41ccc4f410ff9c13d",
       ],
     },
     pinLayout: V00116_OPENSHELL_PIN_LAYOUT,

--- a/scripts/checks/extract-installer-pins.mts
+++ b/scripts/checks/extract-installer-pins.mts
@@ -510,7 +510,7 @@ const TRUSTED_OPENSHELL_RELEASES: readonly OpenShellReleaseTrust[] = [
       "243f607a1b9a67c116f80844d5cd6e7185d63537e74fb08b3994652f79cb00e9",
       "2b6ad3e0730d3220da05d13b88fdba4458de46840bad57942ecad26a5d606017",
       // Exact #11251 template after immutable stable-override validation.
-      "d570aa89cd5845118ca0797180527e686c264d292340fe6cc54f3133be8d0f7c",
+      "24cb9e67b855e8a69df32aae992f4756ef2b29bcdc7846ef57bcfeacb3c1a9a3",
     ],
     manifests: [
       {

--- a/scripts/checks/extract-installer-pins.mts
+++ b/scripts/checks/extract-installer-pins.mts
@@ -492,6 +492,8 @@ const TRUSTED_OPENSHELL_RELEASES: readonly OpenShellReleaseTrust[] = [
       "c0a4ddf25a02a9fe02b2df53a60942ea887610f04d4ce16a121b6e79a5aeff1a",
       "56fc6482d1508b73604099e6fd6c16daea16275cf36cc25c1c5366c82a4394e3",
       "aa4afa0397780c26e0539625945052082731c441b7157cfe5917211418083756",
+      // Exact #11251 template after immutable stable-channel enforcement.
+      "9b906cc4d61c469cbd416169c678a7b4f3d5d3c3dee23fa902e735a6c3d94f27",
     ],
     formula: {
       asset: "openshell.rb",
@@ -507,6 +509,8 @@ const TRUSTED_OPENSHELL_RELEASES: readonly OpenShellReleaseTrust[] = [
     installerTemplateSha256: [
       "243f607a1b9a67c116f80844d5cd6e7185d63537e74fb08b3994652f79cb00e9",
       "2b6ad3e0730d3220da05d13b88fdba4458de46840bad57942ecad26a5d606017",
+      // Exact #11251 template after immutable stable-override validation.
+      "d570aa89cd5845118ca0797180527e686c264d292340fe6cc54f3133be8d0f7c",
     ],
     manifests: [
       {

--- a/test/install/installer-hash-check.test.ts
+++ b/test/install/installer-hash-check.test.ts
@@ -1128,6 +1128,20 @@ describe("installer hash verification", () => {
     expect(result.stdout).not.toContain("All installer hashes are current");
   });
 
+  it.each([
+    ["installer", "installer-changed-url", "installer operational template"],
+    ["Brev launchable", "brev-changed-url", "Brev launchable operational template"],
+  ] as const)(
+    "rejects an operational mutation of the base-trusted v0.0.116 %s fixture",
+    (_consumer, mode, diagnostic) => {
+      const result = runFixture(mode, "0.0.116", true);
+
+      expect(result.status).toBe(1);
+      expect(result.stdout).toContain(`${diagnostic} is not base-trusted`);
+      expect(result.stdout).not.toContain("All installer hashes are current");
+    },
+  );
+
   it("accepts a base-trusted release with non-default consumer cardinality", () => {
     const result = runFixture("allowlisted-alternate-version", "9.9.9", true);
 

--- a/test/install/installer-supervisor-manifest-trust.test.ts
+++ b/test/install/installer-supervisor-manifest-trust.test.ts
@@ -236,6 +236,19 @@ describe("OpenShell supervisor manifest trust", () => {
     expect(result.status, result.stderr).toBe(0);
   });
 
+  it("rejects an operational mutation of the base-trusted prospective supervisor fixture", () => {
+    const result = runParser({
+      transformSupervisor: (source) =>
+        selectSharedGatewayStateResolver(source).replace(
+          "ghcr.io/nvidia/openshell/supervisor@${manifestDigest}",
+          "registry.invalid/openshell/supervisor@${manifestDigest}",
+        ),
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("supervisor runtime operational template is not base-trusted");
+  });
+
   it.each([["0.0.103", V00103_SUPERVISOR_MANIFEST_DIGEST]] as const)(
     "accepts the base-trusted OpenShell %s supervisor identity before version selection (#8893)",
     (version, digest) => {


### PR DESCRIPTION
Authorizes the exact OpenShell 0.0.116 templates required by final #11251 review fixes:

- supervisor recovery validation: 3d0f00a56ecb90e4077b6a1c455df8a659818cf8949b58e41ccc4f410ff9c13d
- stable-only Brev launchable: 9b906cc4d61c469cbd416169c678a7b4f3d5d3c3dee23fa902e735a6c3d94f27
- immutable installer override validation: 24cb9e67b855e8a69df32aae992f4756ef2b29bcdc7846ef57bcfeacb3c1a9a3

This changes no runtime behavior. The base-trusted parser accepts the complete prospective #11251 inputs, and 101 installer/supervisor trust tests pass.

Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded integrity checks for installer and launchable URL changes.
  - Added validation for trusted template configurations and stable-channel overrides.
  - Added regression coverage to ensure invalid supervisor image sources are rejected.
  - Verified gateway recovery configurations fail safely when trust validation does not pass.
- **Chores**
  - Updated trusted release verification data for version 0.0.116.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->