### PR TITLE
feat(ci): promote Hermes managed image pointers alongside OpenClaw

### DIFF
--- a/.github/workflows/managed-images.yaml
+++ b/.github/workflows/managed-images.yaml
@@ -3008,7 +3008,7 @@ jobs:
           fi
 
           # Prove that every staged agent alias is anonymously pullable on both
-          # supported architectures before the single consumer pointer moves.
+          # supported architectures before any shipped-agent consumer pointer moves.
           anonymous_config="$(mktemp -d "$RUNNER_TEMP/anonymous-cohort-docker-XXXXXX")"
           chmod 0700 "$anonymous_config"
           while IFS= read -r manifest; do
@@ -3021,14 +3021,12 @@ jobs:
             done
           done < <(jq -c '.[]' "$cohort_manifests")
 
-          # Record the intended OpenClaw root pointers in every exact contract.
-          # They are not moved until all v2 evidence artifacts are durable.
-          openclaw_manifest="$(jq -ce '.[] | select(.agent == "openclaw")' "$cohort_manifests")"
-          consumer_aliases=("$(jq -r '.image' <<<"$openclaw_manifest"):${GITHUB_SHA}")
+          # Record the intended root pointers for every shipped agent in its
+          # exact contract. They are not moved until all v2 evidence artifacts
+          # are durable. Hermes ships alongside OpenClaw (#11228); Deep Agents
+          # Code stays cohort-only until its own publication decision.
+          shipped_agents=(openclaw hermes)
           release_tag="$(jq -r '.[0].release // empty' "$CANDIDATE_SET")"
-          if [ -n "$release_tag" ]; then
-            consumer_aliases+=("$(jq -r '.image' <<<"$openclaw_manifest"):${release_tag}")
-          fi
 
           while IFS= read -r candidate; do
             agent="$(jq -r '.agent' <<<"$candidate")"
@@ -3041,9 +3039,14 @@ jobs:
               jq -c '{alias, descriptor, reference}' <<<"$cohort_manifest"
             )"
             aliases=("$cohort_alias")
-            if [ "$agent" = "openclaw" ]; then
-              aliases+=("${consumer_aliases[@]}")
-            fi
+            for shipped_agent in "${shipped_agents[@]}"; do
+              if [ "$agent" = "$shipped_agent" ]; then
+                aliases+=("$(jq -r '.image' <<<"$cohort_manifest"):${GITHUB_SHA}")
+                if [ -n "$release_tag" ]; then
+                  aliases+=("$(jq -r '.image' <<<"$cohort_manifest"):${release_tag}")
+                fi
+              fi
+            done
             aliases_json="$(printf '%s\n' "${aliases[@]}" | jq -R . | jq -s .)"
             contract_dir="$contract_root/$agent/$artifact_platform"
             mkdir -p "$contract_dir"
@@ -3266,74 +3269,95 @@ jobs:
             exit 1
           fi
           cohort="$PUBLICATION_COHORT"
-          if ! jq -e \
-            --arg cohort "$cohort" \
-            --arg repository "$GITHUB_REPOSITORY" \
-            --arg revision "$GITHUB_SHA" \
-            --argjson runAttempt "$GITHUB_RUN_ATTEMPT" \
-            --argjson runId "$GITHUB_RUN_ID" \
-            '
-              .contractVersion == 2
-              and .cohort == $cohort
-              and .source.repository == $repository
-              and .source.revision == $revision
-              and .run == {id: $runId, attempt: $runAttempt}
-              and .agents.openclaw.reference ==
-                (.agents.openclaw.image + "@" + .agents.openclaw.digest)
-              and .agents.openclaw.descriptor == {
-                mediaType: "application/vnd.oci.image.index.v1+json",
-                digest: .agents.openclaw.digest,
-                size: .agents.openclaw.descriptor.size
-              }
-              and (.agents.openclaw.descriptor.size | type) == "number"
-              and .agents.openclaw.descriptor.size > 0
-            ' "$cohort_contract" >/dev/null; then
-            echo "ERROR: durable managed image cohort contract cannot authorize promotion." >&2
-            exit 1
-          fi
-
-          image="$(jq -er '.agents.openclaw.image' "$cohort_contract")"
-          exact_reference="$(jq -er '.agents.openclaw.reference' "$cohort_contract")"
-          expected_digest="$(jq -er '.agents.openclaw.digest' "$cohort_contract")"
-          expected_size="$(jq -er '.agents.openclaw.descriptor.size | tostring' "$cohort_contract")"
+          # Root pointers move for every shipped agent: OpenClaw and, per
+          # #11228, Hermes. Deep Agents Code stays cohort-only. Every shipped
+          # agent's contract and exact cohort bytes are validated before any
+          # pointer moves. A registry failure can leave an earlier agent's
+          # pointers moved; rerunning this job reconciles them to this cohort.
+          shipped_agents=(openclaw hermes)
           release_tag="$(jq -r '.source.release // empty' "$cohort_contract")"
-          if [[ ! "$image" =~ ^ghcr\.io/nvidia/nemoclaw/openclaw-sandbox$ ]] ||
-             [[ ! "$exact_reference" =~ ^ghcr\.io/nvidia/nemoclaw/openclaw-sandbox@sha256:[0-9a-f]{64}$ ]] ||
-             [[ ! "$GITHUB_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+          if [[ ! "$GITHUB_SHA" =~ ^[0-9a-f]{40}$ ]]; then
             echo "ERROR: durable managed image pointer identity is invalid." >&2
             exit 1
           fi
-
-          consumer_aliases=("${image}:${GITHUB_SHA}")
-          if [ -n "$release_tag" ]; then
-            if [[ ! "$release_tag" =~ ^v[0-9]+([.][0-9]+){1,3}([-.][0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
-              echo "ERROR: durable managed image release identity is invalid." >&2
-              exit 1
-            fi
-            consumer_aliases+=("${image}:${release_tag}")
-          fi
-
-          exact_raw="$RUNNER_TEMP/managed-image-openclaw-cohort-exact.raw"
-          docker buildx imagetools inspect "$exact_reference" --raw > "$exact_raw"
-          actual_digest="sha256:$(sha256sum "$exact_raw" | awk '{print $1}')"
-          actual_size="$(wc -c < "$exact_raw" | tr -d '[:space:]')"
-          if [ "$actual_digest" != "$expected_digest" ] ||
-             [ "$actual_size" != "$expected_size" ]; then
-            echo "ERROR: exact OpenClaw cohort bytes differ from the durable contract." >&2
+          if [ -n "$release_tag" ] &&
+             [[ ! "$release_tag" =~ ^v[0-9]+([.][0-9]+){1,3}([-.][0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+            echo "ERROR: durable managed image release identity is invalid." >&2
             exit 1
           fi
 
-          consumer_tag_args=()
-          for alias in "${consumer_aliases[@]}"; do
-            consumer_tag_args+=(--tag "$alias")
-          done
-          docker buildx imagetools create "${consumer_tag_args[@]}" "$exact_reference"
-
-          for alias in "${consumer_aliases[@]}"; do
-            alias_raw="$RUNNER_TEMP/managed-image-openclaw-pointer-${alias##*:}.raw"
-            docker buildx imagetools inspect "$alias" --raw > "$alias_raw"
-            if ! cmp -s "$exact_raw" "$alias_raw"; then
-              echo "ERROR: OpenClaw cohort pointer is not exact: $alias" >&2
+          for agent in "${shipped_agents[@]}"; do
+            if ! jq -e \
+              --arg agent "$agent" \
+              --arg cohort "$cohort" \
+              --arg repository "$GITHUB_REPOSITORY" \
+              --arg revision "$GITHUB_SHA" \
+              --argjson runAttempt "$GITHUB_RUN_ATTEMPT" \
+              --argjson runId "$GITHUB_RUN_ID" \
+              '
+                .contractVersion == 2
+                and .cohort == $cohort
+                and .source.repository == $repository
+                and .source.revision == $revision
+                and .run == {id: $runId, attempt: $runAttempt}
+                and .agents[$agent].reference ==
+                  (.agents[$agent].image + "@" + .agents[$agent].digest)
+                and .agents[$agent].descriptor == {
+                  mediaType: "application/vnd.oci.image.index.v1+json",
+                  digest: .agents[$agent].digest,
+                  size: .agents[$agent].descriptor.size
+                }
+                and (.agents[$agent].descriptor.size | type) == "number"
+                and .agents[$agent].descriptor.size > 0
+              ' "$cohort_contract" >/dev/null; then
+              echo "ERROR: durable managed image cohort contract cannot authorize promotion for ${agent}." >&2
               exit 1
             fi
+
+            image="$(jq -er --arg agent "$agent" '.agents[$agent].image' "$cohort_contract")"
+            exact_reference="$(jq -er --arg agent "$agent" '.agents[$agent].reference' "$cohort_contract")"
+            expected_digest="$(jq -er --arg agent "$agent" '.agents[$agent].digest' "$cohort_contract")"
+            expected_size="$(jq -er --arg agent "$agent" '.agents[$agent].descriptor.size | tostring' "$cohort_contract")"
+            if [ "$image" != "ghcr.io/nvidia/nemoclaw/${agent}-sandbox" ] ||
+               [[ ! "$exact_reference" =~ ^ghcr\.io/nvidia/nemoclaw/(openclaw|hermes)-sandbox@sha256:[0-9a-f]{64}$ ]] ||
+               [ "${exact_reference%@*}" != "$image" ]; then
+              echo "ERROR: durable managed image pointer identity is invalid for ${agent}." >&2
+              exit 1
+            fi
+
+            exact_raw="$RUNNER_TEMP/managed-image-${agent}-cohort-exact.raw"
+            docker buildx imagetools inspect "$exact_reference" --raw > "$exact_raw"
+            actual_digest="sha256:$(sha256sum "$exact_raw" | awk '{print $1}')"
+            actual_size="$(wc -c < "$exact_raw" | tr -d '[:space:]')"
+            if [ "$actual_digest" != "$expected_digest" ] ||
+               [ "$actual_size" != "$expected_size" ]; then
+              echo "ERROR: exact ${agent} cohort bytes differ from the durable contract." >&2
+              exit 1
+            fi
+          done
+
+          for agent in "${shipped_agents[@]}"; do
+            image="$(jq -er --arg agent "$agent" '.agents[$agent].image' "$cohort_contract")"
+            exact_reference="$(jq -er --arg agent "$agent" '.agents[$agent].reference' "$cohort_contract")"
+            exact_raw="$RUNNER_TEMP/managed-image-${agent}-cohort-exact.raw"
+
+            consumer_aliases=("${image}:${GITHUB_SHA}")
+            if [ -n "$release_tag" ]; then
+              consumer_aliases+=("${image}:${release_tag}")
+            fi
+
+            consumer_tag_args=()
+            for alias in "${consumer_aliases[@]}"; do
+              consumer_tag_args+=(--tag "$alias")
+            done
+            docker buildx imagetools create "${consumer_tag_args[@]}" "$exact_reference"
+
+            for alias in "${consumer_aliases[@]}"; do
+              alias_raw="$RUNNER_TEMP/managed-image-${agent}-pointer-${alias##*:}.raw"
+              docker buildx imagetools inspect "$alias" --raw > "$alias_raw"
+              if ! cmp -s "$exact_raw" "$alias_raw"; then
+                echo "ERROR: ${agent} cohort pointer is not exact: $alias" >&2
+                exit 1
+              fi
+            done
           done

--- a/docs/manage-sandboxes/install-plugins-hermes.mdx
+++ b/docs/manage-sandboxes/install-plugins-hermes.mdx
@@ -155,10 +155,19 @@ my-hermes-plugin-sandbox/
 If you start from the stock NemoClaw Hermes Dockerfile, keep the NemoClaw Hermes image contract intact.
 The image must still include the generated Hermes config, NemoClaw Hermes plugin, blueprint files, `nemoclaw-start` entrypoint, root-only gateway control helper, root-only managed controller, and shared supervisor library.
 
+Start a standalone custom Dockerfile from the published complete image, which already carries every managed Hermes layer:
+
+```dockerfile
+FROM ghcr.io/nvidia/nemoclaw/hermes-sandbox@sha256:<digest>
+```
+
+Releases publish `ghcr.io/nvidia/nemoclaw/hermes-sandbox:<release>` and its digest alongside `openclaw-sandbox`.
+Pin the digest rather than a tag so rebuilds stay reproducible.
+
 <Warning>
   A custom `--from` Dockerfile replaces the normal NemoClaw Hermes Dockerfile.
-  Starting from `ghcr.io/nvidia/nemoclaw/hermes-sandbox-base:latest` alone is not enough.
-  Your Dockerfile must also preserve the NemoClaw Hermes layers from `agents/hermes/Dockerfile`.
+  Starting from `ghcr.io/nvidia/nemoclaw/hermes-sandbox-base:latest` alone is not enough: the platform base does not include the managed Hermes layers.
+  Extend the complete `ghcr.io/nvidia/nemoclaw/hermes-sandbox` image, or preserve the NemoClaw Hermes layers from `agents/hermes/Dockerfile` yourself.
 </Warning>
 
 If `gateway restart` or `recover` reports `privileged control unavailable` for an older custom image, update the Dockerfile to the current Hermes image contract and rebuild it with `nemohermes <name> rebuild --yes`.

--- a/test/inference/managed/managed-image-publication-promotion.test.ts
+++ b/test/inference/managed/managed-image-publication-promotion.test.ts
@@ -52,7 +52,7 @@ function expectedReceipt(cohort: string, receiptAttempt: number): Record<string,
 }
 
 describe("managed-image publication promotion", () => {
-  it("stages all multi-platform cohort aliases before moving the sole root pointer (#7744)", () => {
+  it("stages all multi-platform cohort aliases before moving the shipped root pointers (#7744, #11228)", () => {
     const promotion = required(
       step(
         managedPromoter(readWorkflow("managed-images.yaml")),
@@ -76,6 +76,7 @@ describe("managed-image publication promotion", () => {
     expect(failedCalls).toContain(`langchain-deepagents-code-sandbox:cohort-${cohort}`);
     expect(failedCalls).toContain(`openclaw-sandbox:cohort-${cohort}`);
     expect(failedCalls).not.toContain(`openclaw-sandbox:${revision}`);
+    expect(failedCalls).not.toContain(`hermes-sandbox:${revision}`);
 
     const accepted = runManagedImagePromotion(promotion, "", pointer);
     const acceptedCalls = accepted.calls.join("\n");
@@ -95,6 +96,7 @@ describe("managed-image publication promotion", () => {
       acceptedCalls.lastIndexOf(`openclaw-sandbox:cohort-${cohort}`),
     );
     const rootPointer = acceptedCalls.indexOf(`openclaw-sandbox:${revision}`);
+    const hermesPointer = acceptedCalls.indexOf(`hermes-sandbox:${revision}`);
 
     expect(accepted.calls.filter((call) => call.startsWith("pull ")).sort()).toEqual(
       expectedPullCalls.sort(),
@@ -108,7 +110,9 @@ describe("managed-image publication promotion", () => {
     });
     expect(lastCohortStage).toBeGreaterThanOrEqual(0);
     expect(rootPointer).toBeGreaterThan(lastCohortStage);
-    expect(acceptedCalls).not.toContain(`hermes-sandbox:${revision}`);
+    // Hermes ships its root pointer alongside OpenClaw (#11228); Deep Agents
+    // Code stays cohort-only.
+    expect(hermesPointer).toBeGreaterThan(lastCohortStage);
     expect(acceptedCalls).not.toContain(`langchain-deepagents-code-sandbox:${revision}`);
     expect(Object.keys(accepted.platformContracts).sort()).toEqual(
       publicationAgents
@@ -203,6 +207,6 @@ describe("managed-image publication promotion", () => {
     });
 
     expect(stalePointer.status).not.toBe(0);
-    expect(stalePointer.stderr).toContain("OpenClaw cohort pointer is not exact");
+    expect(stalePointer.stderr).toContain("cohort pointer is not exact");
   });
 });

--- a/test/inference/managed/managed-image-publication-workflow.test.ts
+++ b/test/inference/managed/managed-image-publication-workflow.test.ts
@@ -1254,11 +1254,15 @@ fi
     expect(promotion.run).toContain('"${descriptor_args[@]}"');
     expect(promotion.run).toContain('cmp -s "$expected_descriptors" "$actual_descriptors"');
     expect(promotion.run).toContain(') == ["linux/amd64", "linux/arm64"]');
+    expect(promotion.run).toContain("shipped_agents=(openclaw hermes)");
     expect(promotion.run).toContain(
-      'consumer_aliases=("$(jq -r \'.image\' <<<"$openclaw_manifest"):${GITHUB_SHA}")',
+      'aliases+=("$(jq -r \'.image\' <<<"$cohort_manifest"):${GITHUB_SHA}")',
     );
     expect(promotion.run).not.toContain('imagetools create "${consumer_tag_args[@]}"');
-    expect(pointer.run).toContain("exact_reference=\"$(jq -er '.agents.openclaw.reference'");
+    expect(pointer.run).toContain("shipped_agents=(openclaw hermes)");
+    expect(pointer.run).toContain(
+      "exact_reference=\"$(jq -er --arg agent \"$agent\" '.agents[$agent].reference'",
+    );
     expect(pointer.run).toContain('imagetools create "${consumer_tag_args[@]}" "$exact_reference"');
     expect(pointer.run).toContain('cmp -s "$exact_raw" "$alias_raw"');
     expect(pointer.run).not.toContain("$openclaw_alias");


### PR DESCRIPTION
## Outcome

NemoClaw publishes Hermes revision and release aliases from the same validated managed-image cohort as OpenClaw. Downstream Hermes images can resolve a release alias and pin its digest without rebuilding the NemoClaw Hermes Dockerfile.

## Reason

The workflow already builds, validates, attests, and publishes the complete Hermes image under cohort tags. The missing consumer aliases make that supported image difficult to discover and use from downstream custom images.

### Related issues

Resolves #11228.

Replays #11298 on a same-repository branch so trusted CI can qualify the contribution. The commit retains Zac Wang as its author.

## Changes

- Record revision and release aliases in the exact OpenClaw and Hermes platform contracts.
- Validate both shipped-agent contracts and exact cohort bytes before any pointer write.
- Publish and verify OpenClaw and Hermes aliases while keeping Deep Agents Code cohort-only.
- Document the complete digest-pinned Hermes image as the custom Dockerfile base.
- Extend the existing workflow tests for Hermes publication and fail-closed validation.

## Verification

- `npx vitest run test/inference/managed/managed-image-publication-promotion.test.ts test/inference/managed/managed-image-publication-workflow.test.ts` — 39 tests passed.
- `npm run docs` — passed with zero errors.
- `NODE_OPTIONS=--max-old-space-size=8192 npm run validate:pr` — passed after installing and building both current-main package workspaces required by the fresh checkout.
- Diff inspection confirmed that no secrets, API keys, or credentials are present.

## Review notes

The accepted product decision is recorded on #11228. NemoClaw managed-image and release maintainers own the release aliases and first-release validation.

This PR changes `.github/workflows/managed-images.yaml`. The completed nine-category security review found no credential, authorization, dependency, cryptography, sandbox, or policy regression. Both agents are validated before publication. GHCR cannot update two image repositories atomically, so a registry failure can leave an earlier alias moved; rerunning the same release job reconciles every alias to the same immutable cohort.

Live pointer promotion runs only from trusted `main` or release-tag workflows. The first shipping release must inspect the published Hermes manifest and run managed-image activation against the published release alias.

---

Signed-off-by: Aaron Erickson <aerickson@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hermes is now included as a shipped managed agent, with commit and release aliases tied to validated cohort manifests.
  * Promotion verifies agent contracts and exact image contents before updating aliases.

* **Documentation**
  * Updated Hermes sandbox guidance to use the complete, digest-pinned published image and clarify required managed layers.

* **Tests**
  * Expanded publication and promotion coverage for Hermes alongside OpenClaw.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->