### PR TITLE
fix(portable): retry incomplete stop identity settlement

### DIFF
--- a/src/lib/adapters/openshell/sandbox-identity.test.ts
+++ b/src/lib/adapters/openshell/sandbox-identity.test.ts
@@ -12,6 +12,7 @@ import {
   isOpenShellSandboxId,
   NEMOCLAW_CREATE_ATTEMPT_LABEL,
   NEMOCLAW_CREATE_ATTEMPT_NONCE_HEX_LENGTH,
+  observeOpenShellSandboxId,
   parseOpenShellSandboxId,
   resolveCreatedOpenShellSandboxId,
   settleCreatedOpenShellSandboxId,
@@ -68,6 +69,16 @@ describe("OpenShell sandbox identity parsing", () => {
     expect(parseOpenShellSandboxId("ID: first\nID: second\n")).toBeNull();
     expect(parseOpenShellSandboxId("ID: sandbox/alpha\n")).toBeNull();
     expect(parseOpenShellSandboxId("id: sandbox-alpha\n")).toBeNull();
+  });
+
+  it("distinguishes an absent ID from invalid identity evidence (#11302)", () => {
+    expect(observeOpenShellSandboxId("Name: alpha\nPhase: Error\n")).toEqual({ kind: "absent" });
+    expect(observeOpenShellSandboxId("ID: first\nID: second\n")).toEqual({ kind: "invalid" });
+    expect(observeOpenShellSandboxId("ID: sandbox/alpha\n")).toEqual({ kind: "invalid" });
+    expect(observeOpenShellSandboxId("ID: sandbox-alpha\n")).toEqual({
+      kind: "present",
+      id: "sandbox-alpha",
+    });
   });
 
   it("fingerprints only one bounded durable ID (#9203)", () => {

--- a/src/lib/adapters/openshell/sandbox-identity.test.ts
+++ b/src/lib/adapters/openshell/sandbox-identity.test.ts
@@ -73,6 +73,12 @@ describe("OpenShell sandbox identity parsing", () => {
 
   it("distinguishes an absent ID from invalid identity evidence (#11302)", () => {
     expect(observeOpenShellSandboxId("Name: alpha\nPhase: Error\n")).toEqual({ kind: "absent" });
+    expect(observeOpenShellSandboxId("Name: alpha\nID:\nPhase: Error\n")).toEqual({
+      kind: "invalid",
+    });
+    expect(observeOpenShellSandboxId("Name: alpha\nID:\nsandbox-alpha\n")).toEqual({
+      kind: "invalid",
+    });
     expect(observeOpenShellSandboxId("ID: first\nID: second\n")).toEqual({ kind: "invalid" });
     expect(observeOpenShellSandboxId("ID: sandbox/alpha\n")).toEqual({ kind: "invalid" });
     expect(observeOpenShellSandboxId("ID: sandbox-alpha\n")).toEqual({

--- a/src/lib/adapters/openshell/sandbox-identity.ts
+++ b/src/lib/adapters/openshell/sandbox-identity.ts
@@ -74,14 +74,14 @@ export type OpenShellSandboxIdObservation =
   | { readonly kind: "invalid" };
 
 export function observeOpenShellSandboxId(output: string): OpenShellSandboxIdObservation {
-  const matches = [
+  const fields = [
     ...String(output)
       .replace(ANSI_RE, "")
-      .matchAll(/^\s*(?:Id|ID):\s*(\S+)\s*$/gm),
-  ].map((match) => match[1] ?? "");
-  if (matches.length === 0) return { kind: "absent" };
-  return matches.length === 1 && isOpenShellSandboxId(matches[0])
-    ? { kind: "present", id: matches[0] as string }
+      .matchAll(/^[\t ]*(?:Id|ID):[\t ]*(.*)$/gmu),
+  ].map((match) => (match[1] ?? "").trim());
+  if (fields.length === 0) return { kind: "absent" };
+  return fields.length === 1 && isOpenShellSandboxId(fields[0])
+    ? { kind: "present", id: fields[0] as string }
     : { kind: "invalid" };
 }
 

--- a/src/lib/adapters/openshell/sandbox-identity.ts
+++ b/src/lib/adapters/openshell/sandbox-identity.ts
@@ -68,13 +68,26 @@ function parseOpenShellSandboxListJson(output: string): readonly unknown[] | nul
   return Array.isArray(rows) ? rows : null;
 }
 
-export function parseOpenShellSandboxId(output: string): string | null {
+export type OpenShellSandboxIdObservation =
+  | { readonly kind: "present"; readonly id: string }
+  | { readonly kind: "absent" }
+  | { readonly kind: "invalid" };
+
+export function observeOpenShellSandboxId(output: string): OpenShellSandboxIdObservation {
   const matches = [
     ...String(output)
       .replace(ANSI_RE, "")
       .matchAll(/^\s*(?:Id|ID):\s*(\S+)\s*$/gm),
   ].map((match) => match[1] ?? "");
-  return matches.length === 1 && isOpenShellSandboxId(matches[0]) ? (matches[0] as string) : null;
+  if (matches.length === 0) return { kind: "absent" };
+  return matches.length === 1 && isOpenShellSandboxId(matches[0])
+    ? { kind: "present", id: matches[0] as string }
+    : { kind: "invalid" };
+}
+
+export function parseOpenShellSandboxId(output: string): string | null {
+  const observed = observeOpenShellSandboxId(output);
+  return observed.kind === "present" ? observed.id : null;
 }
 
 /** Hash the one durable OpenShell ID without importing sandbox mutation owners. */

--- a/src/lib/onboard/experimental/hermes-portable-lifecycle.test.ts
+++ b/src/lib/onboard/experimental/hermes-portable-lifecycle.test.ts
@@ -260,6 +260,7 @@ function lifecycleDeps(
     readonly livePolicy?: string;
     readonly registry?: Partial<SandboxEntry>;
     readonly sandboxPhase?: (running: boolean) => string;
+    readonly sandboxIdentity?: (running: boolean) => string | undefined;
     readonly failPostStartInspectOnce?: boolean;
   } = {},
 ) {
@@ -322,7 +323,7 @@ function lifecycleDeps(
       },
       "sandbox:get": {
         status: 0,
-        stdout: `Name: ${SANDBOX}\nID: ${SANDBOX_ID}\nPhase: ${sandboxPhase()}\n`,
+        stdout: options.sandboxIdentity?.(running) ?? `Name: ${SANDBOX}\nID: ${SANDBOX_ID}\nPhase: ${sandboxPhase()}\n`,
         stderr: "",
       },
       "sandbox:exec": { status: 0, stdout: sandboxExecOutput, stderr: "" },
@@ -1177,10 +1178,10 @@ describe("Hermes portable lifecycle", () => {
     expect(captureOpenShell).not.toHaveBeenCalled();
   });
 
-  it("waits for exact Podman exit and delayed OpenShell Error after stopping one full ID (#11248)", () => {
+  it("retries an incomplete identity before delayed OpenShell Error after stopping one full ID (#11302)", () => {
     const receipt = activeReceipt();
     let elapsedMs = 0;
-    const { deps, podman, captureOpenShell } = lifecycleDeps(receipt, true, { sandboxPhase: (running) => running || elapsedMs < 2_000 ? "Ready" : "Error" });
+    const { deps, podman, captureOpenShell } = lifecycleDeps(receipt, true, { sandboxPhase: (running) => running || elapsedMs < 2_000 ? "Ready" : "Error", sandboxIdentity: (running) => !running && elapsedMs < 1_000 ? `Name: ${SANDBOX}\nPhase: Ready\n` : undefined });
     deps.now = () => elapsedMs; deps.sleep = vi.fn((milliseconds: number) => { elapsedMs += milliseconds; });
     const result = withMcpLifecycleLockSync(
       SANDBOX,
@@ -1268,15 +1269,9 @@ describe("Hermes portable lifecycle", () => {
     expect(podman.mock.calls.filter(([args]) => args[1] === "stop")).toEqual([]);
   });
 
-  it("times out a stopped container when OpenShell remains Ready (#11248)", () => {
+  it("times out a stopped container when OpenShell identity remains incomplete (#11302)", () => {
     const receipt = activeReceipt();
-    const { deps, podman, captureOpenShell } = lifecycleDeps(receipt);
-    const defaultCapture = captureOpenShell.getMockImplementation()!;
-    captureOpenShell.mockImplementation((args: readonly string[]) =>
-      args.slice(0, 2).join(":") === "sandbox:list"
-        ? { status: 0, stdout: sandboxListJson(SANDBOX_ID, "Ready"), stderr: "" }
-        : defaultCapture(args),
-    );
+    const { deps, podman } = lifecycleDeps(receipt, true, { sandboxIdentity: (running) => running ? undefined : `Name: ${SANDBOX}\nPhase: Error\n` });
 
     expect(() =>
       withMcpLifecycleLockSync(

--- a/src/lib/onboard/experimental/hermes-portable-lifecycle.ts
+++ b/src/lib/onboard/experimental/hermes-portable-lifecycle.ts
@@ -8,7 +8,7 @@ import { TextDecoder } from "node:util";
 import {
   fingerprintOpenShellSandboxId,
   fingerprintOpenShellSandboxLiveIdentity,
-  parseOpenShellSandboxId,
+  observeOpenShellSandboxId,
 } from "../../adapters/openshell/sandbox-identity";
 import {
   classifyOpenShellSandboxPresence,
@@ -549,6 +549,13 @@ function fail(message: string): never {
   throw new Error(`Hermes portable lifecycle ${message}`);
 }
 
+class IncompleteOpenShellIdentityError extends Error {
+  constructor() {
+    super("Hermes portable lifecycle OpenShell sandbox identity disagrees with the receipt container");
+    this.name = "IncompleteOpenShellIdentityError";
+  }
+}
+
 function defaultSleep(milliseconds: number): void {
   if (milliseconds > 0) Atomics.wait(SLEEP_BUFFER, 0, 0, milliseconds);
 }
@@ -759,13 +766,23 @@ function observeOpenShellIdentity(
   );
   if (current.status !== 0 || current.error) fail("cannot prove the current OpenShell sandbox");
   const output = commandOutput(current.stdout, "sandbox identity output");
-  const sandboxId = parseOpenShellSandboxId(output);
+  const observedSandboxId = observeOpenShellSandboxId(output);
   const liveIdentityFingerprint = fingerprintOpenShellSandboxLiveIdentity(output);
   if (
     listed.kind !== "present" ||
     !acceptedPhases.includes(listed.phase) ||
-    !sandboxId ||
-    !liveIdentityFingerprint ||
+    listed.id !== receipt.container.sandboxId
+  ) {
+    fail("OpenShell sandbox identity disagrees with the receipt container");
+  }
+  if (observedSandboxId.kind === "absent") {
+    throw new IncompleteOpenShellIdentityError();
+  }
+  if (observedSandboxId.kind !== "present" || !liveIdentityFingerprint) {
+    fail("OpenShell sandbox identity disagrees with the receipt container");
+  }
+  const sandboxId = observedSandboxId.id;
+  if (
     listed.id !== sandboxId ||
     sandboxId !== receipt.container.sandboxId ||
     fingerprintOpenShellSandboxId(listed.id) !== liveIdentityFingerprint
@@ -1074,7 +1091,7 @@ function rollbackStartedHermesPortableRecovery(
       ...(deps.sleep ? { sleep: deps.sleep } : {}),
     });
     failureClass = "openshell-terminal-settlement";
-    settleStoppedHermesPortableLifecycle(sandboxName, context, deps, qualified.snapshot, timing);
+    settleStoppedHermesPortableLifecycle(sandboxName, context, deps, qualified, timing);
   } catch (error) {
     throw new HermesPortableRollbackAttemptError(failureClass, error);
   }
@@ -1084,13 +1101,25 @@ function settleStoppedHermesPortableLifecycle(
   sandboxName: string,
   context: PortableDemoLifecycleContext,
   deps: HermesPortableLifecycleDeps,
-  expected: HermesPortableReceiptSnapshot,
+  authority: QualifiedHermesPortableLifecycle,
   timing?: HermesPortableLifecycleTimingRecorder,
 ): QualifiedHermesPortableLifecycle {
   let stopped: QualifiedHermesPortableLifecycle | null = null;
   const settled = waitFor(STOP_SETTLEMENT_TIMEOUT_MS, deps, () => {
     timing?.increment("qualification");
-    const current = qualify(sandboxName, context, deps, expected, ["Ready", "Error", "Stopped"]);
+    let current: QualifiedHermesPortableLifecycle;
+    try {
+      current = qualify(sandboxName, context, deps, authority.snapshot, ["Ready", "Error", "Stopped"]);
+    } catch (error) {
+      if (!(error instanceof IncompleteOpenShellIdentityError)) throw error;
+      authority.assertTransactionCurrent();
+      const container = assertCurrentHermesPortableContainer(authority.receipt, authority.containerDeps);
+      authority.assertTransactionCurrent();
+      if (container.authority.running || container.status !== "exited") {
+        fail("exact container changed after stop settlement");
+      }
+      return false;
+    }
     if (current.container.authority.running || current.container.status !== "exited") {
       fail("exact container changed after stop settlement");
     }
@@ -1909,7 +1938,7 @@ export function stopHermesPortableSandboxLifecycle(
 ): PortableDemoLifecycleStopResult {
   let qualified = qualify(sandboxName, context, deps, undefined, ["Ready", "Error", "Stopped"]);
   if (!qualified.container.authority.running && qualified.container.status === "exited") {
-    settleStoppedHermesPortableLifecycle(sandboxName, context, deps, qualified.snapshot);
+    settleStoppedHermesPortableLifecycle(sandboxName, context, deps, qualified);
     return { kind: "already-stopped" };
   }
   if (qualified.container.authority.running && qualified.openShellPhase === "Stopped") {
@@ -1929,7 +1958,7 @@ export function stopHermesPortableSandboxLifecycle(
     ...(deps.now ? { now: deps.now } : {}),
     ...(deps.sleep ? { sleep: deps.sleep } : {}),
   });
-  settleStoppedHermesPortableLifecycle(sandboxName, context, deps, qualified.snapshot);
+  settleStoppedHermesPortableLifecycle(sandboxName, context, deps, qualified);
   return { kind: result };
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

Hermes Portable stop and rollback settlement now tolerate the bounded OpenShell observation window in which `sandbox list` still identifies the receipt-owned sandbox but `sandbox get` temporarily omits its ID. Real replacement, conflicting, duplicate, and malformed identity observations continue to fail closed.

## Reason

Immediately after a successful container stop, OpenShell can transiently return an incomplete identity record. NemoClaw previously treated that incomplete observation as definitive disagreement with the signed receipt and failed after roughly 46 seconds, even though the same sandbox and exact receipt-owned Podman container remained present and the next probe recovered normally.

### Related issues

Fixes #11302

## Changes

- Classify OpenShell sandbox-ID observations as present, absent, or invalid while preserving the existing parser contract.
- Retry only the narrowly qualified missing-ID settlement state when the structured sandbox list still proves the receipt-owned sandbox.
- Reassert transaction authority and re-inspect the exact full-ID receipt-owned container before every retry.
- Keep conflicting, replaced, duplicate, malformed, running, and otherwise untrusted states fail-closed.
- Cover delayed recovery and permanent missing-ID timeout behavior in the lifecycle tests.

## Verification

- `npm run validate:pr` — passed on `7c8b6be1013adf6344d4df946d0f92589a1061b0`.
- `npx vitest run --project cli src/lib/adapters/openshell/sandbox-identity.test.ts src/lib/sandbox-presence.test.ts src/lib/onboard/experimental/hermes-portable-contract.test.ts src/lib/onboard/experimental/hermes-portable-container.test.ts src/lib/onboard/experimental/hermes-portable-operating-authority.test.ts src/lib/onboard/experimental/hermes-portable-lifecycle.test.ts` — 163 tests passed.
- `npx vitest run --project growth` — 45 tests passed.
- `npm run build:cli` — passed.
- `npm run typecheck:cli` — passed.
- `npx oxlint` on all four changed files — passed.
- Manual Portable rootless regression — 10 consecutive stop/probe cycles passed; 10/10 stops and 10/10 recovery probes returned rc=0 with no identity-settlement failure.
- `git diff --check` — passed.
- Secret scan — passed; the diff contains no secrets, API keys, or credentials.

## Review notes

This changes sensitive onboarding/OpenShell authority code. The retry is intentionally limited to an absent ID after the structured list proves the expected sandbox; each iteration revalidates transaction authority and the exact receipt-owned full container ID. Conflicting or malformed identity evidence is never retried. Maintainer review should confirm that this boundary remains fail-closed.

`npm run test:changed` selected 7,089 tests through the shared parser import graph. It reported 53 unrelated failures on the live Portable seat because ambient GPU resources, `DOCKER_HOST`, occupied sandbox ports, and live host state violate isolated-test assumptions. The focused suites above and the repository's required `validate:pr` gate passed; PR CI is the authoritative broad isolated run.

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>
