### PR TITLE
fix(build): sync plugin cache seed lock digest

### DIFF
--- a/tools/mcp-tool-discovery-runtime/npm-cache-seed/manifest.json
+++ b/tools/mcp-tool-discovery-runtime/npm-cache-seed/manifest.json
@@ -513,7 +513,7 @@
     }
   ],
   "kind": "nemoclaw-locked-npm-cache-seed-v1",
-  "lockSha256": "66bef669196bb1c61385871e369542d3c321c277adb0f0e2e9f0ad972106b163",
+  "lockSha256": "55a512d782f8a4ad0eac39078b0e652400bf8580767b3a9ac5282a05bae47042",
   "target": {
     "cpu": "x64",
     "libc": "glibc",


### PR DESCRIPTION
## Outcome

The locked plugin cache-seed manifest matches `nemoclaw/package-lock.json` again. The OpenClaw integrity-pin contract and CLI shard 6 no longer reject current `main`.

## Reason

PR #10518 changed the plugin lockfile while leaving the generated cache-seed digest at the previous value. Current main CI therefore fails before unrelated PRs can reach a green gate.

### Related issues

Refs #10518.

Blocks exact qualification of #11310.

## Changes

- Update the existing cache-seed manifest digest to the SHA-256 of the current plugin lockfile.
- Keep the archive inventory and every other cache-seed field unchanged because the production archive set did not change.

## Verification

- `shasum -a 256 nemoclaw/package-lock.json` — produced `55a512d782f8a4ad0eac39078b0e652400bf8580767b3a9ac5282a05bae47042`.
- `npx vitest run test/agents/openclaw/openclaw-integrity-pin-contract.test.ts test/install/materialize-locked-npm-cache-seed.test.ts` — 16 tests passed.
- `NODE_OPTIONS=--max-old-space-size=8192 npm run validate:pr` — passed after building the current-main CLI and plugin artifacts required by a fresh checkout.
- Diff inspection confirmed that no secrets, API keys, or credentials are present.

---

Signed-off-by: Aaron Erickson <aerickson@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the npm cache seed manifest checksum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->