### PR TITLE
fix(onboard): remove misleading Docker gateway messages

### DIFF
--- a/src/lib/onboard/docker-driver-gateway-service.test.ts
+++ b/src/lib/onboard/docker-driver-gateway-service.test.ts
@@ -461,6 +461,7 @@ describe("docker-driver-gateway-service", () => {
   });
 
   it("uses managed service only after metadata and direct gRPC health are ready (#6903)", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
     const events: string[] = [];
     const clock = createVirtualClock();
     let registerCount = 0;
@@ -501,6 +502,7 @@ describe("docker-driver-gateway-service", () => {
     ).resolves.toBe(true);
 
     expect(events).toEqual(["register", "sleep", "register", "ready", "clear", "verify"]);
+    expect(log).toHaveBeenCalledWith("  Starting OpenShell gateway via managed service...");
   });
 
   it.each([

--- a/src/lib/onboard/docker-driver-gateway-service.ts
+++ b/src/lib/onboard/docker-driver-gateway-service.ts
@@ -1441,7 +1441,7 @@ export async function startPackageManagedDockerDriverGateway({
     return false;
   }
 
-  console.log("  Starting OpenShell Docker-driver gateway via managed service...");
+  console.log("  Starting OpenShell gateway via managed service...");
   let serviceStart: OpenShellGatewayUserServiceStartResult;
   try {
     serviceStart = startService({

--- a/src/lib/onboard/gateway/docker-driver-start.ts
+++ b/src/lib/onboard/gateway/docker-driver-start.ts
@@ -268,7 +268,7 @@ export function createDockerDriverGatewayStart(
       fs.mkdirSync(stateDir, { recursive: true, mode: 0o700 });
       const logPath = path.join(stateDir, "openshell-gateway.log");
       const log = dockerDriverGatewayLaunch.openDockerDriverGatewayLog(logPath, { exitOnFailure });
-      console.log("  Starting OpenShell Docker-driver gateway...");
+      console.log("  Starting OpenShell gateway...");
       console.log(`  Gateway log: ${logPath}`);
       dockerDriverGatewayLaunch.prepareAndLogDockerDriverGatewayLaunch(gatewayLaunch);
       const child = dockerDriverGatewayLaunch.spawnDockerDriverGateway(gatewayLaunch, log.fd);

--- a/src/lib/onboard/machine/handlers/gateway.test.ts
+++ b/src/lib/onboard/machine/handlers/gateway.test.ts
@@ -611,7 +611,7 @@ describe("handleGatewayState", () => {
     const result = await handleGatewayState(baseOptions(deps, "foreign-active"));
 
     expect(calls.retireLegacy).not.toHaveBeenCalled();
-    expect(calls.note).not.toHaveBeenCalledWith("  Replacing legacy OpenShell gateway metadata.");
+    expect(calls.note).not.toHaveBeenCalled();
     expect(calls.startGateway).toHaveBeenCalledOnce();
     expect(result.gatewayReuseState).toBe("missing");
   });

--- a/src/lib/onboard/machine/handlers/gateway.test.ts
+++ b/src/lib/onboard/machine/handlers/gateway.test.ts
@@ -566,7 +566,7 @@ describe("handleGatewayState", () => {
     );
   });
 
-  it("replaces legacy metadata before starting the Docker-driver gateway", async () => {
+  it("replaces legacy metadata before starting the managed gateway", async () => {
     const { deps, calls } = createDeps({
       isLinuxDockerDriverGatewayEnabled: vi.fn(() => true),
       reconcileGatewayGpuReuseForGpuIntent: vi.fn(() => "stale" as GatewayReuseState),
@@ -574,15 +574,13 @@ describe("handleGatewayState", () => {
 
     const result = await handleGatewayState(baseOptions(deps, "healthy"));
 
-    expect(calls.note).toHaveBeenCalledWith(
-      "  Replacing legacy OpenShell gateway metadata with Docker-driver gateway.",
-    );
+    expect(calls.note).toHaveBeenCalledWith("  Replacing legacy OpenShell gateway metadata.");
     expect(calls.retireLegacy).toHaveBeenCalledOnce();
     expect(calls.startGateway).toHaveBeenCalledOnce();
     expect(result.gatewayReuseState).toBe("missing");
   });
 
-  it("emits the step [2/8] header before retiring the legacy Docker-driver gateway", async () => {
+  it("emits the step [2/8] header before retiring the legacy gateway", async () => {
     const order: string[] = [];
     const { deps, calls } = createDeps({
       isLinuxDockerDriverGatewayEnabled: vi.fn(() => true),
@@ -601,9 +599,7 @@ describe("handleGatewayState", () => {
     await handleGatewayState(baseOptions(deps, "healthy"));
 
     expect(order).toEqual(["startRecordedStep:gateway", "retireLegacy", "startGateway"]);
-    expect(calls.note).toHaveBeenCalledWith(
-      "  Replacing legacy OpenShell gateway metadata with Docker-driver gateway.",
-    );
+    expect(calls.note).toHaveBeenCalledWith("  Replacing legacy OpenShell gateway metadata.");
   });
 
   it("does not retire a foreign-active Docker-driver gateway (concurrent instances)", async () => {
@@ -615,9 +611,7 @@ describe("handleGatewayState", () => {
     const result = await handleGatewayState(baseOptions(deps, "foreign-active"));
 
     expect(calls.retireLegacy).not.toHaveBeenCalled();
-    expect(calls.note).not.toHaveBeenCalledWith(
-      "  Replacing legacy OpenShell gateway metadata with Docker-driver gateway.",
-    );
+    expect(calls.note).not.toHaveBeenCalledWith("  Replacing legacy OpenShell gateway metadata.");
     expect(calls.startGateway).toHaveBeenCalledOnce();
     expect(result.gatewayReuseState).toBe("missing");
   });

--- a/src/lib/onboard/machine/handlers/gateway.ts
+++ b/src/lib/onboard/machine/handlers/gateway.ts
@@ -259,7 +259,7 @@ async function handleGatewayStatePhase<Gpu>({
       gatewayReuseState !== "missing" &&
       gatewayReuseState !== "foreign-active"
     ) {
-      deps.note("  Replacing legacy OpenShell gateway metadata with Docker-driver gateway.");
+      deps.note("  Replacing legacy OpenShell gateway metadata.");
       deps.retireLegacyGatewayForDockerDriverUpgrade();
       gatewayReuseState = "missing";
     } else if (gatewayReuseState === "foreign-active") {

--- a/test/e2e/live/onboard-resume.test.ts
+++ b/test/e2e/live/onboard-resume.test.ts
@@ -513,7 +513,7 @@ test(
     // still prints phase headings before the resume-skip decisions, so assert
     // the skip evidence and absence of redo-only success strings instead of
     // rejecting headings that now frame the skipped phases.
-    expect(resumeText).not.toContain("Starting OpenShell gateway...");
+    expect(resumeText).not.toMatch(/Starting OpenShell [^\r\n]*gateway/);
     const reconciledExtraProviders = readExtraProviders();
     expect(reconciledExtraProviders).toContain(LIVE_EXTRA_PROVIDER);
     expect(reconciledExtraProviders).not.toContain(STALE_EXTRA_PROVIDER);

--- a/test/e2e/live/onboard-resume.test.ts
+++ b/test/e2e/live/onboard-resume.test.ts
@@ -513,7 +513,7 @@ test(
     // still prints phase headings before the resume-skip decisions, so assert
     // the skip evidence and absence of redo-only success strings instead of
     // rejecting headings that now frame the skipped phases.
-    expect(resumeText).not.toContain("Starting OpenShell Docker-driver gateway...");
+    expect(resumeText).not.toContain("Starting OpenShell gateway...");
     const reconciledExtraProviders = readExtraProviders();
     expect(reconciledExtraProviders).toContain(LIVE_EXTRA_PROVIDER);
     expect(reconciledExtraProviders).not.toContain(STALE_EXTRA_PROVIDER);

--- a/test/e2e/support/hermes-gpu-startup-proof.test.ts
+++ b/test/e2e/support/hermes-gpu-startup-proof.test.ts
@@ -14,7 +14,7 @@ import {
 
 const HEALTHY_NEW_GATEWAY = [
   "Container runtime: docker",
-  "Starting OpenShell Docker-driver gateway...",
+  "Starting OpenShell gateway...",
   "Docker-driver gateway is healthy",
 ].join("\n");
 const NON_FALLBACK_DISCLOSURE_CASES = [

--- a/test/runtime/gateway/gateway-state.test.ts
+++ b/test/runtime/gateway/gateway-state.test.ts
@@ -231,10 +231,11 @@ describe("isGatewayHealthy", () => {
     expect(isGatewayHealthy("", GW_INFO_NAMED, wrongName)).toBe(false);
   });
 
-  it("does not trigger fallback when status is non-empty", () => {
-    // Non-empty status that lacks Connected/Server Status should not fall through to fallback
-    const nonEmptyStatus = "some unexpected output";
-    expect(isGatewayHealthy(nonEmptyStatus, GW_INFO_NAMED, GW_INFO_ACTIVE)).toBe(false);
+  it.each([
+    "Starting OpenShell gateway...",
+    "Starting OpenShell gateway via managed service...",
+  ])("does not treat startup progress as gateway health: %s", (startupMessage) => {
+    expect(isGatewayHealthy(startupMessage, GW_INFO_NAMED, GW_INFO_ACTIVE)).toBe(false);
   });
 
   it("returns false for Disconnected status (regression)", () => {


### PR DESCRIPTION
## Outcome

Shared gateway startup and metadata-replacement messages now say “OpenShell gateway” without incorrectly identifying native Podman as Docker. Preflight continues to identify the selected runtime.

## Reason

The reporter's [instrumented retest](https://github.com/NVIDIA/NemoClaw/issues/11311#issuecomment-5606314096) confirmed successful Podman startup and narrowed the issue to misleading legacy messages. The shared launcher retained Docker wording after it gained native Podman support.

### Related issues

Fixes #11311 in its corrected messaging scope.

## Changes

- Remove the Docker label from standalone startup, managed-service startup, and legacy metadata replacement.
- Update gateway message assertions, the resume test's unwanted-startup check, and the Hermes startup-proof fixture.
- Assert the managed-service startup message in the existing successful-start test. Strengthen the foreign-gateway and resume negative assertions, and check both startup messages as negative health fixtures in the mapped fast suite.

Only three production strings change. No runtime selection, gateway lifecycle, or readiness behavior changes.

## Verification

- `npx vitest run --project cli --project e2e-support src/lib/onboard/machine/handlers/gateway.test.ts src/lib/onboard/docker-driver-gateway-service.test.ts src/lib/onboard/docker-driver-gateway-env.test.ts src/lib/onboard/gateway/late-binding.test.ts test/e2e/support/hermes-gpu-startup-proof.test.ts` — 144 tests passed.
- `npx vitest run --project cli --project integration src/lib/onboard/machine/handlers/gateway.test.ts test/runtime/gateway/gateway-state.test.ts` — 98 tests passed after the review repairs.
- `npx tsx scripts/checks/e2e-mock-parity.mts --base origin/main --head HEAD` — passed.
- `npm run validate:pr` — passed on the repaired commit.
- The diff contains no secrets, API keys, or credentials.
- No live E2E was dispatched manually: the changed contract is terminal wording. The existing live resume assertion was updated to retain its meaning.

## Review notes

Self-review of NVIDIA/NemoClaw commit `5af927bb6f181b35687bd8ce4c4ba3d57ca00c69` covered the changed `src/lib/onboard/**` paths and both E2E test consumers. The three production changes are string replacements; control flow and security checks are unchanged. The diff removes three lines overall. CodeRabbit reviewed this commit with no actionable findings; both earlier review threads are resolved.

The previous detection gap was that gateway tests did not check the managed-service message, while shared startup text still named Docker. This PR adds that assertion and updates the existing metadata and startup-proof coverage. It makes no broader Podman lifecycle qualification claim.

Required CI run [34390148389](https://github.com/NVIDIA/NemoClaw/actions/runs/34390148389) passed 11 CLI shards and failed shard 6 on the inherited plugin cache-seed checksum mismatch. The fast/live parity failure is resolved. The checksum defect is identical on the recorded base and published branch; its canonical fix merged in #11314, superseding #11315. A local dependency refresh passes the 16 checksum/cache tests, but remains unpublished because the validation execution surface changed on canonical main `cad49353438e5ec6fd853eb51a1f6aded84090ff`. The published commit remains `5af927bb6f181b35687bd8ce4c4ba3d57ca00c69`; no CI waiver or broader Podman qualification is claimed.

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Experience**
  * Updated gateway startup and upgrade messages to use consistent, generic OpenShell gateway terminology.
  * Improved lifecycle messaging when legacy gateway metadata is encountered.
* **Bug Fixes**
  * Startup progress messages are no longer treated as an indication that the gateway is healthy.
* **Tests**
  * Expanded coverage for gateway startup messaging, health status handling, resume output, and GPU startup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->