### PR TITLE
test(cli): align version check timeout

### DIFF
--- a/nemoclaw/package-lock.json
+++ b/nemoclaw/package-lock.json
@@ -235,6 +235,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -252,6 +255,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -269,6 +275,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -286,6 +295,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -303,6 +315,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -320,6 +335,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -337,6 +355,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -354,6 +375,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -642,6 +666,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -659,6 +686,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -676,6 +706,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -693,6 +726,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -710,6 +746,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -727,6 +766,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -744,6 +786,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -761,6 +806,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -931,6 +979,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -948,6 +999,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -965,6 +1019,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -982,6 +1039,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -999,6 +1059,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1016,6 +1079,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1669,6 +1735,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1690,6 +1759,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1711,6 +1783,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1732,6 +1807,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/test/agents/openclaw/openclaw-integrity-pin-suite.ts
+++ b/test/agents/openclaw/openclaw-integrity-pin-suite.ts
@@ -7,6 +7,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { lockedArchives } from "../../../scripts/checks/materialize-locked-npm-cache-seed.mts";
 import { parseAuditExceptionRegistry } from "../../../scripts/lib/reviewed-npm-audit.mts";
 import { createBuiltInChannelManifestRegistry } from "../../../src/lib/messaging";
 import { reviewedOpenClawPluginIntegrityByPackageSpec } from "../../../src/lib/messaging/applier/build/messaging-build-applier.mts";
@@ -650,7 +651,6 @@ export type OpenClawIntegrityPinTestGroup = "base" | "contract" | "plugin-instal
 export function registerOpenClawIntegrityPinTests(group: OpenClawIntegrityPinTestGroup): void {
   describe("OpenClaw npm integrity pins", () => {
     if (group === "contract") {
-
       it("keeps NemoClaw's direct tar dependency above the reviewed advisory floor", () => {
         const packageJson = JSON.parse(
           fs.readFileSync(path.join(REPO_ROOT, "nemoclaw", "package.json"), "utf-8"),
@@ -685,6 +685,13 @@ export function registerOpenClawIntegrityPinTests(group: OpenClawIntegrityPinTes
             resolved: PINNED_NEMOCLAW_TAR_TARBALL,
           }),
         );
+        expect(
+          lockedArchives(packageLockSource.toString("utf-8"), {
+            cpu: "x64",
+            libc: "glibc",
+            os: "linux",
+          }).some(({ archive }) => archive.includes("linux-x64-musl")),
+        ).toBe(false);
       });
 
       it("keeps the Teams OpenClaw plugin manifest pinned to the reviewed 2026.7.1 integrity", () => {

--- a/test/package-contract/cli/public-cli-contracts.test.ts
+++ b/test/package-contract/cli/public-cli-contracts.test.ts
@@ -121,7 +121,7 @@ function readCliInvocations(fixture: CliParityFixture): string[] {
 }
 
 describe("public compiled CLI contracts", () => {
-  it("prints the public NemoClaw version prefix (#7616)", () => {
+  it("prints the public NemoClaw version prefix (#7616)", { timeout: 35_000 }, () => {
     const result = spawnSync(process.execPath, [CLI_ENTRYPOINT, "--version"], {
       cwd: REPO_ROOT,
       encoding: "utf-8",

--- a/tools/mcp-tool-discovery-runtime/npm-cache-seed/manifest.json
+++ b/tools/mcp-tool-discovery-runtime/npm-cache-seed/manifest.json
@@ -513,7 +513,7 @@
     }
   ],
   "kind": "nemoclaw-locked-npm-cache-seed-v1",
-  "lockSha256": "66bef669196bb1c61385871e369542d3c321c277adb0f0e2e9f0ad972106b163",
+  "lockSha256": "b068d818f3a685538009e0258c62074a55328b21563d74c172546464259d9cbe",
   "target": {
     "cpu": "x64",
     "libc": "glibc",


### PR DESCRIPTION
## Outcome

The compiled CLI version contract now keeps Vitest alive for the same operation window that it already grants to the child process. Loaded CI runners no longer fail the test at Vitest's unrelated five-second default while the child command is still within its 30-second contract.

## Reason

The test failed at 5.118 seconds in two independent PR runs. Its `spawnSync` call permits 30 seconds, but the enclosing test did not override Vitest's five-second timeout.

### Related issues

Relates to #11173 and #11314.

## Changes

- Set the enclosing version-contract test timeout to 35 seconds, leaving five seconds after the existing 30-second child-process limit for assertions and cleanup.
- Keep the CLI command, production behavior, and child-process timeout unchanged.

## Verification

- `npm run build:cli` — passed.
- `npx vitest run --project package-contract test/package-contract/cli/public-cli-contracts.test.ts -t 'prints the public NemoClaw version prefix'` — passed.
- `npm --prefix nemoclaw run build` — passed.
- `npm run validate:pr` — passed.
- CI reproduction: `build-typecheck` failed at the five-second Vitest boundary in #11314 run 34382895668 and #11173 run 34387070374 while the child process remained inside its 30-second limit.
- The diff contains no secrets, API keys, or credentials.

---

Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded integrity checks to ensure Linux x64/glibc caching excludes incompatible musl archives.
  * Increased the CLI version-prefix contract test timeout to improve reliability.

* **Chores**
  * Updated the npm cache seed integrity checksum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->