### PR TITLE
test(cli): preserve gateway teardown mock exports

### DIFF
--- a/src/lib/actions/sandbox/destroy-gateway-runtime-evidence.test.ts
+++ b/src/lib/actions/sandbox/destroy-gateway-runtime-evidence.test.ts
@@ -19,7 +19,8 @@ vi.mock("node:child_process", () => ({
 vi.mock("../../adapters/docker/volume", () => ({
   dockerRemoveVolumesByPrefix: mocks.dockerRemoveVolumesByPrefix,
 }));
-vi.mock("../../onboard/gateway-teardown-authority", () => ({
+vi.mock("../../onboard/gateway-teardown-authority", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../onboard/gateway-teardown-authority")>()),
   resolveGatewayTeardownAuthority: mocks.resolveGatewayTeardownAuthority,
 }));
 import { cleanupGatewayAfterLastSandbox } from "./destroy-gateway";


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

The gateway runtime-evidence test now preserves the production teardown module's exports while overriding its authority resolver. The test reaches the cleanup behavior it owns instead of failing when the production module adds another export used by `destroy-gateway`.

## Reason

Current `main` deterministically fails this test because its full module mock omits `removeGatewayRegistrationWithPolicy`.

## Changes

- Convert the full gateway teardown authority mock to a partial mock.
- Keep the test-specific `resolveGatewayTeardownAuthority` override.
- Preserve the real registration-removal helper exercised by the cleanup path.

## Verification

- `npx vitest run --project cli src/lib/actions/sandbox/destroy-gateway-runtime-evidence.test.ts` — 1/1 passed after rebasing onto current `main`.
- `npm run check:diff` — passed before commit; normal commit hooks and pre-push CLI typecheck passed.
- GitHub commit verification — commit `9823259eccddc43c3d520cceae03035da87a30e0` is Verified (`valid`).
- Documentation review — no user-facing documentation change is needed because production behavior is unchanged.
- Diff inspection — no secrets, API keys, or credentials.

---
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated gateway teardown test mocking to preserve existing module behavior while overriding the targeted authority resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->