### PR TITLE
test(ci): refresh current main contracts

### DIFF
--- a/test/install/wechat-locked-install.test.ts
+++ b/test/install/wechat-locked-install.test.ts
@@ -123,7 +123,7 @@ printf 'install|%s|offline=%s|peer=%s|cache=%s\n' "$3" "$NPM_CONFIG_OFFLINE" "$N
     executable(
       path.join(tmp, "node"),
       `#!/bin/sh
-printf 'verify|%s|%s|openclaw=%s|offline=%s|cache=%s\n' "$3" "$4" "$5" "$NPM_CONFIG_OFFLINE" "$NPM_CONFIG_CACHE" >> "$TRACE"
+printf 'verify|%s|%s|openclaw=%s|offline=%s|cache=%s\n' "$2" "$3" "$4" "$NPM_CONFIG_OFFLINE" "$NPM_CONFIG_CACHE" >> "$TRACE"
 `,
     );
 

--- a/test/mcp/mcp-tool-discovery-image-contract.test.ts
+++ b/test/mcp/mcp-tool-discovery-image-contract.test.ts
@@ -15,7 +15,7 @@ const repoRoot = path.join(import.meta.dirname, "../..");
 const runtimeRoot = "/usr/local/lib/nemoclaw/mcp-tool-discovery-runtime";
 const managedStartupRuntimeBundle = "managed-startup-image-runtime.bundle";
 const reviewedRuntimeHashOverrides: Readonly<Record<string, string>> = {
-  [managedStartupRuntimeBundle]: "c267456af3ef655f344eea46caa0f23f93b33c88df8b5c290d7fad174346f04c",
+  [managedStartupRuntimeBundle]: "17ac7309b4f830947e0fcf88999c2e7b7e95cd67f880c3f6fccfac0aca2aeb6b",
 };
 const dockerfiles = [
   "Dockerfile",

--- a/test/onboarding/onboard.test.ts
+++ b/test/onboarding/onboard.test.ts
@@ -760,7 +760,7 @@ const { createSandbox } = require(${onboardPath});
         (entry: CommandEntry) =>
           entry.command.includes("forward service my-assistant") &&
           entry.command.includes("--target-port 18789") &&
-          entry.command.includes("--local 0.0.0.0:18789"),
+          entry.command.includes("--local 127.0.0.1:18789"),
       ),
       "expected dashboard forward restore on sandbox reuse",
     );


### PR DESCRIPTION
## Outcome

Restores the three stale integration-test contracts currently failing `main` after the underlying Node-runtime and dashboard-binding changes merged.

## Reason

Current `main` CI run 34398766384 fails shard 6 because the WeChat fake `node` executable still counts a removed Node flag and the reviewed managed-startup bundle hash still pins the pre-regeneration bytes. Shard 4 still expects an external `CHAT_UI_URL` to widen the dashboard listener even though #10931 intentionally made loopback the default.

## Changes

- Read the WeChat verifier arguments from their current positions after removal of the redundant Node flag.
- Pin the SHA-256 of the current reviewed managed-startup runtime bundle.
- Expect the reused dashboard forward to bind `127.0.0.1` without explicit remote-bind opt-in.

## Verification

- `npx vitest run --project integration test/install/wechat-locked-install.test.ts test/mcp/mcp-tool-discovery-image-contract.test.ts test/onboarding/onboard.test.ts` — 69 passed.
- `npm run check:diff` — passed after generating the required local plugin build artifact.
- GitHub check annotations on main run 34398766384 match all three corrected assertions exactly.

## Review notes

This changes tests only; production behavior is unchanged. A documentation-writer review reported `no-docs-needed` because no user-facing contract or workflow changes here.

---

Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated installation verification coverage to reflect revised argument handling.
  - Refreshed the managed startup runtime artifact verification.
  - Updated onboarding coverage to validate dashboard forwarding through the local loopback address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->