### PR TITLE
fix(mcp): refresh reviewed startup runtime digest

### DIFF
--- a/test/mcp/mcp-tool-discovery-image-contract.test.ts
+++ b/test/mcp/mcp-tool-discovery-image-contract.test.ts
@@ -15,7 +15,7 @@ const repoRoot = path.join(import.meta.dirname, "../..");
 const runtimeRoot = "/usr/local/lib/nemoclaw/mcp-tool-discovery-runtime";
 const managedStartupRuntimeBundle = "managed-startup-image-runtime.bundle";
 const reviewedRuntimeHashOverrides: Readonly<Record<string, string>> = {
-  [managedStartupRuntimeBundle]: "c267456af3ef655f344eea46caa0f23f93b33c88df8b5c290d7fad174346f04c",
+  [managedStartupRuntimeBundle]: "17ac7309b4f830947e0fcf88999c2e7b7e95cd67f880c3f6fccfac0aca2aeb6b",
 };
 const dockerfiles = [
   "Dockerfile",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

Restore the reviewed managed startup runtime checksum test after #11317 regenerated its bundle.

## Reason

The bundle lost five redundant Node.js type-stripping flags, but its independent test digest stayed stale. The existing integrity assertion detected the mismatch.

### Related issues

Fixes #11331

## Changes

- Update only the independent expected SHA-256; preserve the bundle and strict equality assertion.
- Verified that #11317's bundle matches its parent after removing exactly five redundant flag arguments; the other three artifact pins pass.
- Overlap: #11173, #11163, and #11251 each replace this bundle and its digest. Their later branch refreshes must retain each PR's own bundle/digest pair.

## Verification

- Contributor validation: Commit hooks and npm run validate:pr passed against the refreshed canonical comparison ref.
- Tests: Focused command: npx --no-install vitest run --project integration test/mcp/mcp-tool-discovery-image-contract.test.ts -t 'pins the reviewed image runtime artifacts exactly': reproduced 1 failure before repair; 4 passed afterward. Complete file: npx --no-install vitest run --project integration test/mcp/mcp-tool-discovery-image-contract.test.ts: 19 passed. Initial sandbox EPERM on the npm cache resolved by running outside the filesystem sandbox. npm run review:local failed during gateway configuration with connection refused and produced no findings; cleanup reported EACCES for temporary review context.
- Secrets review: The diff contains no secrets, API keys, or credentials

---

Signed-off-by: Rebecca Sliter <571084+rsliter@users.noreply.github.com>
