### PR TITLE
fix(images): refresh Hermes probe digest

### DIFF
--- a/agents/hermes/Dockerfile
+++ b/agents/hermes/Dockerfile
@@ -453,7 +453,7 @@ COPY --from=hermes-agent-payload / /
 # published base can carry the expected Hermes version while omitting either
 # optional dependency group. This is a build-time package/import guard; live
 # protocol behavior remains a separate E2E concern.
-ARG NEMOCLAW_HERMES_IMAGE_BUILD_PROBES_SHA256=7c74c3f190845fef222e3aac1bd7074d58968447e78221114344545c149595c2
+ARG NEMOCLAW_HERMES_IMAGE_BUILD_PROBES_SHA256=085fa6866b33295e4efed2a10197d56369d98b25cee1fe0dde7f97e892950cc8
 # hadolint ignore=DL3059,DL4006
 RUN printf '%s  %s\n' \
         "$NEMOCLAW_HERMES_IMAGE_BUILD_PROBES_SHA256" /opt/nemoclaw-hermes-config/image-build-probes.py \
@@ -481,7 +481,7 @@ RUN find /opt/nemoclaw-hermes-config -type d -exec chmod 755 {} + \
 # same-version wheel selected by its lazy installer. Bind that production
 # boundary to NVIDIA/NemoClaw's reviewed wheel hashes.
 ARG NEMOCLAW_HERMES_HINDSIGHT_LAZY_INTEGRITY_PATCH_SHA256=5c619477c10e0b76cffd7adc214cbccf3beb77e7a1121f394c443502d9e0b736
-ARG NEMOCLAW_HERMES_IMAGE_BUILD_PROBES_SHA256=7c74c3f190845fef222e3aac1bd7074d58968447e78221114344545c149595c2
+ARG NEMOCLAW_HERMES_IMAGE_BUILD_PROBES_SHA256=085fa6866b33295e4efed2a10197d56369d98b25cee1fe0dde7f97e892950cc8
 # hadolint ignore=DL4006
 RUN printf '%s  %s\n' \
         "$NEMOCLAW_HERMES_HINDSIGHT_LAZY_INTEGRITY_PATCH_SHA256" /opt/nemoclaw-hermes-config/hindsight-lazy-integrity.patch \

--- a/ci/source-shape-test-budget.json
+++ b/ci/source-shape-test-budget.json
@@ -213,6 +213,11 @@
     },
     {
       "file": "test/agents/hermes/hermes-image-build-probes.test.ts",
+      "test": "binds every image build probe pin to its source digest",
+      "category": "security"
+    },
+    {
+      "file": "test/agents/hermes/hermes-image-build-probes.test.ts",
       "test": "binds the runtime environment validator to its source digest",
       "category": "security"
     },

--- a/test/agents/hermes/hermes-image-build-probes.test.ts
+++ b/test/agents/hermes/hermes-image-build-probes.test.ts
@@ -169,6 +169,29 @@ function runNeutralPlatformProbe(configuration: string) {
 }
 
 describe("Hermes image build probes", () => {
+  // source-shape-contract: security -- Every executed probe must match the reviewed source digest
+  it("binds every image build probe pin to its source digest", () => {
+    const imageDockerfile = fs.readFileSync(
+      path.join(import.meta.dirname, "../../../agents/hermes/Dockerfile"),
+      "utf8",
+    );
+    const imageBuildProbes = fs.readFileSync(
+      path.join(import.meta.dirname, "../../../agents/hermes/image-build-probes.py"),
+    );
+    const digest = createHash("sha256").update(imageBuildProbes).digest("hex");
+    const digestBinding = `ARG NEMOCLAW_HERMES_IMAGE_BUILD_PROBES_SHA256=${digest}`;
+
+    expect(imageDockerfile).toContain(digestBinding);
+    expect(
+      Array.from(
+        imageDockerfile.matchAll(
+          /^ARG NEMOCLAW_HERMES_IMAGE_BUILD_PROBES_SHA256=([0-9a-f]{64})$/gmu,
+        ),
+        (match) => match[1],
+      ),
+    ).toEqual([digest, digest]);
+  });
+
   it("verifies the A2A neutralization patch before root applies it", () => {
     const digest = createHash("sha256").update(a2aNeutralPatch).digest("hex");
     const digestBinding = `ARG NEMOCLAW_HERMES_A2A_NEUTRAL_PATCH_SHA256=${digest}`;


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

Hermes managed-image builds accept the current reviewed image-build probe bytes. A regression test now rejects stale Dockerfile probe pins before image publication.

## Reason

PR #11317 changed `agents/hermes/image-build-probes.py` without refreshing its two Dockerfile SHA-256 pins. Both architecture jobs in the managed-image publisher therefore stopped at the integrity check, which prevented the downstream staging-image workflow from being dispatched.

## Changes

- Update both Hermes image-build probe pins to the current source digest.
- Add a source-shape security contract requiring every Dockerfile pin to match the probe source.
- Register the contract in the source-shape test budget.

## Verification

- Pre-fix targeted test — failed with the current digest `085fa6866b33295e4efed2a10197d56369d98b25cee1fe0dde7f97e892950cc8` versus both stale pins, confirming the regression.
- `node_modules/.bin/vitest run --project integration test/agents/hermes/hermes-image-build-probes.test.ts` — passed, 57 tests.
- `npm run source-shape:check` — passed.
- `npm run test:projects:check` — passed with exact membership across 2,642 candidate files and 7 projects.
- `NODE_OPTIONS=--max-old-space-size=5120 npm run validate:pr` — passed all applicable pre-commit, commit-message, and pre-push checks.
- `gitleaks (secret scan)` — passed as part of `validate:pr`; the diff contains no secrets, API keys, or credentials.

## Review notes

Failure evidence: [NemoClaw E2E job](https://github.com/NVIDIA/NemoClaw/actions/runs/34395295817/job/102613404431) and [managed-image publisher run](https://github.com/NVIDIA/NemoClaw/actions/runs/34394264808).

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Updated the Hermes image-build probe integrity verification to match the current source digest.
  - Added validation ensuring both Dockerfile integrity bindings match the checked-in probe source.
- **Tests**
  - Added coverage confirming exactly two SHA-256 bindings are present and correct.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->