### PR TITLE
fix(hermes): refresh image probe integrity pin

### DIFF
--- a/agents/hermes/Dockerfile
+++ b/agents/hermes/Dockerfile
@@ -453,7 +453,7 @@ COPY --from=hermes-agent-payload / /
 # published base can carry the expected Hermes version while omitting either
 # optional dependency group. This is a build-time package/import guard; live
 # protocol behavior remains a separate E2E concern.
-ARG NEMOCLAW_HERMES_IMAGE_BUILD_PROBES_SHA256=7c74c3f190845fef222e3aac1bd7074d58968447e78221114344545c149595c2
+ARG NEMOCLAW_HERMES_IMAGE_BUILD_PROBES_SHA256=085fa6866b33295e4efed2a10197d56369d98b25cee1fe0dde7f97e892950cc8
 # hadolint ignore=DL3059,DL4006
 RUN printf '%s  %s\n' \
         "$NEMOCLAW_HERMES_IMAGE_BUILD_PROBES_SHA256" /opt/nemoclaw-hermes-config/image-build-probes.py \
@@ -481,7 +481,7 @@ RUN find /opt/nemoclaw-hermes-config -type d -exec chmod 755 {} + \
 # same-version wheel selected by its lazy installer. Bind that production
 # boundary to NVIDIA/NemoClaw's reviewed wheel hashes.
 ARG NEMOCLAW_HERMES_HINDSIGHT_LAZY_INTEGRITY_PATCH_SHA256=5c619477c10e0b76cffd7adc214cbccf3beb77e7a1121f394c443502d9e0b736
-ARG NEMOCLAW_HERMES_IMAGE_BUILD_PROBES_SHA256=7c74c3f190845fef222e3aac1bd7074d58968447e78221114344545c149595c2
+ARG NEMOCLAW_HERMES_IMAGE_BUILD_PROBES_SHA256=085fa6866b33295e4efed2a10197d56369d98b25cee1fe0dde7f97e892950cc8
 # hadolint ignore=DL4006
 RUN printf '%s  %s\n' \
         "$NEMOCLAW_HERMES_HINDSIGHT_LAZY_INTEGRITY_PATCH_SHA256" /opt/nemoclaw-hermes-config/hindsight-lazy-integrity.patch \

--- a/test/agents/hermes/hermes-image-build-probes.test.ts
+++ b/test/agents/hermes/hermes-image-build-probes.test.ts
@@ -169,6 +169,15 @@ function runNeutralPlatformProbe(configuration: string) {
 }
 
 describe("Hermes image build probes", () => {
+  it("binds every image build probe stage to the reviewed source digest", () => {
+    const digest = createHash("sha256").update(fs.readFileSync(probes)).digest("hex");
+    const bindings = [
+      ...dockerfile.matchAll(/ARG NEMOCLAW_HERMES_IMAGE_BUILD_PROBES_SHA256=([a-f0-9]{64})/g),
+    ].map((match) => match[1]);
+
+    expect(bindings).toEqual([digest, digest]);
+  });
+
   it("verifies the A2A neutralization patch before root applies it", () => {
     const digest = createHash("sha256").update(a2aNeutralPatch).digest("hex");
     const digestBinding = `ARG NEMOCLAW_HERMES_A2A_NEUTRAL_PATCH_SHA256=${digest}`;


### PR DESCRIPTION
## Outcome

Hermes sandbox images can verify and run the current reviewed image-build probe source. A focused regression test now rejects stale probe digests before image-build CI.

## Reason

PR #11317 changed `agents/hermes/image-build-probes.py` without updating its two Dockerfile digest bindings. Both Hermes image jobs on main run 34398766384 stopped at the fail-closed digest check.

### Related issues

Refs #10791

## Changes

- Update both Hermes image stages to the SHA-256 digest of the current probe source.
- Verify that every probe digest binding matches the reviewed source bytes.

## Verification

- `npx vitest run --project integration test/agents/hermes/hermes-image-build-probes.test.ts` — 57 passed.
- `npm run validate:pr` — passed against main commit `ae5b2ca922023120f90e23242c133c774ae30aa0`.
- GitHub commit verification — commit `605ba00d990c538a7c088deffc6a728da38ef4b3` is Verified.
- Secret scan — the diff contains no secrets, API keys, or credentials.

## Review notes

`agents/hermes/Dockerfile` is a contributor-sensitive path. A self-review of NVIDIA/NemoClaw commit `605ba00d990c538a7c088deffc6a728da38ef4b3` covered the complete Dockerfile and regression-test diff and found no additional change. A documentation writer review found no user-visible documentation impact. Independent maintainer review remains required.

---

Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>
