### PR TITLE
feat(ci): promote Deep Agents Code managed image pointers

### DIFF
--- a/.github/workflows/managed-images.yaml
+++ b/.github/workflows/managed-images.yaml
@@ -3023,9 +3023,10 @@ jobs:
 
           # Record the intended root pointers for every shipped agent in its
           # exact contract. They are not moved until all v2 evidence artifacts
-          # are durable. Hermes ships alongside OpenClaw (#11228); Deep Agents
-          # Code stays cohort-only until its own publication decision.
-          shipped_agents=(openclaw hermes)
+          # are durable. Hermes ships alongside OpenClaw (#11228), and Deep
+          # Agents Code alongside both (#11341), matching
+          # SHIPPED_MANAGED_IMAGE_AGENTS in src/lib/onboard/managed-image.
+          shipped_agents=(openclaw hermes langchain-deepagents-code)
           release_tag="$(jq -r '.[0].release // empty' "$CANDIDATE_SET")"
 
           while IFS= read -r candidate; do
@@ -3269,12 +3270,14 @@ jobs:
             exit 1
           fi
           cohort="$PUBLICATION_COHORT"
-          # Root pointers move for every shipped agent: OpenClaw and, per
-          # #11228, Hermes. Deep Agents Code stays cohort-only. Every shipped
-          # agent's contract and exact cohort bytes are validated before any
-          # pointer moves. A registry failure can leave an earlier agent's
-          # pointers moved; rerunning this job reconciles them to this cohort.
-          shipped_agents=(openclaw hermes)
+          # Root pointers move for every shipped agent: OpenClaw, Hermes
+          # (#11228), and Deep Agents Code (#11341), matching
+          # SHIPPED_MANAGED_IMAGE_AGENTS in src/lib/onboard/managed-image.
+          # Every shipped agent's contract and exact cohort bytes are validated
+          # before any pointer moves. A registry failure can leave an earlier
+          # agent's pointers moved; rerunning this job reconciles them to this
+          # cohort.
+          shipped_agents=(openclaw hermes langchain-deepagents-code)
           release_tag="$(jq -r '.source.release // empty' "$cohort_contract")"
           if [[ ! "$GITHUB_SHA" =~ ^[0-9a-f]{40}$ ]]; then
             echo "ERROR: durable managed image pointer identity is invalid." >&2
@@ -3319,7 +3322,7 @@ jobs:
             expected_digest="$(jq -er --arg agent "$agent" '.agents[$agent].digest' "$cohort_contract")"
             expected_size="$(jq -er --arg agent "$agent" '.agents[$agent].descriptor.size | tostring' "$cohort_contract")"
             if [ "$image" != "ghcr.io/nvidia/nemoclaw/${agent}-sandbox" ] ||
-               [[ ! "$exact_reference" =~ ^ghcr\.io/nvidia/nemoclaw/(openclaw|hermes)-sandbox@sha256:[0-9a-f]{64}$ ]] ||
+               [[ ! "$exact_reference" =~ ^ghcr\.io/nvidia/nemoclaw/(openclaw|hermes|langchain-deepagents-code)-sandbox@sha256:[0-9a-f]{64}$ ]] ||
                [ "${exact_reference%@*}" != "$image" ]; then
               echo "ERROR: durable managed image pointer identity is invalid for ${agent}." >&2
               exit 1

--- a/docs/get-started/quickstart-langchain-deepagents-code.mdx
+++ b/docs/get-started/quickstart-langchain-deepagents-code.mdx
@@ -70,6 +70,8 @@ If you use the coding-agent prompt in the preceding section, you can skip this p
     If registry or catalog availability prevents resolution, stock onboarding stops before sandbox creation and does not build a shipped Dockerfile.
     Invalid or inconsistent catalog evidence fails closed before sandbox creation.
     An explicit `nemo-deepagents onboard --from <Dockerfile>` remains a separate custom-image path.
+    Start a custom Dockerfile from the published complete image, `FROM ghcr.io/nvidia/nemoclaw/langchain-deepagents-code-sandbox@sha256:<digest>`, which already carries every managed Deep Agents Code layer.
+    Releases publish that image with `:<release>` and `:<revision>` tags alongside `openclaw-sandbox` and `hermes-sandbox`; pin the digest rather than a tag so rebuilds stay reproducible.
 
   </Step>
 

--- a/test/inference/managed/managed-image-publication-promotion.test.ts
+++ b/test/inference/managed/managed-image-publication-promotion.test.ts
@@ -52,7 +52,7 @@ function expectedReceipt(cohort: string, receiptAttempt: number): Record<string,
 }
 
 describe("managed-image publication promotion", () => {
-  it("stages all multi-platform cohort aliases before moving the shipped root pointers (#7744, #11228)", () => {
+  it("stages all multi-platform cohort aliases before moving the shipped root pointers (#7744, #11228, #11341)", () => {
     const promotion = required(
       step(
         managedPromoter(readWorkflow("managed-images.yaml")),
@@ -77,6 +77,7 @@ describe("managed-image publication promotion", () => {
     expect(failedCalls).toContain(`openclaw-sandbox:cohort-${cohort}`);
     expect(failedCalls).not.toContain(`openclaw-sandbox:${revision}`);
     expect(failedCalls).not.toContain(`hermes-sandbox:${revision}`);
+    expect(failedCalls).not.toContain(`langchain-deepagents-code-sandbox:${revision}`);
 
     const accepted = runManagedImagePromotion(promotion, "", pointer);
     const acceptedCalls = accepted.calls.join("\n");
@@ -97,6 +98,7 @@ describe("managed-image publication promotion", () => {
     );
     const rootPointer = acceptedCalls.indexOf(`openclaw-sandbox:${revision}`);
     const hermesPointer = acceptedCalls.indexOf(`hermes-sandbox:${revision}`);
+    const dcodePointer = acceptedCalls.indexOf(`langchain-deepagents-code-sandbox:${revision}`);
 
     expect(accepted.calls.filter((call) => call.startsWith("pull ")).sort()).toEqual(
       expectedPullCalls.sort(),
@@ -110,10 +112,10 @@ describe("managed-image publication promotion", () => {
     });
     expect(lastCohortStage).toBeGreaterThanOrEqual(0);
     expect(rootPointer).toBeGreaterThan(lastCohortStage);
-    // Hermes ships its root pointer alongside OpenClaw (#11228); Deep Agents
-    // Code stays cohort-only.
+    // Every shipped agent's root pointer moves only after all cohort aliases
+    // stage: Hermes per #11228, Deep Agents Code per #11341.
     expect(hermesPointer).toBeGreaterThan(lastCohortStage);
-    expect(acceptedCalls).not.toContain(`langchain-deepagents-code-sandbox:${revision}`);
+    expect(dcodePointer).toBeGreaterThan(lastCohortStage);
     expect(Object.keys(accepted.platformContracts).sort()).toEqual(
       publicationAgents
         .flatMap((agent) => publicationPlatforms.map((platform) => `${agent}|${platform}`))

--- a/test/inference/managed/managed-image-publication-workflow.test.ts
+++ b/test/inference/managed/managed-image-publication-workflow.test.ts
@@ -1254,12 +1254,12 @@ fi
     expect(promotion.run).toContain('"${descriptor_args[@]}"');
     expect(promotion.run).toContain('cmp -s "$expected_descriptors" "$actual_descriptors"');
     expect(promotion.run).toContain(') == ["linux/amd64", "linux/arm64"]');
-    expect(promotion.run).toContain("shipped_agents=(openclaw hermes)");
+    expect(promotion.run).toContain("shipped_agents=(openclaw hermes langchain-deepagents-code)");
     expect(promotion.run).toContain(
       'aliases+=("$(jq -r \'.image\' <<<"$cohort_manifest"):${GITHUB_SHA}")',
     );
     expect(promotion.run).not.toContain('imagetools create "${consumer_tag_args[@]}"');
-    expect(pointer.run).toContain("shipped_agents=(openclaw hermes)");
+    expect(pointer.run).toContain("shipped_agents=(openclaw hermes langchain-deepagents-code)");
     expect(pointer.run).toContain(
       "exact_reference=\"$(jq -er --arg agent \"$agent\" '.agents[$agent].reference'",
     );


### PR DESCRIPTION
## Summary

Publishes the complete Deep Agents Code managed image (`ghcr.io/nvidia/nemoclaw/langchain-deepagents-code-sandbox`) with `:<revision>` and `:<release>` consumer pointers, alongside `openclaw-sandbox` and `hermes-sandbox` (#11228/#11298), from the promote lane that already builds and stages it.

Resolves #11341.

## Related Issue

#11341 — filed with the product-scope fields (ownership, validation plan, compatibility, security) this PR implements. Follows the same pattern as #11228 → #11298 for Hermes.

## What already existed vs what changes

- The six-candidate barrier already builds, validates, attests, stages, and anonymously pull-proves the Deep Agents Code cohort on both architectures; the durable cohort contract already records it.
- **Stock Deep Agents Code onboarding is already buildless by exact digest** — the quickstart states stock onboarding "normally uses the release's exact managed-image digest."
- `SHIPPED_MANAGED_IMAGE_AGENTS` in `src/lib/onboard/managed-image/contract.ts` already names `langchain-deepagents-code` a shipped agent (only `pi` is a candidate).
- The only gap was the consumer pointers: all 370 registry tags are `cohort-ghrun-*` or buildcache — nothing a downstream `nemo-deepagents onboard --from` Dockerfile can `FROM` by name. This PR closes that, and with it the inconsistency that the workflow's pointer set was narrower than the source contract's shipped-agent list.

## Changes

- `.github/workflows/managed-images.yaml`: `shipped_agents=(openclaw hermes)` → `(openclaw hermes langchain-deepagents-code)` at both the staging (alias-recording) and pointer-promotion sites; the exact-reference repository pattern widened accordingly; comments point at #11341 and the source contract, and preserve the post-#11332 registry-failure reconciliation note.
- `test/inference/managed/managed-image-publication-promotion.test.ts`: proves the Deep Agents Code pointer moves only after all cohort aliases stage, and that a failed barrier moves no pointer for any agent.
- `test/inference/managed/managed-image-publication-workflow.test.ts`: source-shape assertions follow the three-agent list.
- `docs/get-started/quickstart-langchain-deepagents-code.mdx`: the custom-image path documents `FROM ghcr.io/nvidia/nemoclaw/langchain-deepagents-code-sandbox@sha256:<digest>` with digest pinning.

## Type of Change

- [x] Code change with doc updates

## Quality Gates

- [x] Tests added or updated for changed behavior
- [x] Docs updated for user-facing behavior changes
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — **requesting maintainer review**, same rationale as #11298: widens *what is published* (one more already-validated artifact gains consumer tags), not *how* — barrier ordering and fail-closed validations unchanged, applied per shipped agent before any pointer moves.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer:

## Documentation Writer Review

- [ ] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: stating plainly the subagent was **not** run; happy to run it if maintainers require the receipt.
- Agent: Claude Code

## Verification

- `npx vitest run test/inference/managed/managed-image-publication-promotion.test.ts test/inference/managed/managed-image-publication-workflow.test.ts` — **39 passed** (these suites execute the actual workflow bash against a recording fake docker).
- Workflow YAML parses; `npm run checks:repository` passes; `docs:sync-agent-variants` up to date.
- `markdownlint-cli2` reports one MD046 finding in the quickstart at a fenced block **outside this diff** — reproduced identically on clean `main` (line 245 there); not introduced here.
- **Not verified: a live promote run** — same constraint as #11298; the first post-merge release completes #11341's validation plan (`docker manifest inspect …:<release>`, buildless `--from` onboard, activation e2e against the published tag).

---

Signed-off-by: Zac Wang <zacw@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added LangChain Deep Agents Code to the shipped managed sandbox images.
  - Deep Agents Code images now support cohort, release, revision, and digest-based references.
  - Promotion and validation workflows now include Deep Agents Code alongside OpenClaw and Hermes.

- **Documentation**
  - Updated the quickstart guide with instructions for using the pinned Deep Agents Code sandbox image.
  - Documented the corresponding release and revision tags for custom Dockerfiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->