### PR TITLE
perf(test): run isolated parameterized fixtures concurrently

### DIFF
--- a/test/e2e/support/e2e-redaction-entry.test.ts
+++ b/test/e2e/support/e2e-redaction-entry.test.ts
@@ -317,7 +317,7 @@ describe("fixture redaction entry point", () => {
     expect(out).not.toContain(canonical);
   });
 
-  it.each([
+  it.concurrent.each([
     { scenario: "hosted inference key" },
     { scenario: "Docker token" },
     { scenario: "gateway token" },

--- a/test/e2e/support/portable-profile-systemctl-shim.test.ts
+++ b/test/e2e/support/portable-profile-systemctl-shim.test.ts
@@ -952,7 +952,7 @@ describe("portable profile systemctl fixture", () => {
     },
   );
 
-  it.each([
+  it.concurrent.each([
     { scenario: "activator PID" },
     { scenario: "service PID" },
     { scenario: "public socket" },
@@ -1048,7 +1048,7 @@ describe("portable profile systemctl fixture", () => {
     },
   );
 
-  it.each([
+  it.concurrent.each([
     { scenario: "activator PID" },
     { scenario: "service PID" },
     { scenario: "public socket" },


### PR DESCRIPTION
## Outcome

Run three parameterized E2E support groups concurrently: portable systemctl restart coordination, process/socket cleanup, and artifact secret redaction. The groups retain their existing assertions and per-case resources.

## Reason

These isolated fixtures spend time awaiting subprocesses and I/O. Serial scheduling delays independent cases. Three paired local measurements showed median group savings of 1.36 seconds, 0.48 seconds, and 36 milliseconds, respectively. These are local measurements without coverage; CI elapsed savings depend on shard scheduling.

## Changes

- Add `concurrent` to the three `it.each` registrations in two test files.
- Each case owns its temporary directory and resources; fixture cleanup remains scoped to that case.

## Verification

- `npx vitest run --project e2e-support test/e2e/support/portable-profile-systemctl-shim.test.ts test/e2e/support/e2e-redaction-entry.test.ts --maxWorkers=1` — 80 tests passed.
- `npx vitest run --project e2e-support test/e2e/support/portable-profile-systemctl-shim.test.ts test/e2e/support/e2e-redaction-entry.test.ts --maxWorkers=1 --maxConcurrency=2 --sequence.shuffle.tests --sequence.seed=9355` — 80 tests passed.
- `npm run validate:pr` — passed (pre-commit, commit-message, and pre-push checks).
- Self-review: inspected fixture directories, sockets, process ownership, explicit child environments, and cleanup for cross-case interference. Adjacent groups with shared resources or no measured gain retain serial scheduling.
- The diff contains no secrets, API keys, or credentials.

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved end-to-end test execution speed by running selected scenario and fixture tests concurrently.
  - Preserved existing test coverage for artifact redaction, systemctl restart behavior, socket races, and cleanup handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->