### PR TITLE
test(openshell): avoid worker PID collision

### DIFF
--- a/src/lib/adapters/openshell/forward-service.test.ts
+++ b/src/lib/adapters/openshell/forward-service.test.ts
@@ -42,6 +42,7 @@ const target: ForwardServiceTarget = {
 };
 
 const ownerTarget: ForwardServiceTarget = { ...target, executable: process.execPath };
+const detachedChildPid = process.pid + 1;
 const temporaryDirectories: string[] = [];
 const startedProcessGroups: number[] = [];
 const processSleepBuffer = new Int32Array(new SharedArrayBuffer(4));
@@ -304,7 +305,7 @@ describe("OpenShell forward service", () => {
   });
 
   it("terminates a detached service that does not bind before the deadline", () => {
-    const child = { pid: 4_321, unref: vi.fn() };
+    const child = { pid: detachedChildPid, unref: vi.fn() };
     const terminateProcessTree = vi.fn();
 
     expect(() =>
@@ -326,7 +327,7 @@ describe("OpenShell forward service", () => {
     expect(() =>
       launchForwardService(target, {
         isReachable: () => false,
-        spawnDetached: () => ({ pid: 4_321, unref: vi.fn() }),
+        spawnDetached: () => ({ pid: detachedChildPid, unref: vi.fn() }),
         terminateProcessTree: () => {
           throw cleanupError;
         },
@@ -347,7 +348,7 @@ describe("OpenShell forward service", () => {
     const signalProcess = vi.fn();
 
     terminateForwardServiceProcessTree(
-      { pid: 4_321, unref: vi.fn() },
+      { pid: detachedChildPid, unref: vi.fn() },
       {
         platform: "linux",
         processGroupHasRunnableMember: () => false,
@@ -355,7 +356,7 @@ describe("OpenShell forward service", () => {
       },
     );
 
-    expect(signalProcess).toHaveBeenCalledWith(-4_321, "SIGKILL");
+    expect(signalProcess).toHaveBeenCalledWith(-detachedChildPid, "SIGKILL");
   });
 
   it("fails closed when POSIX process-group settlement is not proved", () => {
@@ -365,7 +366,7 @@ describe("OpenShell forward service", () => {
     expect(() =>
       launchForwardService(target, {
         isReachable: () => false,
-        spawnDetached: () => ({ pid: 4_321, unref: vi.fn() }),
+        spawnDetached: () => ({ pid: detachedChildPid, unref: vi.fn() }),
         terminateProcessTree: (child) =>
           terminateForwardServiceProcessTree(child, {
             now,
@@ -377,7 +378,7 @@ describe("OpenShell forward service", () => {
         timeoutMs: 0,
       }),
     ).toThrow(expect.objectContaining({ name: ForwardServiceStartupCleanupError.name }));
-    expect(signalProcess).toHaveBeenCalledWith(-4_321, "SIGKILL");
+    expect(signalProcess).toHaveBeenCalledWith(-detachedChildPid, "SIGKILL");
   });
 
   it("resolves Windows taskkill from SystemRoot while PATH is poisoned", () => {
@@ -386,7 +387,7 @@ describe("OpenShell forward service", () => {
     const trustedTaskkill = "C:\\Windows\\System32\\taskkill.exe";
 
     terminateForwardServiceProcessTree(
-      { pid: 4_321, unref: vi.fn() },
+      { pid: detachedChildPid, unref: vi.fn() },
       {
         environment: {
           PATH: "C:\\attacker-controlled",
@@ -399,7 +400,12 @@ describe("OpenShell forward service", () => {
       },
     );
 
-    expect(taskkill).toHaveBeenCalledWith(trustedTaskkill, ["/PID", "4321", "/T", "/F"]);
+    expect(taskkill).toHaveBeenCalledWith(trustedTaskkill, [
+      "/PID",
+      String(detachedChildPid),
+      "/T",
+      "/F",
+    ]);
     expect(signalProcess).not.toHaveBeenCalled();
   });
 
@@ -421,7 +427,7 @@ describe("OpenShell forward service", () => {
 
     expect(() =>
       terminateForwardServiceProcessTree(
-        { pid: 4_321, unref: vi.fn() },
+        { pid: detachedChildPid, unref: vi.fn() },
         {
           environment: {
             PATH: "C:\\attacker-controlled",
@@ -443,7 +449,7 @@ describe("OpenShell forward service", () => {
 
       expect(() =>
         terminateForwardServiceProcessTree(
-          { pid: 4_321, unref: vi.fn() },
+          { pid: detachedChildPid, unref: vi.fn() },
           {
             environment: {
               PATH: "C:\\attacker-controlled",
@@ -464,7 +470,7 @@ describe("OpenShell forward service", () => {
 
     expect(() =>
       terminateForwardServiceProcessTree(
-        { pid: 4_321, unref: vi.fn() },
+        { pid: detachedChildPid, unref: vi.fn() },
         {
           environment: { SystemRoot: "C:\\Windows" },
           isTrustedTaskkillExecutable: () => true,


### PR DESCRIPTION
## Outcome

OpenShell forward-service process-tree tests now always use a synthetic child PID distinct from the Vitest worker. This prevents the tests from rejecting their own fixture when CI assigns the worker PID 4321.

## Reason

PR #11296 exposed the collision in `cli-test-shards (11)`: the worker received PID 4321, matching the hard-coded detached-child fixture, so production safety validation correctly reported that the child PID was unavailable.

### Related issues

Relates to #11296

## Changes

- Derive the synthetic detached-child PID from the current worker PID.
- Update POSIX signal and Windows taskkill assertions to use the derived PID.

## Verification

- `CI=true ./node_modules/.bin/vitest run --project cli src/lib/adapters/openshell/forward-service.test.ts --coverage=false` — 25 tests passed.
- `npm run test:changed` — 45 growth-guardrail tests and 25 affected CLI tests passed.
- `npm run validate:pr` — pre-commit, commit-message, and pre-push checks passed after building the required generated artifacts.
- Reviewed the one-file diff; it contains no secrets, API keys, or credentials.

## Review notes

This is a test-only fixture correction. It does not change production behavior and does not require DGX hardware validation.

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated service termination tests to use dynamically determined child process identifiers.
  * Improved coverage for POSIX process-group termination and Windows task termination scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->