### PR TITLE
fix(test): preserve async subprocess error contract

### DIFF
--- a/test/helpers/onboard-child-process-harness.ts
+++ b/test/helpers/onboard-child-process-harness.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { spawnSync } from "node:child_process";
+import { execFile, spawnSync } from "node:child_process";
 import path from "node:path";
 import {
   createHostProcessWorkspace,
@@ -113,6 +113,37 @@ export function runOnboardProcess(
     stderr,
     output: `${stdout}\n${stderr}`,
   };
+}
+
+/** Runs `node <argv...>` asynchronously so isolated fixtures can run concurrently. */
+export function runOnboardProcessAsync(
+  argv: readonly string[],
+  options: RunOnboardProcessOptions,
+): Promise<OnboardProcessResult> {
+  return new Promise((resolve) => {
+    const child = execFile(
+      process.execPath,
+      [...argv],
+      {
+        cwd: options.cwd ?? testRepoRoot,
+        encoding: "utf-8",
+        env: options.env,
+        ...(options.timeoutMs === undefined ? {} : { timeout: options.timeoutMs }),
+        ...(options.killSignal === undefined ? {} : { killSignal: options.killSignal }),
+      },
+      (error, stdout, stderr) => {
+        resolve({
+          status: error ? (typeof error.code === "number" ? error.code : null) : 0,
+          signal: error?.signal ?? null,
+          error: error ?? undefined,
+          stdout,
+          stderr,
+          output: `${stdout}\n${stderr}`,
+        });
+      },
+    );
+    child.stdin?.end(options.input);
+  });
 }
 
 /** Runs a generated onboarding script with a bounded hard-kill timeout. */

--- a/test/helpers/onboard-child-process-harness.ts
+++ b/test/helpers/onboard-child-process-harness.ts
@@ -135,7 +135,7 @@ export function runOnboardProcessAsync(
         resolve({
           status: error ? (typeof error.code === "number" ? error.code : null) : 0,
           signal: error?.signal ?? null,
-          error: error ?? undefined,
+          error: error && typeof error.code !== "number" ? error : undefined,
           stdout,
           stderr,
           output: `${stdout}\n${stderr}`,

--- a/test/onboarding/onboard-reservation-recreate.test.ts
+++ b/test/onboarding/onboard-reservation-recreate.test.ts
@@ -7,7 +7,7 @@ import path from "node:path";
 import { describe, it, onTestFinished } from "vitest";
 import {
   createOnboardProcessWorkspace,
-  runOnboardProcess,
+  runOnboardProcessAsync,
   trailingJsonPayload,
   workspaceEnv,
 } from "../helpers/onboard-child-process-harness";
@@ -25,7 +25,7 @@ const managedWorkloadOnboardPath = JSON.stringify(
 );
 
 describe("onboard sandbox recreate reservation safety", () => {
-  it.each([
+  it.concurrent.each([
     {
       name: "preserves a current-session pending route reservation across a not-ready recreate",
       reservationSessionId: "session-owner",
@@ -307,7 +307,7 @@ const { createSandbox } = require(${onboardPath});
 `;
       fs.writeFileSync(scriptPath, script);
 
-      const result = runOnboardProcess([scriptPath], {
+      const result = await runOnboardProcessAsync([scriptPath], {
         env: workspaceEnv(workspace, {
           NEMOCLAW_NON_INTERACTIVE: "1",
           NEMOCLAW_TEST_MANAGED_IMAGE_CATALOG: "1",
@@ -363,7 +363,7 @@ const { createSandbox } = require(${onboardPath});
     },
   );
 
-  it.each([
+  it.concurrent.each([
     { scenario: "same-session", resumes: true },
     { scenario: "foreign-reservation", resumes: false },
     { scenario: "changed-checkpoint", resumes: false },
@@ -672,7 +672,7 @@ createArgs[16] = async () => {
         NEMOCLAW_SANDBOX_PREBUILD: "1",
       });
 
-      const first = runOnboardProcess([scriptPath, "seed", scenario], {
+      const first = await runOnboardProcessAsync([scriptPath, "seed", scenario], {
         env,
         timeoutMs: 40_000,
       });
@@ -699,7 +699,7 @@ createArgs[16] = async () => {
         retained.registryEntry.lifecycleLiveIdentityFingerprint,
       );
 
-      const second = runOnboardProcess([scriptPath, "resume", scenario], {
+      const second = await runOnboardProcessAsync([scriptPath, "resume", scenario], {
         env,
         timeoutMs: 40_000,
       });

--- a/test/onboarding/onboard-reservation-recreate.test.ts
+++ b/test/onboarding/onboard-reservation-recreate.test.ts
@@ -323,6 +323,7 @@ const { createSandbox } = require(${onboardPath});
           result.error?.message ||
           "onboarding subprocess returned an unexpected status",
       );
+      assert.equal(result.error, undefined, "a completed child exit is not a spawn error");
       const payload = trailingJsonPayload<{
         sandboxName: string | null;
         error?: string;


### PR DESCRIPTION
## Outcome

Completed child processes with non-zero exit codes now keep the async onboarding helper's existing result contract: the numeric code is returned through `status`, while `error` remains reserved for launch and execution failures.

## Reason

Node's `execFile` callback reports a normal non-zero child exit as an `Error`. The synchronous helper reports the same completed exit through `status` with no `error`, so the new async helper from #11351 could make callers misclassify an expected CLI failure as a spawn failure.

### Related issues

Follow-up to #11351.

## Changes

- Clear `error` when `execFile` supplies a numeric exit code, while retaining the code in `status`.
- Assert that the reservation suite's expected non-zero child exit is not exposed as a spawn error.

The async helper's dedicated tests already cover successful exits, numeric non-zero exits, launch failures, timeouts, cancellation, and output limits. The added consumer assertion locks the error/status distinction at the real onboarding call site.

## Verification

- `npx vitest run --project integration test/helpers/onboard-child-process-harness.test.ts test/onboarding/onboard-reservation-recreate.test.ts --reporter=verbose` — 13/13 passed on the current PR head.
- `npx biome check test/helpers/onboard-child-process-harness.ts test/helpers/onboard-child-process-harness.test.ts test/onboarding/onboard-reservation-recreate.test.ts` — passed.
- `npm run typecheck:cli` — passed.
- Normal pre-commit, commit-msg, and pre-push hooks passed on the contributor commits; GitHub marks every PR commit Verified.
- Documentation review — no docs change needed; production behavior, CLI output, configuration, and supported contracts are unchanged.
- Diff contains no secrets, API keys, or credentials.

## Review notes

This is the two-line contract follow-up identified during automated review. #11351 already owns the reservation-suite speedup. This PR does not change production code.

---
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>
