### PR TITLE
fix(installer): bound stalled OpenShell downloads

### DIFF
--- a/scripts/install-openshell.sh
+++ b/scripts/install-openshell.sh
@@ -1025,7 +1025,9 @@ download_with_curl() {
     curl_progress=(-sS)
   fi
   for name in "${ASSETS[@]}" "${CHECKSUM_FILES[@]}"; do
-    curl -fL "${curl_progress[@]}" "https://github.com/NVIDIA/OpenShell/releases/download/${RELEASE_TAG}/$name" \
+    curl -fL "${curl_progress[@]}" --connect-timeout 10 --retry 3 --retry-delay 2 \
+      --speed-limit 1024 --speed-time 60 \
+      "https://github.com/NVIDIA/OpenShell/releases/download/${RELEASE_TAG}/$name" \
       -o "$tmpdir/$name"
   done
 }

--- a/test/installer-integration/install-openshell-version-check.test.ts
+++ b/test/installer-integration/install-openshell-version-check.test.ts
@@ -943,7 +943,7 @@ exit 1`,
     }
   });
 
-  it("downloads and verifies every Linux arm64 release asset during reinstall", () => {
+  it("bounds stalled Linux arm64 release downloads and verifies every asset (#11281)", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-openshell-linux-arm64-assets-"));
     try {
       const fakeBin = path.join(tmp, "bin");
@@ -1053,7 +1053,7 @@ chmod 755 "$dest"`,
 
       expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
       const downloads = fs.readFileSync(downloadLog, "utf8");
-      expect(downloads).toContain("openshell-aarch64-unknown-linux-musl.tar.gz");
+      expect(downloads.match(/^(?!.*--(?:max-time|retry-all-errors)\b).*--connect-timeout 10 --retry 3 --retry-delay 2 --speed-limit 1024 --speed-time 60 /gm)).toHaveLength(6);
       expect(downloads).toContain("openshell-gateway-aarch64-unknown-linux-gnu.tar.gz");
       expect(downloads).toContain("openshell-sandbox-aarch64-unknown-linux-gnu.tar.gz");
       expect(fs.readFileSync(checksumLog, "utf8").trim().split("\n")).toEqual([


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

OpenShell release-asset downloads now retry transient failures and stop when a connection cannot be established or transfer progress stalls. Previously, the curl fallback could wait indefinitely on a stalled connection.

## Reason

The installer downloads multiple release archives and checksum files. Its curl path had no connection or low-speed bound, so a broken network transfer could hang installation without reaching the existing failure handling.

### Related issues

Fixes #11281

## Changes

- Add a 10-second connection timeout, three retries with a two-second delay, and a 1 KiB/s-for-60-seconds low-speed abort to `download_with_curl`, which serves both the no-`gh` path and the failed-`gh` fallback.
- Keep permanent HTTP failures terminal and omit a fixed total deadline so large, progressing release downloads can finish.
- Extend the existing Linux arm64 installer-process test to verify the policy on all six release-asset and checksum downloads.

## Verification

- Focused regression test before the production change — failed because the logged curl command lacked `--connect-timeout 10`.
- `npx vitest run --project installer-integration test/installer-integration/install-openshell-version-check.test.ts` — 40 passed, 1 skipped.
- `npm run test:changed` — 45 growth-guardrail tests passed; no changed CLI, plugin, or E2E-support tests were selected.
- `npm run checks:repository` — passed.
- `npm run format:check` and `git diff --check` — passed.
- `npm run validate:pr` — passed against canonical `origin/main` at `6f5c9ac408f19f324ad55f00c01dc0099b939178`.
- Normal pre-commit, commit-message, and pre-push hooks — passed.
- GitHub commit verification — `ba07f7dae348edea5e82533ec718f4897994794a` is `Verified` with reason `valid`.
- Documentation writer review — PASS (`no-docs-needed`) on `ba07f7dae3` with root `AGENTS.md` blob `8e614171d435fceee2f8d3d8eee00c26f74b9eae`.
- The diff contains no secrets, API keys, or credentials.

## Review notes

- `scripts/install-openshell.sh` matches the canonical contributor sensitive-path pattern `scripts/**`. Routine private cross-review of repository `nvidia/nemoclaw` at `ba07f7dae348edea5e82533ec718f4897994794a` by Claude reported no findings.
- `--retry-all-errors` is intentionally omitted so permanent HTTP errors remain terminal. `--max-time` is intentionally omitted so large downloads that continue making progress do not fail on a fixed total deadline.
- AI assistance: Codex selected, implemented, tested, and prepared the change; Claude performed the independent private review; a separate Codex documentation-writer subagent reviewed the exact head.

---
<!-- DCO sign-off is required in this PR description. Every commit must appear as Verified in GitHub. -->
<!-- documentation-writer-review
result: PASS
reviewed-head: ba07f7dae348edea5e82533ec718f4897994794a
agents-blob: 8e614171d435fceee2f8d3d8eee00c26f74b9eae
agent-surface: Codex Desktop documentation-writer subagent
-->
Signed-off-by: harjoth <harjoth.khara@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release asset downloads with connection and transfer timeouts, retry handling, and minimum speed requirements.
  * Helps prevent downloads from stalling indefinitely.

* **Tests**
  * Expanded Linux arm64 download coverage to verify stalled-download safeguards across all release assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->