### PR TITLE
fix(docs): preserve accumulated post-merge updates

### DIFF
--- a/.agents/skills/nemoclaw-contributor-update-docs/SKILL.md
+++ b/.agents/skills/nemoclaw-contributor-update-docs/SKILL.md
@@ -19,6 +19,10 @@ documentation task, use the commit range supplied by the user or current checkou
 
 Release-entry completion belongs to `nemoclaw-maintainer-evening`, not this workflow.
 
+For an existing managed draft, extend its staged changes after the workflow merges them with `main`.
+Preserve previous documentation changes unless current source and tests justify a revision or removal.
+The independent reviewer checks those revisions against the previous draft commit.
+
 ## Load current authority
 
 Follow [Discover the Current Implementation](../_shared/implementation-discovery.md).

--- a/.github/workflows/post-merge-docs.yaml
+++ b/.github/workflows/post-merge-docs.yaml
@@ -23,29 +23,26 @@ jobs:
       pull-requests: read
     outputs:
       automate: ${{ steps.scan.outputs.automate }}
+      previous_sha: ${{ steps.scan.outputs.previous_sha }}
     steps:
       - id: scan
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          owner="$(
+          selection="$(
             gh api --paginate "repos/$GITHUB_REPOSITORY/pulls?state=open&base=main&per_page=100" |
               jq --slurp -r '
                 [.[][] | select((.head.ref | test("^automation/post-merge-docs-[0-9a-f]{12}$")) and .head.repo.full_name == "NVIDIA/NemoClaw")] |
-                if length > 1 then "invalid"
-                elif length == 0 or .[0].draft == true then "automation"
-                elif .[0].draft == false then "maintainer"
-                else "invalid"
-                end
+                if length > 1 then error("multiple managed documentation PRs are open")
+                elif length == 0 then {automate: true, previous_sha: ""}
+                elif (.[0].draft | type) == "boolean" and (.[0].head.sha | test("^[0-9a-f]{40}$"))
+                  then {automate: .[0].draft, previous_sha: .[0].head.sha}
+                else error("invalid managed documentation PR")
+                end | to_entries[] | "\(.key)=\(.value)"
               '
           )"
-          [[ "$owner" == "automation" || "$owner" == "maintainer" ]]
-          if [[ "$owner" == "automation" ]]; then
-            echo "automate=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "automate=false" >> "$GITHUB_OUTPUT"
-          fi
+          printf '%s\n' "$selection" >> "$GITHUB_OUTPUT"
 
   author:
     name: Docs / Author and review documentation catch-up
@@ -61,6 +58,7 @@ jobs:
       OPENSHELL_GATEWAY_ENDPOINT: http://127.0.0.1:8080
       PI_IMAGE: ghcr.io/nvidia/openshell-community/sandboxes/pi@sha256:00d0c5e9e733f94f6db3eaa2ab70d4fd75bcc4aace6b13a54535cbf2dd20dfcd
       POST_MERGE_DOCS_CONFIG_DIR: ${{ github.workspace }}/config
+      POST_MERGE_DOCS_PREVIOUS_SHA: ${{ needs.gate.outputs.previous_sha }}
       TRUSTED_CHECKOUT: ${{ github.workspace }}/trusted
     steps:
       - name: Checkout exact main commit

--- a/test/generation/post-merge-docs.test.ts
+++ b/test/generation/post-merge-docs.test.ts
@@ -7,6 +7,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { parse } from "yaml";
 
 import { nextPatchReleaseTag } from "../../tools/post-merge-docs/contract.mts";
 import { publishDocumentation, type Request } from "../../tools/post-merge-docs/publish.mts";
@@ -94,7 +95,7 @@ function emptyFixture() {
   return { finalTree: mainTree, mainSha, patch: Buffer.alloc(0), source };
 }
 type Fixture = ReturnType<typeof fixture>;
-function artifact(value: Fixture): string {
+function artifact(value: Fixture, previousSha = ""): string {
   const directory = temporary("docs-artifact");
   fs.writeFileSync(path.join(directory, "docs.patch"), value.patch);
   fs.writeFileSync(
@@ -103,10 +104,11 @@ function artifact(value: Fixture): string {
       mainSha: value.mainSha,
       outcome: "approved",
       patchSha256: createHash("sha256").update(value.patch).digest("hex"),
+      previousSha,
       rangeStartTag,
       repository,
       targetReleaseTag,
-      version: 2,
+      version: 3,
     }),
   );
   return directory;
@@ -118,7 +120,6 @@ class FakeGitHub {
   openPulls: Array<ReturnType<FakeGitHub["pull"]>> = [];
   readonly branch: string;
   readonly commitSha = "c".repeat(40);
-  readonly existingSha = "b".repeat(40);
   readonly initialParent = "a".repeat(40);
   readonly partialSha = "d".repeat(40);
   readonly commits = new Map<string, Record<string, unknown>>();
@@ -132,7 +133,10 @@ class FakeGitHub {
       head: { ...pull.head, sha: headSha },
     }));
   };
-  constructor(readonly value: Fixture) {
+  constructor(
+    readonly value: Fixture,
+    readonly existingSha = "b".repeat(40),
+  ) {
     this.branch = `automation/post-merge-docs-${value.mainSha.slice(0, 12)}`;
     this.liveSha = value.mainSha;
   }
@@ -315,7 +319,11 @@ class FakeGitHub {
     }
   });
 }
-function publish(value: Fixture, api: FakeGitHub, approved = artifact(value)) {
+function publish(
+  value: Fixture,
+  api: FakeGitHub,
+  approved = artifact(value, api.openPulls[0]?.head.sha),
+) {
   return publishDocumentation({
     artifactDirectory: approved,
     expectedMainSha: value.mainSha,
@@ -360,6 +368,7 @@ function runnerFixture(phase: "author" | "review", startTag = rangeStartTag) {
       POST_MERGE_DOCS_CANDIDATE_DIR: candidate,
       POST_MERGE_DOCS_CONFIG_DIR: path.join(root, "config"),
       POST_MERGE_DOCS_PHASE: phase,
+      POST_MERGE_DOCS_PREVIOUS_SHA: "",
       POST_MERGE_DOCS_WORKDIR: path.join(root, "work"),
       RANGE_START_SHA: mainSha,
       RANGE_START_TAG: startTag,
@@ -379,6 +388,8 @@ function runnerTools(
   const sandbox = path.join(root, "sandbox");
   const output = path.join(root, "work/output");
   const state = {
+    author: (repository: string) =>
+      fs.writeFileSync(path.join(repository, "docs/guide.mdx"), "authored\n"),
     agentArgs: [] as readonly string[],
     createArgs: [] as readonly string[],
     deleted: false,
@@ -392,7 +403,7 @@ function runnerTools(
     agent: (args) => {
       state.agentArgs = args;
       const agents = {
-        author: () => fs.writeFileSync(path.join(sandbox, "docs/guide.mdx"), "authored\n"),
+        author: () => state.author(sandbox),
         review: () => {
           const reports = {
             approved: () => undefined,
@@ -420,7 +431,10 @@ function runnerTools(
       fs.copyFileSync(path.join(output, name), path.join(args[4], name));
     },
     list: () => env.SANDBOX_NAME,
-    delete: () => (state.deleted = true),
+    delete: () => {
+      fs.rmSync(sandbox, { recursive: true, force: true });
+      state.deleted = true;
+    },
   };
   const commands: Record<string, string> = { bash: "export", node: "agent" };
   const run: OpenShellTools["run"] = (_command, args, options) => {
@@ -446,6 +460,58 @@ afterEach(() => {
   vi.unstubAllEnvs();
   for (const directory of directories.splice(0))
     fs.rmSync(directory, { force: true, recursive: true });
+});
+
+function selection(pulls: unknown[]) {
+  const workflow = parse(
+    fs.readFileSync(
+      new URL("../../.github/workflows/post-merge-docs.yaml", import.meta.url),
+      "utf8",
+    ),
+  );
+  const root = temporary("docs-selection");
+  const fixture = path.join(root, "pulls.json");
+  const output = path.join(root, "output");
+  fs.writeFileSync(fixture, JSON.stringify(pulls));
+  const run = () =>
+    execFileSync(
+      "bash",
+      ["-c", `gh() { cat "$PULLS_FIXTURE"; }\n${workflow.jobs.gate.steps[0].run}`],
+      {
+        env: {
+          ...process.env,
+          GITHUB_REPOSITORY: repository,
+          GITHUB_OUTPUT: output,
+          PULLS_FIXTURE: fixture,
+        },
+        stdio: "pipe",
+      },
+    );
+  return { run, output };
+}
+
+describe("post-merge documentation selection", () => {
+  it.each(["absent", "draft", "ready"])(
+    "selects the draft baseline when PR state is %s",
+    (state) => {
+      const api = new FakeGitHub(emptyFixture());
+      api.installActive();
+      const pull = api.openPulls[0]!;
+      pull.draft = state !== "ready";
+      const { run, output } = selection(state === "absent" ? [] : [pull]);
+      run();
+      expect(fs.readFileSync(output, "utf8")).toBe(
+        `automate=${state !== "ready"}\nprevious_sha=${state === "absent" ? "" : api.existingSha}\n`,
+      );
+    },
+  );
+  it("stops selection when multiple managed PRs are open", () => {
+    const api = new FakeGitHub(emptyFixture());
+    api.installActive();
+    const { run, output } = selection([...api.openPulls, ...api.openPulls]);
+    expect(run).toThrow();
+    expect(fs.existsSync(output)).toBe(false);
+  });
 });
 
 describe("post-merge documentation publisher", () => {
@@ -536,6 +602,29 @@ describe("post-merge documentation publisher", () => {
     expect(api.branchRef?.object.sha).toBe(api.existingSha);
     expect(writeCount(api)).toBe(0);
   });
+  it.each(["changed", "closed", "appeared"])(
+    "rejects publication when the draft %s after authoring started",
+    async (change) => {
+      const value = fixture();
+      const api = new FakeGitHub(value);
+      api.installActive();
+      const previousSha = change === "appeared" ? "" : api.existingSha;
+      const approved = artifact(value, previousSha);
+      const changes = {
+        closed: () => {
+          api.openPulls = [];
+        },
+        changed: () => api.projectPullHead(api.partialSha),
+        appeared: () => undefined,
+      };
+      changes[change as keyof typeof changes]();
+      await expect(publish(value, api, approved)).rejects.toThrow(
+        "draft changed after authoring started",
+      );
+      expect(writeCount(api)).toBe(0);
+      expect(api.branchRef?.object.sha).toBe(api.existingSha);
+    },
+  );
   it("rejects a patch whose digest was not approved", async () => {
     const value = emptyFixture();
     const approved = artifact(value);
@@ -797,6 +886,107 @@ describe("post-merge documentation publisher", () => {
 });
 
 describe("post-merge documentation runner", () => {
+  it.each(["New guidance.\n", ""])(
+    "preserves the previous draft when the author appends %j",
+    async (additionalText) => {
+      const input = runnerFixture("author");
+      const source = input.env.TRUSTED_CHECKOUT;
+      git(source, ["checkout", "-b", "draft", input.env.GITHUB_SHA]);
+      fs.writeFileSync(path.join(source, "docs/previous.mdx"), "Previously reviewed guidance.\n");
+      git(source, ["add", "."]);
+      git(source, ["commit", "-m", "docs: previous draft"]);
+      input.env.POST_MERGE_DOCS_PREVIOUS_SHA = git(source, ["rev-parse", "HEAD"]);
+      git(source, ["checkout", "main"]);
+      input.env.GITHUB_SHA = git(source, ["rev-parse", "HEAD"]);
+      const { state, tools } = runnerTools(input);
+      state.author = (repository) => {
+        expect(fs.readFileSync(path.join(repository, "docs/previous.mdx"), "utf8")).toBe(
+          "Previously reviewed guidance.\n",
+        );
+        expect(fs.readFileSync(path.join(repository, "docs/guide.mdx"), "utf8")).toBe("later\n");
+        fs.appendFileSync(path.join(repository, "docs/guide.mdx"), additionalText);
+      };
+      executePostMergeDocs(input.env, tools);
+      const patch = fs.readFileSync(path.join(input.root, "artifact/docs.patch"), "utf8");
+      expect(patch).toContain("+Previously reviewed guidance.");
+      expect(patch.includes("+New guidance.")).toBe(Boolean(additionalText));
+      expect(fs.readFileSync(path.join(input.root, "work/repo/docs/previous.mdx"), "utf8")).toBe(
+        "Previously reviewed guidance.\n",
+      );
+      const value: Fixture = {
+        finalTree: git(path.join(input.root, "work/repo"), ["write-tree"]),
+        mainSha: input.env.GITHUB_SHA,
+        patch: Buffer.from(patch),
+        source,
+      };
+      input.env.POST_MERGE_DOCS_PHASE = "review";
+      input.env.POST_MERGE_DOCS_CANDIDATE_DIR = input.env.POST_MERGE_DOCS_ARTIFACT_DIR;
+      input.env.POST_MERGE_DOCS_ARTIFACT_DIR = path.join(input.root, "approved");
+      executePostMergeDocs(input.env, runnerTools(input).tools);
+      const api = new FakeGitHub(value, input.env.POST_MERGE_DOCS_PREVIOUS_SHA);
+      api.installActive();
+      await expect(publish(value, api, input.env.POST_MERGE_DOCS_ARTIFACT_DIR)).rejects.toThrow(
+        "Documentation remains pending",
+      );
+      expect(api.commitBodies[0]).toMatchObject({
+        parents: [input.env.POST_MERGE_DOCS_PREVIOUS_SHA, input.env.GITHUB_SHA],
+        tree: value.finalTree,
+      });
+    },
+  );
+
+  it("stops before authoring when the draft conflicts with newer main changes", () => {
+    const input = runnerFixture("author");
+    const source = input.env.TRUSTED_CHECKOUT;
+    git(source, ["checkout", "-b", "draft", input.env.GITHUB_SHA]);
+    fs.writeFileSync(path.join(source, "docs/guide.mdx"), "Previous draft guidance.\n");
+    git(source, ["commit", "-am", "docs: previous draft"]);
+    input.env.POST_MERGE_DOCS_PREVIOUS_SHA = git(source, ["rev-parse", "HEAD"]);
+    git(source, ["checkout", "main"]);
+    input.env.GITHUB_SHA = git(source, ["rev-parse", "HEAD"]);
+    const { tools } = runnerTools(input);
+    expect(() => executePostMergeDocs(input.env, tools)).toThrow();
+    expect(tools.run).not.toHaveBeenCalled();
+    expect(fs.existsSync(path.join(input.root, "artifact/docs.patch"))).toBe(false);
+  });
+
+  it("preserves separate main and draft edits to the same page", () => {
+    const input = runnerFixture("author");
+    const source = input.env.TRUSTED_CHECKOUT;
+    const file = path.join(source, "docs/guide.mdx");
+    const original = "Introduction\n\nA\nB\nC\nD\nE\nF\nG\nH\n\nConclusion\n";
+    fs.writeFileSync(file, original);
+    git(source, ["commit", "-am", "docs: initialize shared page"]);
+    git(source, ["checkout", "-b", "draft"]);
+    fs.writeFileSync(file, original.replace("Introduction", "Reviewed introduction"));
+    git(source, ["commit", "-am", "docs: previous draft"]);
+    input.env.POST_MERGE_DOCS_PREVIOUS_SHA = git(source, ["rev-parse", "HEAD"]);
+    git(source, ["checkout", "main"]);
+    fs.writeFileSync(file, original.replace("Conclusion", "Updated conclusion on main"));
+    git(source, ["commit", "-am", "docs: advance main"]);
+    input.env.GITHUB_SHA = git(source, ["rev-parse", "HEAD"]);
+    const { state, tools } = runnerTools(input);
+    state.author = () => undefined;
+    executePostMergeDocs(input.env, tools);
+    expect(fs.readFileSync(path.join(input.root, "work/repo/docs/guide.mdx"), "utf8")).toBe(
+      original
+        .replace("Introduction", "Reviewed introduction")
+        .replace("Conclusion", "Updated conclusion on main"),
+    );
+  });
+
+  it("rejects code changes in the draft before creating a sandbox", () => {
+    const input = runnerFixture("author");
+    const source = input.env.TRUSTED_CHECKOUT;
+    fs.writeFileSync(path.join(source, "unrelated.ts"), "throw new Error('untrusted');\n");
+    git(source, ["add", "."]);
+    git(source, ["commit", "-m", "fix: change code"]);
+    input.env.POST_MERGE_DOCS_PREVIOUS_SHA = git(source, ["rev-parse", "HEAD"]);
+    const { tools } = runnerTools(input);
+    expect(() => executePostMergeDocs(input.env, tools)).toThrow("unsupported path: unrelated.ts");
+    expect(tools.run).not.toHaveBeenCalled();
+  });
+
   it("enables bind mounts before creating a reviewer sandbox", async () => {
     const input = runnerFixture("review");
     const responses = new Map([["which", "/trusted/bin/openshell-sandbox"]]);
@@ -869,10 +1059,11 @@ describe("post-merge documentation runner", () => {
       mainSha: input.env.GITHUB_SHA,
       outcome: "approved",
       patchSha256: createHash("sha256").update("").digest("hex"),
+      previousSha: "",
       rangeStartTag,
       repository,
       targetReleaseTag,
-      version: 2,
+      version: 3,
     });
   });
   it("produces and accepts an exact release target above the safe-integer range", async () => {

--- a/tools/post-merge-docs/README.md
+++ b/tools/post-merge-docs/README.md
@@ -5,6 +5,11 @@
 
 This directory owns the trusted authoring and publishing boundary for `Docs / Author Post-Merge Catch-Up`.
 
+Each refresh merges the selected draft commit with the triggering `main` commit before authoring.
+The author extends those staged documentation changes. The reviewer checks the combined patch and
+compares revisions or removals with the previous draft. A merge conflict stops the run for maintainer
+resolution. Publication stops if the managed draft changed after selection.
+
 Repository administrators retain the `POST_MERGE_DOCS_API_KEY` Actions secret until rotation or
 removal. GitHub exposes it only to the author job's `Configure isolated inference` step. Hosted-runner
 cleanup removes the gateway runtime copy. Sandboxes, artifacts, and the publisher do not receive the

--- a/tools/post-merge-docs/publish.mts
+++ b/tools/post-merge-docs/publish.mts
@@ -57,6 +57,7 @@ function sha(value: string, name: string): string {
 }
 type Approval = {
   patch: Buffer;
+  previousSha: string;
   rangeStartTag: string;
   targetReleaseTag: string;
 };
@@ -74,12 +75,14 @@ function approvedPatch(directory: string, repository: string, mainSha: string): 
   const review = value as Record<string, unknown>;
   if (
     Object.keys(review).sort().join() !==
-      "mainSha,outcome,patchSha256,rangeStartTag,repository,targetReleaseTag,version" ||
-    review.version !== 2 ||
+      "mainSha,outcome,patchSha256,previousSha,rangeStartTag,repository,targetReleaseTag,version" ||
+    review.version !== 3 ||
     review.repository !== repository ||
     review.mainSha !== mainSha ||
     review.patchSha256 !== createHash("sha256").update(patch).digest("hex") ||
     review.outcome !== "approved" ||
+    typeof review.previousSha !== "string" ||
+    (review.previousSha !== "" && !SHA.test(review.previousSha)) ||
     typeof review.rangeStartTag !== "string" ||
     typeof review.targetReleaseTag !== "string" ||
     nextPatchReleaseTag(
@@ -90,6 +93,7 @@ function approvedPatch(directory: string, repository: string, mainSha: string): 
     fail("review does not approve the exact patch and release target for this main commit");
   return {
     patch,
+    previousSha: review.previousSha,
     rangeStartTag: review.rangeStartTag,
     targetReleaseTag: review.targetReleaseTag,
   };
@@ -482,6 +486,8 @@ export async function publishDocumentation(input: {
   const title = pullTitle(target);
   const active = await checkpoint(repository, mainSha, request);
   if (active && !active.draft) return;
+  if ((active?.head.sha ?? "") !== approval.previousSha)
+    fail("managed documentation draft changed after authoring started");
   const temporary = fs.mkdtempSync(path.join(tmpdir(), "nemoclaw-docs-publish-"));
   try {
     const destination = path.join(temporary, "repository");

--- a/tools/post-merge-docs/run.mts
+++ b/tools/post-merge-docs/run.mts
@@ -58,6 +58,12 @@ function exactSha(value: string | undefined, name: string): string {
   return SHA.test(sha) ? sha : fail(`${name} must be a full commit SHA`);
 }
 
+function previousSha(env: NodeJS.ProcessEnv): string {
+  return env.POST_MERGE_DOCS_PREVIOUS_SHA
+    ? exactSha(env.POST_MERGE_DOCS_PREVIOUS_SHA, "POST_MERGE_DOCS_PREVIOUS_SHA")
+    : "";
+}
+
 function git(repository: string, args: readonly string[]): string {
   return execFileSync("git", ["-C", repository, ...args], {
     encoding: "utf8",
@@ -134,10 +140,15 @@ function prompt(env: NodeJS.ProcessEnv, current: Phase): string {
   const main = exactSha(env.GITHUB_SHA, "GITHUB_SHA");
   const rules =
     "Read AGENTS.md, WRITING.md, docs/AGENTS.md, docs/CONTRIBUTING.md, .agents/skills/nemoclaw-contributor-update-docs/SKILL.md, and .agents/skills/_shared/documentation-writing-review.md.";
+  const previous = previousSha(env);
+  const continuity = previous
+    ? `The staged changes include the draft at ${previous} merged with main. Preserve its documentation. Check every revision or removal against current source and tests.`
+    : "";
   if (current === "review") {
     return [
       `Independently review documentation coverage for ${range}..${main}.`,
       rules,
+      continuity,
       "Inspect the committed range and staged candidate. Do not edit the repository.",
       "Approve only if it completely and accurately covers user-visible changes, follows DORI and writing rules, and makes no unsupported claim.",
       "An empty patch is valid only when no documentation update is needed.",
@@ -149,6 +160,8 @@ function prompt(env: NodeJS.ProcessEnv, current: Phase): string {
   return [
     `Update NemoClaw documentation for committed changes from ${tag} (${range}) through ${main}.`,
     rules,
+    continuity,
+    "Extend the staged documentation changes. Do not regenerate the draft from scratch.",
     `Inspect git history and git diff ${range}..${main}, then verify behavior in source and tests.`,
     "Update only public docs/ files, fern/docs.yml, or files under fern/assets/.",
     "Do not change fern/fern.config.json, docs/_build, dependencies, or code.",
@@ -159,7 +172,17 @@ function prompt(env: NodeJS.ProcessEnv, current: Phase): string {
 function prepare(env: NodeJS.ProcessEnv): void {
   const current = phase(env);
   const repository = prepareRepository(env);
-  if (current === "review") applyPatch(repository, patchPath(env));
+  const main = exactSha(env.GITHUB_SHA, "GITHUB_SHA");
+  const previous = previousSha(env);
+  if (previous) {
+    const merged = git(repository, ["merge-tree", "--write-tree", main, previous]);
+    git(repository, ["read-tree", "--reset", "-u", exactSha(merged, "merged draft tree")]);
+    validateCandidate(repository);
+  }
+  if (current === "review") {
+    git(repository, ["read-tree", "--reset", "-u", main]);
+    applyPatch(repository, patchPath(env));
+  }
   const output = path.join(
     required(env.POST_MERGE_DOCS_WORKDIR, "POST_MERGE_DOCS_WORKDIR"),
     "output",
@@ -316,10 +339,12 @@ function exportArtifact(env: NodeJS.ProcessEnv, tools: OpenShellTools): void {
     const patch = download(env, PATCH_FILE, tools);
     const file = path.join(artifact, PATCH_FILE);
     write(file, patch);
-    applyPatch(
-      path.join(required(env.POST_MERGE_DOCS_WORKDIR, "POST_MERGE_DOCS_WORKDIR"), "repo"),
-      file,
+    const repository = path.join(
+      required(env.POST_MERGE_DOCS_WORKDIR, "POST_MERGE_DOCS_WORKDIR"),
+      "repo",
     );
+    git(repository, ["read-tree", "--reset", "-u", exactSha(env.GITHUB_SHA, "GITHUB_SHA")]);
+    applyPatch(repository, file);
     return;
   }
   const decision = download(env, "decision.json", tools).toString("utf8").trim();
@@ -337,13 +362,14 @@ function exportArtifact(env: NodeJS.ProcessEnv, tools: OpenShellTools): void {
       mainSha: exactSha(env.GITHUB_SHA, "GITHUB_SHA"),
       outcome: "approved",
       patchSha256: createHash("sha256").update(patch).digest("hex"),
+      previousSha: previousSha(env),
       rangeStartTag: required(env.RANGE_START_TAG, "RANGE_START_TAG"),
       repository: required(env.GITHUB_REPOSITORY, "GITHUB_REPOSITORY"),
       targetReleaseTag: nextPatchReleaseTag(
         required(env.RANGE_START_TAG, "RANGE_START_TAG"),
         "RANGE_START_TAG cannot produce a release target",
       ),
-      version: 2,
+      version: 3,
     })}\n`,
   );
 }


### PR DESCRIPTION
## Outcome

Post-merge documentation refreshes now extend the existing draft after merging it with the triggering `main` commit. Earlier documentation edits remain in the candidate when a later authoring run adds no new changes.

## Reason

The workflow previously started each authoring run from clean `main`. The publisher retained earlier bot commits as parents but replaced their content with the newly generated patch. In [PR #11277](https://github.com/NVIDIA/NemoClaw/pull/11277), a later refresh dropped the rootless Docker socket guidance added by the first commit.

## Changes

- Capture the selected draft commit and use Git's three-way merge to carry its documentation into the authoring workspace. Stop before authoring if the merge conflicts or introduces unsupported paths.
- Ask the author and independent reviewer to preserve the prior draft and justify revisions or removals against current source and tests.
- Bind review approval to the selected draft commit. Reject publication if that draft changes, closes, or appears after authoring starts.
- Extend regression coverage through selection, authoring, review, and publication, including no-new-edit runs and separate edits to the same page.

This fixes future accumulation. Recovery of content already overwritten in past documentation PRs is separate work.

## Verification

- `npx vitest run --project integration test/generation/post-merge-docs.test.ts` — 63 tests passed. The preservation and conflict regressions failed before the implementation change.
- `npm run build:cli` and `npm --prefix nemoclaw run build` — passed.
- `node --max-old-space-size=8192 node_modules/typescript/bin/tsc -p tsconfig.cli.json` — passed; the default heap was insufficient for the full repository type check.
- `NODE_OPTIONS=--max-old-space-size=8192 npm run validate:pr` — passed against canonical `main` at `6f5c9ac408f19f324ad55f00c01dc0099b939178`.
- `git diff --check` and the pre-commit secret scan — passed. The diff contains no secrets, API keys, or credentials.
- Live GitHub Actions and OpenShell execution remain for CI; local tests use real Git repositories with simulated sandbox and GitHub boundaries.

## Review notes

Self-review covered the complete NVIDIA/NemoClaw candidate `1932dfc241eca732ec1c7ca0941ec49785c12f4f`, including the sensitive paths `.github/workflows/post-merge-docs.yaml` and `.agents/skills/nemoclaw-contributor-update-docs/SKILL.md`. It checked draft preservation, documentation path restrictions, credential isolation, review binding, and concurrent publication behavior. No blocker was found in that self-review. Independent review of these paths is pending; this PR is a draft and claims no maintainer approval or waiver.

---
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the post-merge documentation workflow to preserve and merge existing draft changes with the latest main branch.
  * Added guidance for resolving merge conflicts and documenting revisions or removals.
  * Improved review documentation by comparing updates with the previous draft.

* **Bug Fixes**
  * Added safeguards to prevent publication when a managed draft changes during authoring or review.
  * Improved validation for draft selection, conflicting changes, and unsupported updates.

* **Tests**
  * Expanded coverage for draft preservation, merging, concurrency, conflict handling, and cleanup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->