### PR TITLE
ci(typecheck): give CLI type checking a 5 GiB heap

### DIFF
--- a/.github/actions/ci-build-typecheck/action.yaml
+++ b/.github/actions/ci-build-typecheck/action.yaml
@@ -15,6 +15,8 @@ runs:
 
     - name: Typecheck CLI + tests
       shell: bash
+      env:
+        NODE_OPTIONS: --max-old-space-size=5120
       run: npm run typecheck:cli
 
     - name: Typecheck plugin tests


### PR DESCRIPTION
## Outcome

The shared CLI and test type-check step receives a 5 GiB JavaScript heap. This gives the current TypeScript program enough memory to finish instead of aborting near the default 4 GiB limit.

## Reason

The [build-typecheck job on #11353](https://github.com/NVIDIA/NemoClaw/actions/runs/34424271617/job/102706461224) passed all 1,299 package-contract tests, then aborted during `npm run typecheck:cli` with `JavaScript heap out of memory` and exit 134.

## Changes

Set `NODE_OPTIONS: --max-old-space-size=5120` on `Typecheck CLI + tests` in `.github/actions/ci-build-typecheck/action.yaml`. Both PR and main CI use this shared action. The value matches the existing CLI heap remediation in `scripts/dev-setup.sh`.

## Verification

- Node.js 22.23.1 reproduction on the original failing compiler inputs: `--max-old-space-size=4096` reproduced exit 134; `--max-old-space-size=5120` passed and reported `Memory used: 4356061K`.
- Executed the changed YAML step's command and environment under Node.js 22.23.1 on this branch — `npm run typecheck:cli` passed.
- `npx vitest run --project integration test/automation/pull-requests/pr-workflow-contract.test.ts` — all 44 tests passed.
- `npm run validate:pr` — passed against canonical base `a4265abfc2e46922100baff0ba8f5985b681cf69`, with unchanged local validator sources and executables.
- `git diff --check` and secret scans — passed. The diff contains no secrets, API keys, or credentials.

## Review notes

Self-reviewed NVIDIA/NemoClaw commit `35bc9934af317cff2cdc0ea7da0310f64986676f` and the changed `.github/actions/ci-build-typecheck/action.yaml` against both callers, the existing setup remediation, and the executed type-check result. No actionable finding. Independent review of this sensitive path is pending; this PR is a draft.

PR CI loads this action from its base commit. This PR's CI can still encounter the old heap limit until the shared action change lands on `main`. The local execution above exercises the proposed setting directly.

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the memory available to CLI and test type-checking workflows, improving reliability for larger builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->