### PR TITLE
fix(e2e): align Launchable NVIDIA provider configuration

### DIFF
--- a/.agents/skills/nemoclaw-maintainer-e2e/SKILL.md
+++ b/.agents/skills/nemoclaw-maintainer-e2e/SKILL.md
@@ -44,8 +44,9 @@ results before it succeeds:
 - `NEMOCLAW_IMAGE_DISPATCH_TOKEN` is exposed as `GH_TOKEN` only to the trusted host script. It
   grants Actions read/write access to `brevdev/nemoclaw-image` for workflow dispatch, run inspection,
   and artifact download.
-- `NVIDIA_INFERENCE_API_KEY` is exported into the Brev guest for the full E2E process. Code in the
-  baked candidate checkout can read and use it.
+- `NVIDIA_API_KEY` supplies the public NVIDIA endpoint credential. The workflow exports it as
+  `NVIDIA_INFERENCE_API_KEY` into the Brev guest for full E2E. Code in the baked candidate checkout
+  can read and use it.
 
 `brev login` writes `BREV_API_KEY` and `BREV_ORG_ID` to `$HOME/.brev/credentials.json` on the
 GitHub-hosted runner. Later trusted steps and processes in that job can read the file. The workflow

--- a/.agents/skills/nemoclaw-maintainer-e2e/references/main-runs.md
+++ b/.agents/skills/nemoclaw-maintainer-e2e/references/main-runs.md
@@ -44,8 +44,9 @@ Before dispatch:
 
 `Staging Brev Launchable` uses `BREV_API_KEY` and `BREV_ORG_ID` during trusted host
 preparation. It exposes `NEMOCLAW_IMAGE_DISPATCH_TOKEN` only to the trusted host script as
-`GH_TOKEN`. It exports `NVIDIA_INFERENCE_API_KEY` into the Brev guest for full E2E. Candidate code in
-that guest can read the inference key. The workflow requires repository `maintain` or `admin`
+`GH_TOKEN`. It exports the public `NVIDIA_API_KEY` secret as `NVIDIA_INFERENCE_API_KEY` into the Brev
+guest for full E2E. Candidate code in that guest can read the inference key.
+The workflow requires repository `maintain` or `admin`
 permission before source checkout. If cleanup fails, remove the recorded workspace. Rotate or revoke
 credentials that may remain accessible.
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2628,7 +2628,7 @@ jobs:
         env:
           BREV_LAUNCHABLE_ID: ${{ vars.NEMOCLAW_STAGING_LAUNCHABLE_ID }}
           GH_TOKEN: ${{ github.repository == 'NVIDIA/NemoClaw' && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && secrets.NEMOCLAW_IMAGE_DISPATCH_TOKEN || '' }}
-          NVIDIA_INFERENCE_API_KEY: ${{ github.repository == 'NVIDIA/NemoClaw' && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && secrets.NVIDIA_INFERENCE_API_KEY || '' }}
+          NVIDIA_INFERENCE_API_KEY: ${{ github.repository == 'NVIDIA/NemoClaw' && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && secrets.NVIDIA_API_KEY || '' }}
           WORK_DIR: ${{ steps.workspace.outputs.work_dir }}
         run: tools/e2e/brev-launchable-e2e.sh
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1421,8 +1421,10 @@ The job reads these credentials from repository Actions secrets:
 - `NEMOCLAW_IMAGE_DISPATCH_TOKEN` is exposed as `GH_TOKEN` only to the trusted
   host controller. The controller uses it to list successful producer runs in
   `brevdev/nemoclaw-image` and download the selected staging handoff artifact.
-- `NVIDIA_INFERENCE_API_KEY` is exported into the Brev guest for the full E2E
-  process. Code in the baked candidate checkout can read and use it.
+- `NVIDIA_API_KEY` supplies the public NVIDIA endpoint credential. The workflow
+  exports it as `NVIDIA_INFERENCE_API_KEY` into the Brev guest for full E2E.
+  The preinstalled suite selects `build` for `brev-quickstart` and probes the
+  public endpoint. Code in the baked candidate checkout can read and use the key.
 
 `brev login` writes `BREV_API_KEY` and `BREV_ORG_ID` to
 `$HOME/.brev/credentials.json` on the GitHub-hosted runner. Later trusted steps

--- a/test/e2e/fixtures/hosted-inference.ts
+++ b/test/e2e/fixtures/hosted-inference.ts
@@ -4,6 +4,9 @@
 import fs from "node:fs";
 import path from "node:path";
 
+import { DEFAULT_CLOUD_MODEL } from "../../../src/lib/inference/config.ts";
+import { BUILD_ENDPOINT_URL } from "../../../src/lib/inference/provider-models.ts";
+import { validateNvidiaApiKeyValue } from "../../../src/lib/validation.ts";
 import {
   PORTABLE_INFERENCE_DESCRIPTOR_PATH,
   type PortableInferenceDescriptor,
@@ -26,14 +29,15 @@ export interface HostedInferenceSecrets {
 
 export interface HostedInferenceOptions {
   model?: string;
+  provider?: "build";
 }
 
 export interface HostedInferenceConfig {
   apiKey: string;
   sourceSecretName: typeof HOSTED_INFERENCE_SECRET;
-  credentialEnv: typeof HOSTED_INFERENCE_CREDENTIAL_ENV;
-  provider: typeof HOSTED_INFERENCE_PROVIDER;
-  providerName: typeof HOSTED_INFERENCE_PROVIDER_NAME;
+  credentialEnv: typeof HOSTED_INFERENCE_CREDENTIAL_ENV | typeof HOSTED_INFERENCE_SECRET;
+  provider: typeof HOSTED_INFERENCE_PROVIDER | "build";
+  providerName: typeof HOSTED_INFERENCE_PROVIDER_NAME | "nvidia-prod";
   env: NodeJS.ProcessEnv;
   model: string;
   endpointUrl: string;
@@ -196,6 +200,26 @@ export function requireHostedInferenceConfig(
   options: HostedInferenceOptions = {},
 ): HostedInferenceConfig {
   const apiKey = secrets.required(HOSTED_INFERENCE_SECRET);
+  if (options.provider === "build") {
+    const error = validateNvidiaApiKeyValue(apiKey);
+    if (error) throw new Error(error.trim());
+    const model = env.NEMOCLAW_MODEL || options.model || DEFAULT_CLOUD_MODEL;
+    return {
+      apiKey,
+      sourceSecretName: HOSTED_INFERENCE_SECRET,
+      credentialEnv: HOSTED_INFERENCE_SECRET,
+      provider: "build",
+      providerName: "nvidia-prod",
+      endpointUrl: BUILD_ENDPOINT_URL,
+      model,
+      env: {
+        NEMOCLAW_PROVIDER: "build",
+        NEMOCLAW_MODEL: model,
+        [HOSTED_INFERENCE_SECRET]: apiKey,
+      },
+      contractLabel: "The Launchable uses the public NVIDIA endpoint and its nvapi credential",
+    };
+  }
   const endpointUrl = env.NEMOCLAW_ENDPOINT_URL || DEFAULT_HOSTED_INFERENCE_BASE_URL;
   const model =
     env.NEMOCLAW_MODEL ||

--- a/test/e2e/live/full-e2e.test.ts
+++ b/test/e2e/live/full-e2e.test.ts
@@ -405,7 +405,11 @@ test("full e2e: install, onboard, inference, cli operations, and cleanup", {
     ],
   },
 }, async ({ artifacts, cleanup: cleanupRegistry, host, lifecycle, progress, sandbox, secrets, skip }) => {
-  const hosted = requireHostedInferenceConfig(secrets);
+  const hosted = requireHostedInferenceConfig(
+    secrets,
+    process.env,
+    USE_PREINSTALLED_LAUNCHABLE ? { provider: "build" } : {},
+  );
   const portableHostedDescriptor =
     PORTABLE_PROFILE && !USE_PREINSTALLED_LAUNCHABLE
       ? stagePortableHostedInferenceDescriptor(hosted)

--- a/test/e2e/support/hosted-inference.test.ts
+++ b/test/e2e/support/hosted-inference.test.ts
@@ -187,6 +187,38 @@ printf 'modelFn=%s\n' "$(nemoclaw_e2e_hosted_inference_model)"
 }
 
 describe("hosted inference E2E config", () => {
+  it("uses the public NVIDIA route for preinstalled Launchable onboarding", () => {
+    const cfg = requireHostedInferenceConfig(
+      secrets({ NVIDIA_INFERENCE_API_KEY: "nvapi-launchable-test" }),
+      {
+        NEMOCLAW_MODEL: "nvidia/launchable-model",
+        NEMOCLAW_ENDPOINT_URL: "https://inference-api.nvidia.com/v1",
+      },
+      { provider: "build" },
+    );
+
+    expect(cfg.provider).toBe("build");
+    expect(cfg.providerName).toBe("nvidia-prod");
+    expect(cfg.credentialEnv).toBe("NVIDIA_INFERENCE_API_KEY");
+    expect(cfg.endpointUrl).toBe("https://integrate.api.nvidia.com/v1");
+    expect(cfg.model).toBe("nvidia/launchable-model");
+    expect(cfg.env).toEqual({
+      NEMOCLAW_PROVIDER: "build",
+      NEMOCLAW_MODEL: "nvidia/launchable-model",
+      NVIDIA_INFERENCE_API_KEY: "nvapi-launchable-test",
+    });
+  });
+
+  it("rejects an Inference Hub credential for the public NVIDIA route", () => {
+    expect(() =>
+      requireHostedInferenceConfig(
+        secrets({ NVIDIA_INFERENCE_API_KEY: "sk-inference-hub-test" }),
+        {},
+        { provider: "build" },
+      ),
+    ).toThrow("Invalid NVIDIA API key. Must start with nvapi-");
+  });
+
   it("uses NVIDIA_INFERENCE_API_KEY as the hosted compatible endpoint source secret", () => {
     const cfg = requireHostedInferenceConfig(
       secrets({ NVIDIA_INFERENCE_API_KEY: "repo-hosted-key" }),

--- a/test/e2e/support/staging-brev-launchable-identity-workflow-boundary.test.ts
+++ b/test/e2e/support/staging-brev-launchable-identity-workflow-boundary.test.ts
@@ -157,6 +157,19 @@ describe("staging Brev Launchable identity workflow boundary", () => {
     expect(validateE2eWorkflow(value)).toContain(expected);
   });
 
+  it("rejects the Inference Hub secret for public NVIDIA Launchable onboarding", () => {
+    const value = workflow();
+    const run = step(value, "Build, deploy, verify, test, and clean up", "staging-brev-launchable");
+    run.env!.NVIDIA_INFERENCE_API_KEY = String(run.env!.NVIDIA_INFERENCE_API_KEY).replace(
+      "secrets.NVIDIA_API_KEY",
+      "secrets.NVIDIA_INFERENCE_API_KEY",
+    );
+
+    expect(validateE2eWorkflow(value)).toContain(
+      "staging-brev-launchable NVIDIA_INFERENCE_API_KEY must use the trusted-run secret guard",
+    );
+  });
+
   it("rejects identity-only mode for staging-brev-launchable (#9925)", () => {
     const value = workflow();
     const strictStep = step(

--- a/tools/e2e/workflow-boundary.mts
+++ b/tools/e2e/workflow-boundary.mts
@@ -2178,7 +2178,7 @@ function validateStagingBrevLaunchableJob(errors: string[], jobs: WorkflowRecord
     [prepareEnv, "BREV_API_KEY", "BREV_API_KEY"],
     [prepareEnv, "BREV_ORG_ID", "BREV_ORG_ID"],
     [runEnv, "GH_TOKEN", "NEMOCLAW_IMAGE_DISPATCH_TOKEN"],
-    [runEnv, "NVIDIA_INFERENCE_API_KEY", "NVIDIA_INFERENCE_API_KEY"],
+    [runEnv, "NVIDIA_INFERENCE_API_KEY", "NVIDIA_API_KEY"],
   ] as const) {
     const expected = `\${{ ${trustedRun} && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && secrets.${secret} || '' }}`;
     if (env[key] !== expected) {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome
The preinstalled Brev Launchable E2E selects the supported `build` provider with the public NVIDIA endpoint, baked model, and matching public NVIDIA credential. Other hosted-inference tests retain their existing Inference Hub configuration.

## Reason
[Staging job 102667875417](https://github.com/NVIDIA/NemoClaw/actions/runs/34411668250/job/102667875417) tested commit `801fb0c5bad751d4c06fdd51840bf5e755b5a48c` and failed before onboarding with `brev-quickstart: unsupported launchable provider 'custom'`. Image identity and provenance passed. The shared test fixture supplied an Inference Hub configuration to a quickstart that accepts named providers.

Changing the provider alone would leave the wrong credential and direct-probe endpoint. NVIDIA's public provider requires an `nvapi-` credential and uses `integrate.api.nvidia.com`.

## Changes
- Add an explicit public NVIDIA option to the existing inference fixture and select it only for preinstalled Launchable E2E. Reuse the CLI's endpoint, default model, and credential validation.
- Map the existing `NVIDIA_API_KEY` Actions secret to the guest's `NVIDIA_INFERENCE_API_KEY` variable. Retain the trusted-run guard and update its workflow validator.
- Add regression tests for the provider, endpoint, model, credential environment, wrong credential family, and wrong Actions secret mapping. The configuration tests failed against the original fixture; the workflow regression failed against the original validator.
- Update the owning E2E guidance. The bootstrap smoke test and ordinary hosted-inference consumers still use the compatible endpoint route.

## Verification
- `npm run build:cli` — passed.
- `npx vitest run --project e2e-support test/e2e/support/hosted-inference.test.ts test/e2e/support/staging-brev-launchable-identity-workflow-boundary.test.ts test/e2e/support/e2e-operations-workflow-boundary.test.ts` — 111 tests passed.
- `NODE_OPTIONS=--max-old-space-size=5120 npm --prefix nemoclaw run build` — passed; restores the packaged plugin prerequisite for CLI type checking.
- Normal pre-commit and commit-message hooks — passed.
- `NODE_OPTIONS=--max-old-space-size=5120 npm run validate:pr` — passed, including the CLI type check, against refreshed canonical base `c8cbebc602`. The initial default-heap attempt ran out of memory; the successful run followed the documented heap adjustment and plugin build.
- `actionlint` — base and candidate produce identical existing diagnostics; this change adds none.
- The diff contains no secrets, API keys, or credentials; test credentials are synthetic.
- Live Launchable validation remains outstanding. This PR does not claim onboarding or inference success on a new image.

## Review notes
Sensitive paths are `.github/workflows/e2e.yaml`, `tools/e2e/workflow-boundary.mts`, `.agents/skills/nemoclaw-maintainer-e2e/SKILL.md`, and its `references/main-runs.md`. The author reviewed the complete NVIDIA/NemoClaw diff at `c5cfa2842c4cbe3c1cddeb5699d5de40314f8020` against base `a4265abfc2e46922100baff0ba8f5985b681cf69`, checked the original job artifacts, and ran the regression tests. No independent pre-publication review exists; these paths await review, so this PR is a draft.

The public NVIDIA key replaces the Inference Hub key at the existing trusted host-to-guest boundary. Candidate code can read the guest environment credential. Resource cleanup, credential redaction, and issuer-side expiry or revocation remain unchanged. The validator change is limited to requiring the public NVIDIA secret under the existing guard.

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Staging end-to-end runs now support the public NVIDIA Launchable build provider.
  - Build-based runs automatically resolve the appropriate endpoint, model, and NVIDIA credentials.

- **Bug Fixes**
  - Corrected staging credential sourcing to use the NVIDIA API key consistently.
  - Invalid Inference Hub credentials are now rejected for public NVIDIA routes.

- **Documentation**
  - Updated staging E2E guidance with credential setup, build selection, and public endpoint verification steps.

- **Tests**
  - Added coverage for provider configuration, credential validation, endpoint resolution, and trusted workflow safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->