### PR TITLE
fix(deps): upgrade smol-toml to 1.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "js-yaml": "^4.3.2",
         "p-retry": "^4.6.2",
         "qrcode-terminal": "^0.12.0",
-        "smol-toml": "1.7.0",
+        "smol-toml": "1.8.0",
         "typebox": "1.1.38",
         "undici": "8.10.0",
         "yaml": "2.8.3"
@@ -8256,9 +8256,9 @@
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.0.tgz",
-      "integrity": "sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+      "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "js-yaml": "^4.3.2",
     "p-retry": "^4.6.2",
     "qrcode-terminal": "^0.12.0",
-    "smol-toml": "1.7.0",
+    "smol-toml": "1.8.0",
     "typebox": "1.1.38",
     "undici": "8.10.0",
     "yaml": "2.8.3"

--- a/src/lib/sandbox/config-format.test.ts
+++ b/src/lib/sandbox/config-format.test.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { spawnSync } from "node:child_process";
 import { describe, expect, it } from "vitest";
 
 const { parseConfig, serializeConfig } =
@@ -38,6 +39,32 @@ describe("sandbox config formats", () => {
       model: { id: "nemotron" },
     });
   });
+
+  it.each(["values = [1 #", "value = { nested = 1 #"])(
+    "rejects an unfinished TOML structure ending in a comment: %s",
+    (source) => {
+      // Bound the child process because a parser regression can block the event loop.
+      const result = spawnSync(
+        process.execPath,
+        [
+          "--require",
+          require.resolve("tsx/cjs"),
+          "--eval",
+          `const assert = require("node:assert/strict");
+           const { parseConfig } = require(process.argv[1]);
+           assert.throws(() => parseConfig(process.argv[2], "toml"), {
+             message: "Invalid TOML configuration syntax.",
+           });`,
+          require.resolve("./config-format"),
+          source,
+        ],
+        { encoding: "utf8", timeout: 2000, killSignal: "SIGKILL" },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.status, result.stderr).toBe(0);
+    },
+  );
 
   it("rejects excessive TOML nesting with a generic source-safe error", () => {
     const secret = "credential-canary-must-not-escape";


### PR DESCRIPTION
## Outcome
Upgrade smol-toml to 1.8.0 so malformed TOML arrays and inline tables ending in a comment produce the existing generic configuration error instead of hanging the CLI.

## Reason
The [reviewed npm audit job](https://github.com/NVIDIA/NemoClaw/actions/runs/34422125153/job/102699676195) blocks 1.7.0 for [GHSA-7w5x-hrqm-74c2](https://github.com/advisories/GHSA-7w5x-hrqm-74c2). Existing parser tests did not cover an unfinished structure with a comment at end of input.

## Changes
- Update the direct smol-toml pin and its lockfile version, registry URL, and integrity hash to 1.8.0.
- Add two process-bounded regression cases through parseConfig for unfinished arrays and inline tables with a trailing comment.
- Review 1.7.0 → 1.7.1 → 1.7.2 → 1.8.0: the comment-loop fix, internal parser refactoring, and Temporal serialization require no changes to NemoClaw's public parse/stringify consumers. The package retains its CommonJS and ESM exports, Node >=18 requirement, BSD-3-Clause license, and no runtime dependencies.

## Verification
- Reproduced both malformed-input hangs with 1.7.0: both child processes reached the timeout; the eight existing config-format tests passed.
- `npm run build:cli` — passed in a container with Node 22.23.1 and npm 10.9.8.
- `npx vitest run --project cli src/lib/sandbox/config-format.test.ts src/lib/inference/vllm-storage.test.ts src/lib/onboard/docker-driver-gateway-config-toml.test.ts src/lib/onboard/docker-driver-gateway-config-auth-contract.test.ts src/lib/state/state-file-key-merge-behavior.test.ts src/lib/state/state-file-key-merge-file-safety.test.ts src/lib/onboard/created-sandbox-finalization.test.ts` — 123 tests passed across seven files with 1.8.0.
- `npm --prefix nemoclaw run build` — passed.
- `npm run typecheck:cli`, `npx tsc -p jsconfig.json`, and focused Oxlint — passed.
- `npm audit --omit=dev --audit-level=high --registry=https://registry.npmjs.org/` — zero vulnerabilities.
- `NODE_OPTIONS=--max-old-space-size=5120 npm run validate:pr` — passed all applicable pre-commit, commit-message, and pre-push checks in an isolated container; no tracked files changed.
- Reviewed the complete diff: no secrets, API keys, credentials, unrelated dependency changes, or new runtime mechanisms.

## Review notes
Self-review covers NVIDIA/NemoClaw commit 579c9e35f6a4d8e73840c822302ff4e4168ef558 and all three changed files, including the sensitive path src/lib/sandbox/config-format.test.ts. The regression exercises the production parser and bounds each child process to prevent a reintroduced hang from blocking the test worker. Validation used the unchanged checks from canonical main `270275f2a2b31a70fa72692d2ec304b5dffe8ee3` in a container with no host credentials. No independent pre-publication review exists. This draft awaits independent review.

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added regression coverage for malformed TOML arrays and inline tables ending with comments.
  - Confirmed these inputs produce the expected syntax errors without blocking process termination or event handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->