### PR TITLE
fix(test): load unbuilt shared modules during E2E collection

### DIFF
--- a/test/helpers/register-source-require.ts
+++ b/test/helpers/register-source-require.ts
@@ -414,6 +414,23 @@ moduleRuntime._resolveFilename = function resolveSourceFilename(request, parent,
   } catch (error) {
     const parentFilename = parent?.filename ? path.resolve(parent.filename) : "";
     const sourceRoot = path.join(repoRoot, "src") + path.sep;
+    const sharedSourceRoot = path.join(repoRoot, "nemoclaw/src/shared");
+    const requestedPath = path.resolve(path.dirname(parentFilename), request);
+    // Runtime require calls bypass Vitest aliases. Resolve unbuilt shared
+    // modules only for typed source callers; packaged callers must use dist.
+    if (
+      /\.c?ts$/.test(parentFilename) &&
+      request.startsWith(".") &&
+      request.endsWith(".cjs") &&
+      [path.join(repoRoot, "nemoclaw/dist/shared"), sharedSourceRoot].includes(
+        path.dirname(requestedPath),
+      )
+    ) {
+      const sourceCandidate = path.join(sharedSourceRoot, `${path.basename(request, ".cjs")}.cts`);
+      if (fs.existsSync(sourceCandidate)) {
+        return resolveFilename.call(this, sourceCandidate, parent, isMain, options);
+      }
+    }
     if (request.startsWith(".") && request.endsWith(".js") && parentFilename) {
       const sourceRequest = `${request.slice(0, -3)}.ts`;
       const sourceCandidate = path.resolve(path.dirname(parentFilename), sourceRequest);
@@ -434,3 +451,5 @@ moduleRuntime._extensions[".ts"] = (module, filename) => {
   stats.compileMs += nowMs() - compileStart;
   module._compile(outputText, filename);
 };
+
+moduleRuntime._extensions[".cts"] = moduleRuntime._extensions[".ts"];

--- a/test/repository/source-require-loader.test.ts
+++ b/test/repository/source-require-loader.test.ts
@@ -116,6 +116,96 @@ function waitForFile(filename: string, timeoutMs = 2_000): void {
 }
 
 describe("source require loader", () => {
+  it.each([
+    { built: false, prepareBuild: (_root: string) => {} },
+    {
+      built: true,
+      prepareBuild: (root: string) => {
+        fs.mkdirSync(path.join(root, "nemoclaw/dist/shared"), { recursive: true });
+        fs.writeFileSync(
+          path.join(root, "nemoclaw/dist/shared/fixture.cjs"),
+          "exports.value = 7;\n",
+        );
+      },
+    },
+  ])(
+    "loads shared CommonJS dependencies when build output exists: $built",
+    ({ built, prepareBuild }) => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-source-require-shared-"));
+      roots.push(root);
+      fs.mkdirSync(path.join(root, "test/helpers"), { recursive: true });
+      fs.mkdirSync(path.join(root, "src"));
+      fs.mkdirSync(path.join(root, "nemoclaw/src/shared"), { recursive: true });
+      fs.mkdirSync(path.join(root, "node_modules"));
+      fs.copyFileSync(
+        SOURCE_REQUIRE_HOOK,
+        path.join(root, "test/helpers/onboard-script-mocks.cjs"),
+      );
+      fs.copyFileSync(
+        path.join(REPO_ROOT, "test/helpers/onboard-fixture-contract.json"),
+        path.join(root, "test/helpers/onboard-fixture-contract.json"),
+      );
+      fs.copyFileSync(
+        path.join(REPO_ROOT, "test/helpers/register-source-require.ts"),
+        path.join(root, "test/helpers/register-source-require.ts"),
+      );
+      fs.copyFileSync(
+        path.join(REPO_ROOT, "test/helpers/source-require-cache.ts"),
+        path.join(root, "test/helpers/source-require-cache.ts"),
+      );
+      fs.symlinkSync(
+        path.join(REPO_ROOT, "node_modules/typescript"),
+        path.join(root, "node_modules/typescript"),
+        "junction",
+      );
+      fs.writeFileSync(
+        path.join(root, "tsconfig.src.json"),
+        JSON.stringify({
+          compilerOptions: { module: "commonjs", target: "ES2022", esModuleInterop: true },
+        }),
+      );
+      fs.writeFileSync(
+        path.join(root, "src/entry.ts"),
+        'export { value } from "../nemoclaw/dist/shared/fixture.cjs";\n',
+      );
+      fs.writeFileSync(
+        path.join(root, "nemoclaw/src/shared/fixture.cts"),
+        'export { value } from "./nested.cjs";\n',
+      );
+      fs.writeFileSync(
+        path.join(root, "nemoclaw/src/shared/nested.cts"),
+        "export const value: number = 42;\n",
+      );
+      prepareBuild(root);
+      const script = `
+const assert = require("node:assert/strict");
+const { createRequire } = require("node:module");
+require("./test/helpers/onboard-script-mocks.cjs");
+assert.equal(require("./src/entry.ts").value, ${built ? 7 : 42});
+const sourceRequire = createRequire(process.cwd() + "/src/entry.ts");
+assert.throws(() => sourceRequire("../other/dist/shared/fixture.cjs"), { code: "MODULE_NOT_FOUND" });
+assert.throws(() => sourceRequire("../nemoclaw/dist/shared/missing.cjs"), { code: "MODULE_NOT_FOUND" });
+const packagedRequire = createRequire(process.cwd() + "/dist/entry.js");
+${
+  built
+    ? 'assert.equal(packagedRequire("../nemoclaw/dist/shared/fixture.cjs").value, 7);'
+    : 'assert.throws(() => packagedRequire("../nemoclaw/dist/shared/fixture.cjs"), { code: "MODULE_NOT_FOUND" });'
+}
+`;
+      const result = spawnSync(process.execPath, ["-e", script], {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          NODE_OPTIONS: nodeOptionsWithoutSourceLoader(process.env.NODE_OPTIONS),
+        },
+        timeout: 10_000,
+      });
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(fs.existsSync(path.join(root, "nemoclaw/dist"))).toBe(built);
+    },
+  );
+
   it("emits opt-in cache statistics and reuses a cross-process cache entry (#6237)", () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-source-require-"));
     roots.push(root);


### PR DESCRIPTION
## Outcome

The five reported E2E suites can load when `nemoclaw/dist/shared/` has not been built. The managed-image OpenClaw security suite also passes collection.

## Reason

[Run 34432799967](https://github.com/NVIDIA/NemoClaw/actions/runs/34432799967/job/102732040737) fails before tests execute because native `require()` bypasses Vitest aliases and requests `sandbox-name.cjs`. Existing builds can hide the missing source-resolution path.

### Related issues

Fixes #11368.

## Changes

- Extend the existing source loader to resolve missing shared `.cjs` imports to their `.cts` source, including imports between shared modules.
- Restrict the fallback to typed callers and the repository's shared directories. Preserve existing compiled modules and missing-module errors for packaged callers.
- Add isolated fixtures for absent and present build output, nested shared imports, missing modules, and unrelated paths.

## Verification

- Reproduced the missing-module failure before the fix. The new absent-build fixture also failed before the fix.
- `node node_modules/vitest/vitest.mjs run --project integration test/repository/source-require-loader.test.ts test/automation/pull-requests/growth-guardrails.test.ts --coverage=false` — 57 tests passed.
- Collection-only run of bootstrap installation, standard installation, snapshot commands, Ollama authentication proxy, and WhatsApp compact QR — all five suites loaded with `nemoclaw/dist` absent. Used `E2E_TARGET_ID=bootstrap-install-smoke`, `NEMOCLAW_RUN_LIVE_E2E=1`, and `--testNamePattern='^$'` to exclude every test body.
- `NEMOCLAW_TEST_IMAGE=collection-only node node_modules/vitest/vitest.mjs list --project integration test/e2e-runtime/managed-image-openclaw-security.test.ts --json` — one test collected with `nemoclaw/dist` absent.
- `npm run build:cli` — passed.
- `npm --prefix nemoclaw run build` — passed.
- `npm run validate:pr` — passed after building both packages.
- [Targeted E2E run 34435643438](https://github.com/NVIDIA/NemoClaw/actions/runs/34435643438) — failed in `base-image-publication` before any target started: `exact managed-image workflow run is missing or ambiguous`. No managed-image workflow run exists for this PR commit. Selected bootstrap installation, standard installation, snapshot commands, Ollama authentication proxy, and WhatsApp compact QR.
- Reviewed the diff for secrets, API keys, and credentials; none found. Full runtime E2E was not run locally.

---
Signed-off-by: San Dang <sdang@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CommonJS dependency resolution for shared modules when using TypeScript source files or packaged builds.
  * Out-of-scope and missing dependencies continue to report clear module-not-found errors.

* **Tests**
  * Added integration coverage for source and built package scenarios, including expected build artifacts and failure cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->