### PR TITLE
feat(config): export retained managed proxy settings

### DIFF
--- a/schemas/nemoclaw-config-v1.schema.json
+++ b/schemas/nemoclaw-config-v1.schema.json
@@ -134,6 +134,24 @@
                 "type": "object",
                 "required": ["policy"],
                 "properties": {
+                  "proxy": {
+                    "type": "object",
+                    "required": ["host", "port"],
+                    "properties": {
+                      "host": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 256,
+                        "pattern": "^[A-Za-z0-9._-]+$(?![\\s\\S])"
+                      },
+                      "port": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 65535
+                      }
+                    },
+                    "additionalProperties": false
+                  },
                   "policy": {
                     "type": "object",
                     "required": ["explicit"],

--- a/src/lib/config/config.test.ts
+++ b/src/lib/config/config.test.ts
@@ -83,6 +83,28 @@ describe("NemoClawConfig v1", () => {
     expect(validateNemoClawConfig(config())).toEqual(config());
   });
 
+  it.each([
+    { host: "user:secret-canary@proxy.internal", port: 3129 },
+    { host: "http://proxy.internal", port: 3129 },
+    { host: "proxy.internal\n", port: 3129 },
+    { host: "a".repeat(257), port: 3129 },
+    { host: "proxy.internal", port: 0 },
+    { host: "proxy.internal", port: 65_536 },
+    { host: "proxy.internal", port: 3129.5 },
+    { host: "proxy.internal", port: 3129, credential: "secret-canary" },
+    { host: "proxy.internal" },
+    { port: 3129 },
+  ])("rejects malformed or incomplete managed proxy configuration", (proxy) => {
+    const value = config();
+    Object.assign(value.spec.sandboxes[0]!.network, { proxy });
+    expect(() => validateNemoClawConfig(value)).toThrow();
+    try {
+      validateNemoClawConfig(value);
+    } catch (error) {
+      expect(String(error)).not.toContain("secret-canary");
+    }
+  });
+
   it("returns an owned and deeply frozen validated document (#10938)", () => {
     const input = config();
     const validated = validateNemoClawConfig(input);

--- a/src/lib/config/model.ts
+++ b/src/lib/config/model.ts
@@ -94,6 +94,17 @@ const UuidSchema = Type.Unsafe<NemoClawConfigDocumentUid>({
   pattern: "^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
 });
 export const TcpPortSchema = Type.Integer({ minimum: 1, maximum: 65_535 });
+export const NemoClawManagedProxyConfigSchema = Type.Object(
+  {
+    host: Type.String({
+      minLength: 1,
+      maxLength: 256,
+      pattern: "^[A-Za-z0-9._-]+$(?![\\s\\S])",
+    }),
+    port: TcpPortSchema,
+  },
+  { additionalProperties: false },
+);
 export const CredentialEnvironmentReferenceNameSchema = Type.String({
   pattern: CREDENTIAL_ENVIRONMENT_REFERENCE_PATTERN,
 });
@@ -272,6 +283,7 @@ const NemoClawSandboxConfigSchema = Type.Object(
     runtime: NemoClawSandboxRuntimeConfigSchema,
     network: Type.Object(
       {
+        proxy: Type.Optional(NemoClawManagedProxyConfigSchema),
         policy: Type.Object(
           { explicit: NemoClawExplicitPolicySchema },
           { additionalProperties: false },

--- a/src/lib/domain/config/export-document.ts
+++ b/src/lib/domain/config/export-document.ts
@@ -61,7 +61,10 @@ export function buildExportConfig(
             provider: source.runtime.provider,
             image: { ref: source.runtime.imageRef },
           },
-          network: { policy: { explicit: source.policy } },
+          network: {
+            policy: { explicit: source.policy },
+            ...(source.proxy === undefined ? {} : { proxy: source.proxy }),
+          },
           agents: [
             {
               name: "primary",

--- a/src/lib/domain/config/export-evidence.ts
+++ b/src/lib/domain/config/export-evidence.ts
@@ -9,6 +9,7 @@ import {
   InferenceEndpointSchema,
   LocalResourceNameSchema,
   NemoClawInferenceApiSchema,
+  NemoClawManagedProxyConfigSchema,
   RuntimeProviderSchema,
   SandboxNameSchema,
   TcpPortSchema,
@@ -202,6 +203,7 @@ export const ExportSourceValuesSchema = Type.Object({
     imageRef: ImmutableImageReferenceSchema,
   }),
   gateway: Type.Object({ name: LocalResourceNameSchema, port: TcpPortSchema }),
+  proxy: Type.Optional(NemoClawManagedProxyConfigSchema),
   inference: ExportInferenceSchema,
 });
 

--- a/src/lib/domain/config/verify-export-source.test.ts
+++ b/src/lib/domain/config/verify-export-source.test.ts
@@ -1,9 +1,17 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { createHash } from "node:crypto";
+import YAML from "yaml";
 import { Check } from "typebox/value";
 import { ExportSourceValuesSchema } from "./export-evidence";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { runConfigExport } from "../../actions/config/export";
+import { validateNemoClawConfig } from "../../config/schema";
+import {
+  parseNemoClawConfigDocumentName,
+  parseNemoClawConfigDocumentUid,
+} from "../../config/model";
 import { observeStableExportSource } from "../../actions/config/observe-export-source";
 import { fingerprintOpenShellSandboxId } from "../sandbox/openshell-identity";
 import {
@@ -195,6 +203,36 @@ function verify(
   return verifyExportSource(requestedSandboxName, qualified);
 }
 
+async function exportSnapshots(sequence: readonly ObservedExportSnapshot[]) {
+  let index = 0;
+  const read = vi.fn(async () => sequence[Math.min(index++, sequence.length - 1)]!);
+  const writeStdout = vi.fn(async (_contents: string) => undefined);
+  const publish = vi.fn(() => ({ ok: true, outputPath: "/tmp/alpha.yaml" }) as const);
+  const outcome = await runConfigExport(
+    {
+      sandboxName: "alpha",
+      documentName: parseNemoClawConfigDocumentName("alpha"),
+      target: { kind: "stdout" },
+    },
+    {
+      observe: (name) => observeStableExportSource(name, { read }),
+      createDocumentUid: () => parseNemoClawConfigDocumentUid(sandboxId),
+      writeStdout,
+      publish,
+    },
+  );
+  return { outcome, read, writeStdout, publish };
+}
+
+function proxySnapshot(
+  environment = { NEMOCLAW_PROXY_HOST: "proxy.internal", NEMOCLAW_PROXY_PORT: "3129" },
+) {
+  return {
+    ...snapshot(),
+    registry: { ...entry(), workload: managedWorkload(profileInput({ environment })) },
+  } satisfies ObservedExportSnapshot;
+}
+
 describe("config export source verification (#10938)", () => {
   it("qualifies and verifies two equal snapshots through the observer", async () => {
     const observed = snapshot();
@@ -208,6 +246,126 @@ describe("config export source verification (#10938)", () => {
       source: { sandboxName: "alpha", policy: canonicalPolicy },
     });
   });
+
+  it("exports retained managed proxy settings through the complete action", async () => {
+    const observed = proxySnapshot();
+    const result = await exportSnapshots([observed]);
+
+    expect(result.outcome).toEqual({ ok: true, completion: { kind: "stdout" } });
+    expect(result.read).toHaveBeenCalledTimes(2);
+    expect(result.publish).not.toHaveBeenCalled();
+    const [yaml] = result.writeStdout.mock.calls[0]!;
+    const config = validateNemoClawConfig(YAML.parse(yaml));
+    expect(config.spec.sandboxes[0]!.network).toEqual({
+      proxy: { host: "proxy.internal", port: 3129 },
+      policy: { explicit: canonicalPolicy },
+    });
+    expect(Object.isFrozen(verifiedSource(verify(observed)).proxy)).toBe(true);
+  });
+
+  it("omits the default proxy from existing canonical exports", async () => {
+    const result = await exportSnapshots([snapshot()]);
+    expect(result.outcome.ok).toBe(true);
+    const [yaml] = result.writeStdout.mock.calls[0]!;
+    expect(validateNemoClawConfig(YAML.parse(yaml)).spec.sandboxes[0]!.network).toEqual({
+      policy: { explicit: canonicalPolicy },
+    });
+    expect(verifiedSource(verify(snapshot()))).not.toHaveProperty("proxy");
+  });
+
+  it("exports a complete proxy pair when only its port changes", () => {
+    const observed = proxySnapshot({
+      NEMOCLAW_PROXY_HOST: "10.200.0.1",
+      NEMOCLAW_PROXY_PORT: "3129",
+    });
+    expect(verifiedSource(verify(observed)).proxy).toEqual({ host: "10.200.0.1", port: 3129 });
+  });
+
+  it("uses a stable proxy observation after one changed pair", async () => {
+    const changed = proxySnapshot();
+    const result = await exportSnapshots([snapshot(), changed, changed, changed]);
+    expect(result.outcome.ok).toBe(true);
+    expect(result.read).toHaveBeenCalledTimes(4);
+    const [yaml] = result.writeStdout.mock.calls[0]!;
+    expect(validateNemoClawConfig(YAML.parse(yaml)).spec.sandboxes[0]!.network.proxy).toEqual({
+      host: "proxy.internal",
+      port: 3129,
+    });
+  });
+
+  it("does not publish proxy settings when both snapshot pairs change", async () => {
+    const result = await exportSnapshots([
+      snapshot(),
+      proxySnapshot(),
+      snapshot(),
+      proxySnapshot(),
+    ]);
+    expect(result.outcome).toMatchObject({
+      ok: false,
+      failure: {
+        kind: "observation",
+        findings: [expect.objectContaining({ category: "unstable-source" })],
+      },
+    });
+    expect(result.writeStdout).not.toHaveBeenCalled();
+    expect(result.publish).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { managedHost: "user:secret-canary@proxy.internal" },
+    { managedHost: "http://proxy.internal" },
+    { managedHost: "proxy.internal\n" },
+    { managedHost: "a".repeat(257) },
+    { managedPort: 0 },
+    { managedPort: 65_536 },
+    { managedPort: 3129.5 },
+    { unexpected: "secret-canary" },
+    { hostHttpUrl: "http://proxy.internal:3129" },
+    { hostHttpsUrl: "http://proxy.internal:3129" },
+    { hostNoProxy: ["private.internal"] },
+  ])("does not publish invalid or unsupported retained proxy fields", async (change) => {
+    const workload = managedWorkload();
+    const profile = JSON.parse(Buffer.from(workload.encodedProfile, "base64url").toString("utf8"));
+    Object.assign(profile.proxy, change);
+    const encodedProfile = Buffer.from(JSON.stringify(profile)).toString("base64url");
+    const observed = snapshot({
+      registry: entry({
+        workload: {
+          ...workload,
+          encodedProfile,
+          startupProfileSha256: createHash("sha256").update(encodedProfile, "utf8").digest("hex"),
+        },
+      }),
+    });
+    const result = await exportSnapshots([observed]);
+    expect(result.outcome).toMatchObject({ ok: false, failure: { kind: "observation" } });
+    expect(result.writeStdout).not.toHaveBeenCalled();
+    expect(result.publish).not.toHaveBeenCalled();
+    expect(JSON.stringify(result.outcome)).not.toContain("secret-canary");
+  });
+
+  it.each([
+    { credentialProxyReplayRequired: true },
+    { corporateCaB64: "secret-canary" },
+    { startupProfileSha256: "c".repeat(64) },
+    { reference: imageRef.replace(/a{64}$/, "b".repeat(64)) },
+  ])(
+    "does not publish proxy settings without eligible matching workload authority",
+    async (change) => {
+      const observed = proxySnapshot();
+      const workload = observed.registry.workload!;
+      const result = await exportSnapshots([
+        {
+          ...observed,
+          registry: { ...observed.registry, workload: { ...workload, ...change } },
+        },
+      ]);
+      expect(result.outcome).toMatchObject({ ok: false, failure: { kind: "observation" } });
+      expect(result.writeStdout).not.toHaveBeenCalled();
+      expect(result.publish).not.toHaveBeenCalled();
+      expect(JSON.stringify(result.outcome)).not.toContain("secret-canary");
+    },
+  );
 
   it("narrows one supported snapshot to an immutable verified source", () => {
     const result = verify(snapshot());
@@ -540,7 +698,7 @@ describe("config export source verification (#10938)", () => {
     },
   );
 
-  it("rejects any noncanonical managed startup profile", async () => {
+  it("rejects unsupported startup settings alongside a managed proxy", async () => {
     const base = profileInput();
     const dashboard = base.dashboard as Extract<
       ManagedStartupProfileBuilderInput["dashboard"],
@@ -548,6 +706,7 @@ describe("config export source verification (#10938)", () => {
     >;
     const configured = profileInput({
       dashboard: { ...dashboard, url: "http://127.0.0.1:18888", port: 18_888 },
+      environment: { NEMOCLAW_PROXY_HOST: "proxy.internal", NEMOCLAW_PROXY_PORT: "3129" },
     });
     const workload = managedWorkload(configured);
     const raw = snapshot({ registry: entry({ imageTag: workload.reference, workload }) });

--- a/src/lib/domain/config/verify-export-source.ts
+++ b/src/lib/domain/config/verify-export-source.ts
@@ -39,7 +39,7 @@ const { Check } = require("typebox/value") as typeof TypeBoxValueModule;
 
 type VerifiedExportSourceData = Pick<
   VerifiedExportSource,
-  "gateway" | "inference" | "policy" | "runtime" | "sandboxName"
+  "gateway" | "inference" | "policy" | "proxy" | "runtime" | "sandboxName"
 >;
 
 function verifiedExportSource(data: VerifiedExportSourceData): VerifiedExportSource {
@@ -295,6 +295,14 @@ function classifyManagedStartupProfile(
   let expected: ManagedStartupProfile;
   try {
     expected = expectedManagedStartupProfile(entry);
+    expected = {
+      ...expected,
+      proxy: {
+        ...expected.proxy,
+        managedHost: profile.proxy.managedHost,
+        managedPort: profile.proxy.managedPort,
+      },
+    };
   } catch {
     return [
       finding(
@@ -679,10 +687,14 @@ function completeVerifiedSource(
 ): ExportSourceVerificationResult {
   const entry = snapshot.registry;
   const selected = normalizeInferenceSelection(entry);
+  const proxy = authority?.profile.proxy;
   const values = {
     sandboxName: requestedSandboxName,
     runtime: { provider: entry.openshellDriver, imageRef: authority?.receipt.reference },
     gateway: { name: snapshot.gateway.name, port: snapshot.gateway.port },
+    ...(proxy && !hasEqualJsonStructure(proxy, expectedManagedStartupProfile(entry).proxy)
+      ? { proxy: { host: proxy.managedHost, port: proxy.managedPort } }
+      : {}),
     inference: {
       provider: selected.provider,
       model: selected.model,


### PR DESCRIPTION
## Outcome

`nemoclaw config export` preserves a nondefault managed proxy host and port in `spec.sandboxes[].network.proxy`. The canonical default proxy stays omitted, preserving existing export output.

## Reason

Managed deployments using `NEMOCLAW_PROXY_HOST` or `NEMOCLAW_PROXY_PORT` currently fail export even when their retained configuration and live workload identity agree.

### Related issues

Refs #10904.

## Changes

- Extend the existing public schema, verified evidence and export builder with a strict optional proxy pair.
- Admit the validated retained managed host and port into the expected profile while preserving complete comparison of all other fields.
- Cover nondefault and default output, receipt authority, unstable observations, malformed values and unsupported host-proxy/CA settings through the complete export action.

The exported pair records retained desired state; it does not assert proxy reachability.

## Verification

- Focused config schema, verifier, builder, observer and export-action tests — 153 passed during implementation.
- Generated schema, CLI type checking and relevant lint checks — passed during implementation.
- `npm run validate:pr` — passed on `1750d948bff617ea3a477552886f3fc706894907` with the canonical validator and dependencies from `edfa1e78870106a14aac8e3f550a758165ff8219`.
- Reviewed the diff: no secrets, API keys or credentials added.

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional managed proxy settings to sandbox network configuration.
  * Proxy configurations require a valid hostname and TCP port.
  * Valid proxy settings are retained in exported configuration data when applicable.

* **Bug Fixes**
  * Improved validation for malformed proxy settings and prevented proxy credentials from appearing in validation errors.

* **Tests**
  * Added coverage for proxy validation, export behavior, defaults, stability, and startup-profile compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->