### PR TITLE
fix(e2e): distinguish gateway starts from step headings

### DIFF
--- a/test/e2e/live/hermes-gpu-startup-proof.ts
+++ b/test/e2e/live/hermes-gpu-startup-proof.ts
@@ -12,6 +12,7 @@ import { MANAGED_BOOTSTRAP_REQUEST_FILE } from "../../../src/lib/onboard/managed
 import { fingerprintManagedStartupProfile } from "../../../src/lib/onboard/managed-startup/profile.ts";
 import { OPENSHELL_SANDBOX_SUPERVISOR_ARGV } from "../../../src/lib/onboard/sandbox-create-launch.ts";
 import { load as loadSandboxRegistry } from "../../../src/lib/state/registry/persistence.ts";
+import { OPENSHELL_GATEWAY_START_LINE } from "../../helpers/openshell-gateway-start-output.ts";
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
 import {
   type HostCliClient,
@@ -60,7 +61,7 @@ export function assertHermesGpuStartupOutputContract(
   installText: string,
 ): void {
   expect(installText).toContain(`Container runtime: ${runtimeProviderId}`);
-  expect(installText).toMatch(/Starting OpenShell .*gateway/u);
+  expect(installText).toMatch(OPENSHELL_GATEWAY_START_LINE);
   expect(installText).toMatch(/gateway is healthy/u);
   expect(installText).not.toContain("Reusing healthy NemoClaw gateway.");
   expect(installText).not.toMatch(/Reusing existing .*gateway/u);

--- a/test/e2e/live/onboard-resume.test.ts
+++ b/test/e2e/live/onboard-resume.test.ts
@@ -12,6 +12,7 @@ import {
 } from "../../../tools/e2e/onboard-timeout-contract.mts";
 import { parseOpenShellSandboxId } from "../../../src/lib/adapters/openshell/sandbox-identity.ts";
 import { parseSandboxPhase } from "../../../src/lib/state/gateway.ts";
+import { OPENSHELL_GATEWAY_START_LINE } from "../../helpers/openshell-gateway-start-output.ts";
 import { execTimeout, testTimeout } from "../../helpers/timeouts.ts";
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
 import { assertCleanupSucceededOrAbsent } from "../fixtures/cleanup-resources.ts";
@@ -513,7 +514,7 @@ test(
     // still prints phase headings before the resume-skip decisions, so assert
     // the skip evidence and absence of redo-only success strings instead of
     // rejecting headings that now frame the skipped phases.
-    expect(resumeText).not.toMatch(/Starting OpenShell [^\r\n]*gateway/);
+    expect(resumeText).not.toMatch(OPENSHELL_GATEWAY_START_LINE);
     const reconciledExtraProviders = readExtraProviders();
     expect(reconciledExtraProviders).toContain(LIVE_EXTRA_PROVIDER);
     expect(reconciledExtraProviders).not.toContain(STALE_EXTRA_PROVIDER);

--- a/test/e2e/support/hermes-gpu-startup-proof.test.ts
+++ b/test/e2e/support/hermes-gpu-startup-proof.test.ts
@@ -14,7 +14,7 @@ import {
 
 const HEALTHY_NEW_GATEWAY = [
   "Container runtime: docker",
-  "Starting OpenShell gateway...",
+  "  Starting OpenShell gateway...",
   "Docker-driver gateway is healthy",
 ].join("\n");
 const NON_FALLBACK_DISCLOSURE_CASES = [

--- a/test/e2e/support/workflow-plan.test.ts
+++ b/test/e2e/support/workflow-plan.test.ts
@@ -626,6 +626,25 @@ describe("E2E workflow plan", () => {
     expect(selectedWorkflowJobs(plan)).toEqual(["catalogue-standard", "jetson-nvmap-gpu"]);
   });
 
+  it("selects Hermes GPU startup when its output proof changes", () => {
+    const plan = buildE2eWorkflowPlan(
+      {},
+      { changedFiles: ["test/e2e/live/hermes-gpu-startup-proof.ts"] },
+    );
+
+    expect(selectedWorkflowJobs(plan)).toContain("hermes-gpu-startup");
+  });
+
+  it("selects both live consumers when their gateway-start matcher changes", () => {
+    const plan = buildE2eWorkflowPlan(
+      {},
+      { changedFiles: ["test/helpers/openshell-gateway-start-output.ts"] },
+    );
+
+    expect(plan.catalogueMatrices.standard.map((row) => row.id)).toContain("onboard-resume");
+    expect(selectedWorkflowJobs(plan)).toContain("hermes-gpu-startup");
+  });
+
   it("selects only catalogue targets that own changed files", () => {
     const changedFile = "test/e2e/live/snapshot-commands.test.ts";
     const plan = buildE2eWorkflowPlan({}, { changedFiles: [changedFile] });

--- a/test/helpers/openshell-gateway-start-output.ts
+++ b/test/helpers/openshell-gateway-start-output.ts
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export const OPENSHELL_GATEWAY_START_LINE =
+  /^ {2}Starting OpenShell gateway(?: via managed service)?\.\.\.\r?$/mu;

--- a/test/runtime/gateway/gateway-state.test.ts
+++ b/test/runtime/gateway/gateway-state.test.ts
@@ -19,6 +19,7 @@ import {
   parseSandboxPhase,
   shouldSelectNamedGatewayForReuse,
 } from "../../../src/lib/state/gateway.js";
+import { OPENSHELL_GATEWAY_START_LINE } from "../../helpers/openshell-gateway-start-output.ts";
 
 const OPENSHELL_STATUS_ERROR_CONTRACT = JSON.parse(
   readFileSync(
@@ -108,6 +109,25 @@ Gateway: other-gw
 Server: https://127.0.0.1:9090/
 Connected
 `;
+
+describe("OpenShell gateway startup output", () => {
+  it.each([
+    "  Starting OpenShell gateway...",
+    "  Starting OpenShell gateway via managed service...",
+  ])("recognizes a gateway start line: %s", (startupLine) => {
+    expect(`before\n${startupLine}\nafter`).toMatch(OPENSHELL_GATEWAY_START_LINE);
+  });
+
+  it("does not treat an onboarding phase heading as a gateway start", () => {
+    const resumeOutput = [
+      "  [2/8] Starting OpenShell gateway",
+      "  ──────────────────────────────────────────────────",
+      "  [resume] Skipping gateway (running)",
+    ].join("\n");
+
+    expect(resumeOutput).not.toMatch(OPENSHELL_GATEWAY_START_LINE);
+  });
+});
 
 describe("hasStaleGateway", () => {
   it("returns true when output contains the named gateway", () => {

--- a/tools/e2e/target-catalogue.mts
+++ b/tools/e2e/target-catalogue.mts
@@ -1033,7 +1033,10 @@ export const E2E_TARGET_CATALOGUE: readonly E2eCatalogueTarget[] = [
     installMode: "credential-free",
     restoreCli: true,
     exposeCliBin: true,
-    owningPaths: ["tools/e2e/onboard-timeout-contract.mts"],
+    owningPaths: [
+      "test/helpers/openshell-gateway-start-output.ts",
+      "tools/e2e/onboard-timeout-contract.mts",
+    ],
     environment: { ...nonInteractive, NEMOCLAW_SANDBOX_NAME: "e2e-resume" },
   }),
   managedRuntimeTarget("openclaw-discord-pairing", {

--- a/tools/e2e/workflow-boundary.mts
+++ b/tools/e2e/workflow-boundary.mts
@@ -799,6 +799,8 @@ const RESTORED_GATEWAY_PAIRING_RUNTIME_FILES = new Set([
 ]);
 const LIVE_E2E_OWNING_FILE_JOBS = new Map<string, readonly string[]>([
   ["test/e2e/lib/fake-wechat-api.mts", ["messaging-providers"]],
+  ["test/e2e/live/hermes-gpu-startup-proof.ts", ["hermes-gpu-startup"]],
+  ["test/helpers/openshell-gateway-start-output.ts", ["hermes-gpu-startup"]],
   ["test/e2e/fixtures/openclaw-plugin-runtime-exdev-onboard.ts", ["openclaw-plugin-runtime-exdev"]],
   [
     "test/e2e/live/openclaw-plugin-runtime-exdev-trusted-prebuild.ts",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

Onboarding resume now distinguishes an actual OpenShell gateway start from the onboarding phase heading. A resume that reports `[resume] Skipping gateway (running)` no longer fails as a false restart, while startup proof still requires the real start line.

## Reason

[Onboarding resume](https://github.com/NVIDIA/NemoClaw/actions/runs/34411668250/job/102667875985) failed because its broad restart assertion matched the `Starting OpenShell gateway` phase heading even though the command skipped the running gateway.

## Changes

- Add one exact matcher for the two current OpenShell gateway start lines.
- Use the matcher in onboarding resume and Hermes GPU startup proof so both live consumers classify the same output consistently; changing only the resume assertion would leave the existing startup proof vulnerable to the same heading ambiguity.
- Add deterministic regression coverage that accepts real start lines and rejects the phase heading followed by the resume skip report.
- Route changes to the Hermes proof or shared matcher to the Hermes GPU live job, and route matcher changes to the onboarding resume target; planner tests protect both ownership paths.
- Align the Hermes startup-proof fixture with the actual indented command output.

## Verification

- `npx vitest run --project integration --project e2e-support test/runtime/gateway/gateway-state.test.ts test/e2e/support/hermes-gpu-startup-proof.test.ts test/e2e/support/workflow-plan.test.ts` — passed, 211 tests.
- `npm run checks:repository` — passed.
- `npm run test:e2e-phases:check` — passed, 134 tests across 88 files.
- `npm run validate:pr` — passed at `16bab1cb0723261c4916cc781bd0ff807635f307` against canonical base `f1a5bc1031babb1d7ed15baa8fa2a6a53c76b6df`.
- GitHub commit verification — both published commits are Verified.
- Live E2E was not dispatched because the defect is output classification covered at the deterministic matcher and workflow-planner boundaries.
- Reviewed the diff; it contains no secrets, API keys, or credentials.

## Review notes

The contributor-sensitive paths are `tools/e2e/target-catalogue.mts` and `tools/e2e/workflow-boundary.mts`, matching `tools/e2e/**`. For `NVIDIA/NemoClaw` commit `16bab1cb0723261c4916cc781bd0ff807635f307`, the contributor agent self-reviewed the mapping against canonical base `f1a5bc1031babb1d7ed15baa8fa2a6a53c76b6df` and verified both ownership routes with focused planner and semantic-phase tests. No independent pre-publication review exists for these final sensitive-path changes; the draft awaits automated and human review.

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>
<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved end-to-end coverage for gateway startup and onboarding resume scenarios.
  - Added validation for startup messages across supported formats, including managed-service wording and different line endings.
  - Added checks to prevent onboarding headings from being mistaken for gateway startup messages.
  - Expanded workflow-planning coverage so relevant tests run when gateway startup behavior or related helpers change.
  - Updated GPU startup expectations to reflect the current output format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->