### PR TITLE
feat(config): export fixed managed vLLM serving profile

### DIFF
--- a/schemas/nemoclaw-config-v1.schema.json
+++ b/schemas/nemoclaw-config-v1.schema.json
@@ -56,42 +56,167 @@
         "inferenceProviders": {
           "type": "array",
           "items": {
-            "type": "object",
-            "required": ["name", "provider", "api", "endpoint"],
-            "properties": {
-              "name": {
-                "type": "string",
-                "minLength": 1,
-                "maxLength": 63,
-                "pattern": "^[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$"
-              },
-              "provider": {
-                "type": "string",
-                "minLength": 1,
-                "maxLength": 512,
-                "pattern": "^[^\\s\\p{Cc}\\p{Cf}]+$"
-              },
-              "api": {
-                "enum": ["openai-completions", "openai-responses", "anthropic-messages"]
-              },
-              "endpoint": {
-                "type": "string",
-                "maxLength": 2048,
-                "pattern": "^https://[^\\s]+$"
-              },
-              "credential": {
+            "anyOf": [
+              {
                 "type": "object",
-                "required": ["env"],
+                "required": ["name", "provider", "api", "endpoint"],
                 "properties": {
-                  "env": {
+                  "name": {
                     "type": "string",
-                    "pattern": "^[A-Z][A-Z0-9_]{0,127}$"
+                    "minLength": 1,
+                    "maxLength": 63,
+                    "pattern": "^[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$"
+                  },
+                  "provider": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 512,
+                    "pattern": "^[^\\s\\p{Cc}\\p{Cf}]+$"
+                  },
+                  "api": {
+                    "enum": ["openai-completions", "openai-responses", "anthropic-messages"]
+                  },
+                  "endpoint": {
+                    "type": "string",
+                    "maxLength": 2048,
+                    "pattern": "^https://[^\\s]+$"
+                  },
+                  "credential": {
+                    "type": "object",
+                    "required": ["env"],
+                    "properties": {
+                      "env": {
+                        "type": "string",
+                        "pattern": "^[A-Z][A-Z0-9_]{0,127}$"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "required": ["name", "provider", "api", "serving"],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 63,
+                    "pattern": "^[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$"
+                  },
+                  "provider": {
+                    "type": "string",
+                    "const": "vllm-local"
+                  },
+                  "api": {
+                    "type": "string",
+                    "const": "openai-completions"
+                  },
+                  "serving": {
+                    "type": "object",
+                    "required": [
+                      "backend",
+                      "catalogDigest",
+                      "profile",
+                      "recipe",
+                      "model",
+                      "runtime",
+                      "hostPort"
+                    ],
+                    "properties": {
+                      "backend": {
+                        "type": "string",
+                        "const": "vllm"
+                      },
+                      "catalogDigest": {
+                        "type": "string",
+                        "pattern": "^sha256:[a-f0-9]{64}$"
+                      },
+                      "profile": {
+                        "type": "object",
+                        "required": ["id", "digest"],
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "const": "vllm.linux-amd64-nvidia.single.nemotron-3.5-lightning-30b-a3b-nvfp4"
+                          },
+                          "digest": {
+                            "type": "string",
+                            "pattern": "^sha256:[a-f0-9]{64}$"
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "recipe": {
+                        "type": "object",
+                        "required": ["id", "digest"],
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "const": "vllm.nemotron-3.5-lightning-30b-a3b-nvfp4.linux-amd64-single.v1"
+                          },
+                          "digest": {
+                            "type": "string",
+                            "pattern": "^sha256:[a-f0-9]{64}$"
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "model": {
+                        "type": "object",
+                        "required": ["id", "revision", "servedName"],
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 512,
+                            "pattern": "^[^\\s\\p{Cc}\\p{Cf}]+$"
+                          },
+                          "revision": {
+                            "type": "string",
+                            "pattern": "^[a-f0-9]{40}$"
+                          },
+                          "servedName": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 512,
+                            "pattern": "^[^\\s\\p{Cc}\\p{Cf}]+$"
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "runtime": {
+                        "type": "object",
+                        "required": ["image"],
+                        "properties": {
+                          "image": {
+                            "type": "object",
+                            "required": ["ref"],
+                            "properties": {
+                              "ref": {
+                                "type": "string",
+                                "maxLength": 512,
+                                "pattern": "^(?:[a-z0-9]+(?:[._-][a-z0-9]+)*(?::[0-9]+)?/)?(?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*@sha256:[0-9a-f]{64}$"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "hostPort": {
+                        "type": "integer",
+                        "minimum": 1024,
+                        "maximum": 65535
+                      }
+                    },
+                    "additionalProperties": false
                   }
                 },
                 "additionalProperties": false
               }
-            },
-            "additionalProperties": false
+            ]
           },
           "minItems": 1
         },
@@ -194,6 +319,11 @@
                                     "minLength": 1,
                                     "maxLength": 512,
                                     "pattern": "^[^\\s\\p{Cc}\\p{Cf}]+$"
+                                  },
+                                  "contextWindow": {
+                                    "type": "integer",
+                                    "minimum": 1,
+                                    "maximum": 4194304
                                   }
                                 },
                                 "additionalProperties": false

--- a/src/lib/actions/config/observe-export-source.ts
+++ b/src/lib/actions/config/observe-export-source.ts
@@ -85,6 +85,7 @@ const LIVE_READ_SOURCE_LABELS = {
   "inference-route": "live gateway inference route",
   "provider-metadata": "live inference provider metadata",
   "web-search-provider": "live web-search provider metadata",
+  "managed-serving": "managed serving runtime",
   "effective-policy": "effective OpenShell policy",
 } satisfies Readonly<Record<ExportSnapshotReadStage, string>>;
 

--- a/src/lib/adapters/config/live-export-source.test.ts
+++ b/src/lib/adapters/config/live-export-source.test.ts
@@ -7,10 +7,16 @@ import { managedBraveProfile } from "../../../../test/fixtures/openshell-provide
 import { runConfigExport } from "../../actions/config/export";
 import {
   parseNemoClawConfigDocumentName,
+  EXPORTED_VLLM_PROFILE_ID,
+  EXPORTED_VLLM_RECIPE_ID,
+  type ImmutableImageReference,
   parseNemoClawConfigDocumentUid,
 } from "../../config/model";
 import { validateNemoClawConfig } from "../../config/schema";
 
+vi.mock("../../inference/serving/vllm-export-runtime", () => ({
+  observeManagedVllmForExport: vi.fn(),
+}));
 vi.mock("../../state/registry/persistence", () => ({ load: vi.fn() }));
 vi.mock("../../state/registry-entry-view", () => ({ getSandboxEntryInference: vi.fn() }));
 vi.mock("../../inference/live", () => ({ getLiveGatewayInference: vi.fn() }));
@@ -31,6 +37,12 @@ vi.mock("../../onboard/gateway/state-dir", () => ({
   resolveGatewayStateDirForPort: vi.fn(() => "/managed/gateway"),
 }));
 
+import { observeManagedVllmForExport } from "../../inference/serving/vllm-export-runtime";
+import { loadServingCatalog } from "../../inference/serving/catalog-loader";
+import { servingProfileProvenance } from "../../inference/serving/profile-provenance";
+import { applyVllmRuntimeContextWindow } from "../../inference/vllm-runtime-context";
+import { resolveManagedStartupInferenceRoute } from "../../inference/gateway/route-contract";
+import type { ObservedManagedVllmRuntime } from "../../domain/config/export-evidence";
 import { getLiveGatewayInference } from "../../inference/live";
 import { resolveGatewayStateDirForPort } from "../../onboard/gateway/state-dir";
 import {
@@ -852,5 +864,306 @@ describe("live export snapshot reader", () => {
 
     expect(result).toEqual({ kind: "read-failed", stage: "registry" });
     expect(JSON.stringify(result)).not.toContain(canary);
+  });
+});
+
+function mockManagedVllmSource(
+  environmentOverrides: NodeJS.ProcessEnv = {},
+  webSearch: ManagedStartupProfileBuilderInput["webSearch"] = null,
+) {
+  const catalog = loadServingCatalog();
+  const provenance = servingProfileProvenance(catalog, EXPORTED_VLLM_PROFILE_ID);
+  const recipe = catalog.recipes.find(({ metadata }) => metadata.id === EXPORTED_VLLM_RECIPE_ID)!;
+  const model = recipe.spec.model.servedName!;
+  const runtimeImage = provenance.runtimeImage as ImmutableImageReference;
+  const inference = resolveManagedStartupInferenceRoute(
+    "openclaw",
+    "vllm-local",
+    model,
+    "openai-completions",
+  );
+  const environment: NodeJS.ProcessEnv = {};
+  // This is the actual onboarding projection of the fixed server's /v1/models response.
+  applyVllmRuntimeContextWindow({ data: [{ id: model, max_model_len: 65536 }] }, model, {
+    env: environment,
+    logger: { log: vi.fn(), warn: vi.fn() },
+  });
+  Object.assign(environment, environmentOverrides);
+  const built = buildManagedStartupProfile({
+    agent: "openclaw",
+    inference: {
+      routeProvider: inference.providerKey,
+      upstreamProvider: "vllm-local",
+      model,
+      routedBaseUrl: inference.inferenceBaseUrl,
+      upstreamEndpointUrl: null,
+      api: "openai-completions",
+      primaryModelRef: inference.primaryModelRef,
+      compatibility: inference.inferenceCompat ?? {},
+    },
+    dashboard: {
+      agent: "openclaw",
+      mode: "loopback",
+      url: "http://127.0.0.1:18789",
+      port: 18789,
+      bindAddress: "127.0.0.1",
+      wslExposure: false,
+    },
+    webSearch,
+    toolDisclosure: "progressive",
+    hermesToolGateways: [],
+    messagingPlan: null,
+    dcodeAutoApprovalMode: null,
+    observabilityEnabled: null,
+    corporateCa: null,
+    environment,
+  });
+  const source: SandboxEntry = {
+    ...entry,
+    provider: "vllm-local",
+    model,
+    endpointUrl: "http://host.openshell.internal:18000/v1",
+    credentialEnv: null,
+    servingProfileProvenance: provenance,
+    webSearchEnabled: webSearch !== null,
+    webSearchProvider: webSearch?.provider ?? null,
+    workload: {
+      ...entry.workload!,
+      encodedProfile: built.encodedProfile,
+      startupProfileSha256: built.startupProfileSha256,
+    } as SandboxEntry["workload"],
+  };
+  const observed: ObservedManagedVllmRuntime = {
+    containerId: "a".repeat(64),
+    imageId: `sha256:${"b".repeat(64)}`,
+    networkId: "c".repeat(64),
+    startedAt: "2026-09-10T12:00:00Z",
+    serving: {
+      backend: "vllm",
+      catalogDigest: provenance.catalogDigest,
+      profile: { id: EXPORTED_VLLM_PROFILE_ID, digest: provenance.preset.digest },
+      recipe: { id: EXPORTED_VLLM_RECIPE_ID, digest: provenance.recipe.digest },
+      model: { ...provenance.model, servedName: model },
+      runtime: { image: { ref: runtimeImage } },
+      hostPort: 18000,
+    },
+  };
+  mockSupportedLiveSource(3, 3, source);
+  vi.mocked(observeManagedVllmForExport).mockReturnValue(observed);
+  vi.mocked(getSandboxEntryInference).mockReturnValue({
+    kind: "configured",
+    provider: "vllm-local",
+    model,
+  });
+  vi.mocked(getLiveGatewayInference).mockReturnValue({
+    failure: null,
+    inference: { provider: "vllm-local", model },
+    output: "",
+    status: 0,
+  });
+  const liveSandbox = inventory();
+  Object.assign(liveSandbox.sandbox.spec, { providers: ["vllm-local"] });
+  raw.getSandbox.mockResolvedValue(liveSandbox);
+  const credentials = { NEMOCLAW_VLLM_LOCAL_TOKEN: readFailureCanary };
+  raw.getProvider.mockResolvedValue({
+    provider: {
+      metadata: {
+        id: "provider-id",
+        name: "vllm-local",
+        workspace: "default",
+        resourceVersion: 8n,
+      },
+      type: "openai",
+      profileWorkspace: "default",
+      credentials,
+      config: { OPENAI_BASE_URL: source.endpointUrl },
+    },
+  });
+  raw.getProviderProfile.mockResolvedValue({
+    profile: {
+      id: "openai",
+      source: "user",
+      scope: "workspace",
+      resourceVersion: 4n,
+      credentials: [],
+      endpoints: [],
+      binaries: [],
+      inferenceCapable: true,
+    },
+  });
+  return { source, observed };
+}
+
+describe("managed vLLM export pipeline", () => {
+  it("exports the real fixed onboarding profile and reparses its managed provider", async () => {
+    const f = mockManagedVllmSource();
+    const output = vi.fn(async (_value: string) => {});
+    const publish = vi.fn();
+    const result = await runConfigExport(
+      {
+        sandboxName: "alpha",
+        documentName: parseNemoClawConfigDocumentName("alpha"),
+        target: { kind: "stdout" },
+      },
+      {
+        observe: (name) => observeStableExportSource(name, createLiveExportSnapshotReader()),
+        createDocumentUid: () =>
+          parseNemoClawConfigDocumentUid("123e4567-e89b-42d3-a456-426614174000"),
+        publish,
+        writeStdout: output,
+      },
+    );
+    expect(result).toEqual({ ok: true, completion: { kind: "stdout" } });
+    const yaml = output.mock.calls[0]![0];
+    const document = validateNemoClawConfig(YAML.parse(yaml));
+    expect(document.spec.inferenceProviders).toEqual([
+      {
+        name: "managed-vllm",
+        provider: "vllm-local",
+        api: "openai-completions",
+        serving: f.observed.serving,
+      },
+    ]);
+    expect(document.spec.sandboxes[0]!.agents[0]!.inference.routes[0]!.overrides).toEqual({
+      model: f.source.model,
+      contextWindow: 65536,
+    });
+    expect(yaml).not.toContain(readFailureCanary);
+    expect(yaml).not.toContain("NEMOCLAW_VLLM_LOCAL_TOKEN");
+    expect(yaml).not.toContain("host.openshell.internal");
+    expect(publish).not.toHaveBeenCalled();
+  });
+
+  it("exports managed vLLM and Brave with both qualified profile bindings", async () => {
+    const f = mockManagedVllmSource({}, { fetchEnabled: true, provider: "brave" });
+    const search = braveProvider();
+    const readManagedProvider = raw.getProvider.getMockImplementation()!;
+    const readManagedProfile = raw.getProviderProfile.getMockImplementation()!;
+    raw.getProvider.mockImplementation(async (request: { name: string }) =>
+      request.name === "alpha-brave-search"
+        ? { provider: search.provider }
+        : readManagedProvider(request),
+    );
+    raw.getProviderProfile.mockImplementation(async (request: { id: string }) =>
+      request.id === "brave" ? { profile: managedBraveProfile() } : readManagedProfile(request),
+    );
+    const liveSandbox = inventory();
+    Object.assign(liveSandbox.sandbox.spec, { providers: ["vllm-local", "alpha-brave-search"] });
+    raw.getSandbox.mockResolvedValue(liveSandbox);
+    const { result, writeStdout, publish } = await exportLiveSource();
+    expect(result).toEqual({ ok: true, completion: { kind: "stdout" } });
+    const document = validateNemoClawConfig(YAML.parse(writeStdout.mock.calls[0]![0]));
+    expect(document.spec.inferenceProviders[0]).toMatchObject({ serving: f.observed.serving });
+    expect(document.spec.sandboxes[0]!.integrations?.webSearch).toEqual({
+      provider: "brave",
+      agentRefs: ["primary"],
+      credential: { env: "BRAVE_API_KEY" },
+    });
+    expect(search.readCredential).not.toHaveBeenCalled();
+    expect(publish).not.toHaveBeenCalled();
+  });
+
+  it.each(["NEMOCLAW_MAX_TOKENS", "NEMOCLAW_AGENT_TIMEOUT"])(
+    "rejects unrepresented %s instead of losing it",
+    async (field) => {
+      mockManagedVllmSource({ [field]: "8192" });
+      const result = await observeStableExportSource("alpha", createLiveExportSnapshotReader());
+      expect(result).toMatchObject({
+        ok: false,
+        findings: expect.arrayContaining([
+          expect.objectContaining({
+            category: "unsupported",
+            field: "source.workload.startupProfile",
+          }),
+        ]),
+      });
+    },
+  );
+
+  it("rejects a changed managed route and keeps publication unreachable", async () => {
+    const f = mockManagedVllmSource();
+    vi.mocked(observeManagedVllmForExport).mockReturnValue({
+      ...f.observed,
+      serving: { ...f.observed.serving, hostPort: 19000 },
+    });
+    const result = await observeStableExportSource("alpha", createLiveExportSnapshotReader());
+    expect(result).toMatchObject({
+      ok: false,
+      findings: expect.arrayContaining([
+        expect.objectContaining({ field: "spec.inferenceProviders[].serving" }),
+      ]),
+    });
+  });
+
+  it("detects managed container restart between complete snapshots", async () => {
+    const f = mockManagedVllmSource();
+    let revision = 0;
+    vi.mocked(observeManagedVllmForExport).mockImplementation(() => ({
+      ...f.observed,
+      startedAt: String(revision++),
+    }));
+    expect(
+      await observeStableExportSource("alpha", createLiveExportSnapshotReader()),
+    ).toMatchObject({
+      ok: false,
+      attempts: 2,
+      findings: [expect.objectContaining({ category: "unstable-source" })],
+    });
+  });
+
+  it("rejects a shadowed OpenAI profile with additional endpoint behavior", async () => {
+    mockManagedVllmSource();
+    raw.getProviderProfile.mockResolvedValue({
+      profile: {
+        id: "openai",
+        source: "user",
+        scope: "workspace",
+        resourceVersion: 4n,
+        credentials: [],
+        endpoints: [{ host: "unexpected.example", port: 443 }],
+        binaries: [],
+        inferenceCapable: true,
+      },
+    });
+    expect(await createLiveExportSnapshotReader().read("alpha")).toEqual({
+      kind: "read-failed",
+      stage: "provider-metadata",
+    });
+  });
+
+  it("detects resolved provider profile revision changes", async () => {
+    mockManagedVllmSource();
+    let revision = 4n;
+    raw.getProviderProfile.mockImplementation(async () => ({
+      profile: {
+        id: "openai",
+        source: "user",
+        scope: "workspace",
+        resourceVersion: revision++,
+        credentials: [],
+        endpoints: [],
+        binaries: [],
+        inferenceCapable: true,
+      },
+    }));
+    expect(
+      await observeStableExportSource("alpha", createLiveExportSnapshotReader()),
+    ).toMatchObject({
+      ok: false,
+      attempts: 2,
+      findings: [expect.objectContaining({ category: "unstable-source" })],
+    });
+  });
+
+  it("contains runtime failures before provider metadata or publication", async () => {
+    mockManagedVllmSource();
+    vi.mocked(observeManagedVllmForExport).mockImplementation(() => {
+      throw new Error(readFailureCanary);
+    });
+    expect(await createLiveExportSnapshotReader().read("alpha")).toEqual({
+      kind: "read-failed",
+      stage: "managed-serving",
+    });
+    expect(raw.getProvider).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/adapters/config/live-export-source.ts
+++ b/src/lib/adapters/config/live-export-source.ts
@@ -5,7 +5,7 @@ import os from "node:os";
 import { isDeepStrictEqual } from "node:util";
 import { isValidNemoClawPort } from "../../config/model";
 
-import { createProviders } from "../openshell/providers";
+import { createProviders, type Provider } from "../openshell/providers";
 import { createSandboxes, type Sandbox } from "../openshell/sandboxes";
 import { createSandboxConfig } from "../openshell/sandbox-config";
 import { captureSanitizedResolvedOpenshell } from "../openshell/sanitized-capture";
@@ -18,12 +18,15 @@ import type {
   ObservedExportGateway,
   ObservedExportInference,
   ObservedExportWebSearchProvider,
+  ObservedManagedVllmRuntime,
   ObservedExportEndpointEvidence,
   ObservedExportRegistry,
   ObservedExportSandboxIdentity,
   RawExportSnapshot,
 } from "../../domain/config/export-evidence";
 import { getLiveGatewayInference } from "../../inference/live";
+import { VLLM_LOCAL_CREDENTIAL_ENV } from "../../inference/serving/vllm-credential-contract";
+import { observeManagedVllmForExport } from "../../inference/serving/vllm-export-runtime";
 import { normalizeInferenceSelection } from "../../inference/selection";
 import { resolveGatewayName } from "../../onboard/gateway-binding/identity";
 import {
@@ -123,22 +126,52 @@ function providerContract(api: string | null | undefined) {
   return { type, configKey: "OPENAI_BASE_URL" } as const;
 }
 
+function providerIdentity(provider: Provider, gatewayName: string, managed: boolean) {
+  return {
+    gatewayName,
+    workspace: provider.workspace,
+    name: provider.name,
+    id: provider.id,
+    resourceVersion: provider.resourceVersion,
+    ...(managed
+      ? { profileWorkspace: provider.profileWorkspace, managedProfile: provider.managedProfile }
+      : {}),
+  };
+}
+
+function expectedCredentialKeys(credentialEnv: string | null, managed: boolean): string[] {
+  if (managed) return [VLLM_LOCAL_CREDENTIAL_ENV];
+  return credentialEnv === null ? [] : [credentialEnv];
+}
+
+function inferenceTopology(
+  entry: Readonly<SandboxEntry>,
+  managed: boolean,
+): ObservedExportInference["topology"] {
+  if (managed) return "managed";
+  return entry.hostLocalInferenceReceipt || entry.hostLocalInferenceProvenance || entry.nimContainer
+    ? "local"
+    : "hosted";
+}
+
 async function readProviderEvidence(
   normalized: ReturnType<typeof normalizeInferenceSelection>,
   routeProvider: string,
   gatewayName: string,
   signal: AbortSignal,
+  managedServing?: ObservedManagedVllmRuntime,
 ): Promise<ObservedExportEndpointEvidence> {
   const { type, configKey } = providerContract(normalized.preferredInferenceApi);
   const provider = await createProviders().get({
     target: namedOpenShellGateway(gatewayName),
     workspace: "default",
     name: routeProvider,
+    ...(managedServing ? { profileContract: "openai" as const } : {}),
     configKeys: [configKey],
     signal,
   });
   if (!provider) throw new Error("The live inference provider is missing.");
-  const credentialKeys = normalized.credentialEnv === null ? [] : [normalized.credentialEnv];
+  const credentialKeys = expectedCredentialKeys(normalized.credentialEnv, !!managedServing);
   const builtin = provider.builtinInferenceEndpoint !== undefined;
   if (
     type === null ||
@@ -150,13 +183,7 @@ async function readProviderEvidence(
     throw new Error("The live inference provider metadata does not match the registry.");
   }
   return {
-    provider: {
-      gatewayName,
-      workspace: provider.workspace,
-      name: provider.name,
-      id: provider.id,
-      resourceVersion: provider.resourceVersion,
-    },
+    provider: providerIdentity(provider, gatewayName, !!managedServing),
     endpoint: provider.builtinInferenceEndpoint ?? provider.config[configKey] ?? "",
     source: builtin
       ? { kind: "builtin-profile", profileId: "nvidia" }
@@ -168,6 +195,7 @@ async function inferenceFor(
   entry: Readonly<SandboxEntry>,
   beforeProviderRead: () => void,
   signal: AbortSignal,
+  managedServing?: ObservedManagedVllmRuntime,
 ): Promise<ObservedExportInference> {
   const normalized = normalizeInferenceSelection(entry);
   const gateway = resolveGatewayBinding(entry);
@@ -178,18 +206,17 @@ async function inferenceFor(
     live.provider,
     gateway.name,
     signal,
+    managedServing,
   );
   return {
-    topology:
-      entry.hostLocalInferenceReceipt || entry.hostLocalInferenceProvenance || entry.nimContainer
-        ? "local"
-        : "hosted",
+    topology: inferenceTopology(entry, !!managedServing),
     provider: live.provider,
     model: live.model,
     api: normalized.preferredInferenceApi ?? "",
     endpoint: normalized.endpointUrl ?? "",
     endpointEvidence,
     credentialEnv: normalized.credentialEnv,
+    ...(managedServing ? { managedServing } : {}),
   };
 }
 
@@ -270,6 +297,11 @@ async function readSnapshot(sandboxName: string): Promise<RawExportSnapshot> {
     if (!row) throw new Error("The live sandbox is missing.");
     stage = "sandbox-identity";
     const sandbox = sandboxIdentity(row);
+    stage = "managed-serving";
+    const managedServing =
+      entry.provider === "vllm-local" && entry.servingProfileProvenance
+        ? observeManagedVllmForExport(entry.servingProfileProvenance)
+        : undefined;
     stage = "inference-route";
     const inference = await inferenceFor(
       entry,
@@ -277,6 +309,7 @@ async function readSnapshot(sandboxName: string): Promise<RawExportSnapshot> {
         stage = "provider-metadata";
       },
       signal,
+      managedServing,
     );
     let webSearchProvider: ObservedExportWebSearchProvider | undefined;
     if (entry.webSearchEnabled === true && entry.webSearchProvider === "brave") {

--- a/src/lib/config/config.test.ts
+++ b/src/lib/config/config.test.ts
@@ -5,6 +5,8 @@ import YAML from "yaml";
 import { describe, expect, it } from "vitest";
 import { renderCanonicalNemoClawConfig, validateNemoClawConfig } from "./index";
 import {
+  EXPORTED_VLLM_PROFILE_ID,
+  EXPORTED_VLLM_RECIPE_ID,
   isCredentialEnvironmentReferenceName,
   isImmutableImageReference,
   isValidNemoClawBoundedText,
@@ -447,5 +449,106 @@ describe("NemoClawConfig v1", () => {
     expect(second.documentDigest).not.toBe(first.documentDigest);
     expect(second.specDigest).toBe(first.specDigest);
     expect(first.documentDigest).toMatch(/^sha256:[0-9a-f]{64}$/u);
+  });
+});
+
+function managedServingConfig() {
+  const value = config();
+  const provider = {
+    name: "managed-vllm",
+    provider: "vllm-local",
+    api: "openai-completions",
+    serving: {
+      backend: "vllm",
+      catalogDigest: `sha256:${"b".repeat(64)}`,
+      profile: { id: EXPORTED_VLLM_PROFILE_ID, digest: `sha256:${"c".repeat(64)}` },
+      recipe: { id: EXPORTED_VLLM_RECIPE_ID, digest: `sha256:${"d".repeat(64)}` },
+      model: { id: "nvidia/model", revision: "e".repeat(40), servedName: "managed-model" },
+      runtime: { image: { ref: `nvcr.io/nvidia/vllm@sha256:${"f".repeat(64)}` } },
+      hostPort: 18000,
+    },
+  };
+  Object.assign(value.spec, { inferenceProviders: [provider] });
+  const route = {
+    name: "primary",
+    providerRef: "managed-vllm",
+    overrides: { model: "managed-model", contextWindow: 65536 },
+  };
+  value.spec.sandboxes[0]!.agents[0]!.inference.routes = [route];
+  return { value, provider, route };
+}
+
+describe("fixed managed serving public contract", () => {
+  it("round trips an immutable catalog reference and nondefault published port", () => {
+    const { value } = managedServingConfig();
+    expect(validateNemoClawConfig(YAML.parse(renderInput(value).yaml))).toEqual(value);
+  });
+
+  it.each([
+    [
+      "transport credential",
+      (f: ReturnType<typeof managedServingConfig>) =>
+        Object.assign(f.provider, { credential: { env: "NEMOCLAW_VLLM_LOCAL_TOKEN" } }),
+    ],
+    [
+      "arbitrary endpoint",
+      (f: ReturnType<typeof managedServingConfig>) =>
+        Object.assign(f.provider, { endpoint: "http://127.0.0.1:18000/v1" }),
+    ],
+    [
+      "arbitrary arguments",
+      (f: ReturnType<typeof managedServingConfig>) =>
+        Object.assign(f.provider.serving, { arguments: ["--trust-remote-code"] }),
+    ],
+    [
+      "other recipe",
+      (f: ReturnType<typeof managedServingConfig>) => {
+        Object.assign(f.provider.serving.recipe, { id: "other" });
+      },
+    ],
+    [
+      "mutable image",
+      (f: ReturnType<typeof managedServingConfig>) => {
+        f.provider.serving.runtime.image.ref = "vllm:latest";
+      },
+    ],
+    [
+      "unknown backend",
+      (f: ReturnType<typeof managedServingConfig>) => {
+        f.provider.serving.backend = "ollama";
+      },
+    ],
+    [
+      "unknown runtime property",
+      (f: ReturnType<typeof managedServingConfig>) =>
+        Object.assign(f.provider.serving.runtime, { env: { SECRET: "private" } }),
+    ],
+    [
+      "missing context",
+      (f: ReturnType<typeof managedServingConfig>) =>
+        Reflect.deleteProperty(f.route.overrides, "contextWindow"),
+    ],
+    [
+      "different context",
+      (f: ReturnType<typeof managedServingConfig>) => {
+        f.route.overrides.contextWindow = 32768;
+      },
+    ],
+    [
+      "different model",
+      (f: ReturnType<typeof managedServingConfig>) => {
+        f.route.overrides.model = "other";
+      },
+    ],
+    [
+      "different runtime",
+      (f: ReturnType<typeof managedServingConfig>) => {
+        f.value.spec.sandboxes[0]!.runtime.provider = "apple-container";
+      },
+    ],
+  ])("rejects %s instead of accepting an incomplete managed intent", (_name, change) => {
+    const f = managedServingConfig();
+    change(f);
+    expect(() => validateNemoClawConfig(f.value)).toThrow();
   });
 });

--- a/src/lib/config/model.ts
+++ b/src/lib/config/model.ts
@@ -210,7 +210,7 @@ const NemoClawGatewayConfigSchema = Type.Object(
   { additionalProperties: false },
 );
 
-const NemoClawInferenceProviderConfigSchema = Type.Object(
+const NemoClawHostedInferenceProviderConfigSchema = Type.Object(
   {
     name: LocalResourceNameSchema,
     provider: BoundedTextSchema,
@@ -221,8 +221,69 @@ const NemoClawInferenceProviderConfigSchema = Type.Object(
   { additionalProperties: false },
 );
 
+export const EXPORTED_VLLM_PROFILE_ID =
+  "vllm.linux-amd64-nvidia.single.nemotron-3.5-lightning-30b-a3b-nvfp4" as const;
+export const EXPORTED_VLLM_CONTEXT_WINDOW = 65_536;
+export const EXPORTED_VLLM_RECIPE_ID =
+  "vllm.nemotron-3.5-lightning-30b-a3b-nvfp4.linux-amd64-single.v1" as const;
+
+const ServingDigestSchema = Type.String({ pattern: "^sha256:[a-f0-9]{64}$" });
+
+/** The first managed-serving branch describes one fixed, catalog-owned deployment. */
+export const NemoClawManagedVllmServingSchema = Type.Object(
+  {
+    backend: Type.Literal("vllm"),
+    catalogDigest: ServingDigestSchema,
+    profile: Type.Object(
+      { id: Type.Literal(EXPORTED_VLLM_PROFILE_ID), digest: ServingDigestSchema },
+      { additionalProperties: false },
+    ),
+    recipe: Type.Object(
+      { id: Type.Literal(EXPORTED_VLLM_RECIPE_ID), digest: ServingDigestSchema },
+      { additionalProperties: false },
+    ),
+    model: Type.Object(
+      {
+        id: BoundedTextSchema,
+        revision: Type.String({ pattern: "^[a-f0-9]{40}$" }),
+        servedName: BoundedTextSchema,
+      },
+      { additionalProperties: false },
+    ),
+    runtime: Type.Object(
+      {
+        image: Type.Object({ ref: ImmutableImageReferenceSchema }, { additionalProperties: false }),
+      },
+      { additionalProperties: false },
+    ),
+    hostPort: Type.Integer({ minimum: 1024, maximum: 65_535 }),
+  },
+  { additionalProperties: false },
+);
+export type NemoClawManagedVllmServing = TypeBoxModule.Type.Static<
+  typeof NemoClawManagedVllmServingSchema
+>;
+
+const NemoClawManagedInferenceProviderConfigSchema = Type.Object(
+  {
+    name: LocalResourceNameSchema,
+    provider: Type.Literal("vllm-local"),
+    api: Type.Literal("openai-completions"),
+    serving: NemoClawManagedVllmServingSchema,
+  },
+  { additionalProperties: false },
+);
+
+const NemoClawInferenceProviderConfigSchema = Type.Union([
+  NemoClawHostedInferenceProviderConfigSchema,
+  NemoClawManagedInferenceProviderConfigSchema,
+]);
+
 const NemoClawRouteOverridesSchema = Type.Object(
-  { model: BoundedTextSchema },
+  {
+    model: BoundedTextSchema,
+    contextWindow: Type.Optional(Type.Integer({ minimum: 1, maximum: 4_194_304 })),
+  },
   { additionalProperties: false },
 );
 

--- a/src/lib/config/schema.ts
+++ b/src/lib/config/schema.ts
@@ -15,8 +15,10 @@ import { cloneAndDeepFreeze } from "../core/immutable";
 import { isSandboxPolicyCredentialFree } from "../policy/sandbox-policy-validation";
 import {
   isCredentialEnvironmentReferenceName,
+  EXPORTED_VLLM_CONTEXT_WINDOW,
   NemoClawConfigSchema,
   type NemoClawConfig,
+  type NemoClawInferenceProviderConfig,
   type NemoClawSandboxConfig,
   type ValidatedNemoClawConfig,
 } from "./model";
@@ -119,6 +121,30 @@ function webSearchProblems(sandbox: NemoClawSandboxConfig, sandboxIndex: number)
   return problems;
 }
 
+function managedProviderProblems(
+  config: NemoClawConfig,
+  provider: Extract<NemoClawInferenceProviderConfig, { serving: unknown }>,
+  providerIndex: number,
+): string[] {
+  const matches = config.spec.sandboxes.every((sandbox) =>
+    sandbox.agents.every((agent) =>
+      agent.inference.routes.every(
+        (route) =>
+          route.providerRef !== provider.name ||
+          isDeepStrictEqual(
+            [sandbox.runtime.provider, route.overrides.model, route.overrides.contextWindow],
+            ["docker", provider.serving.model.servedName, EXPORTED_VLLM_CONTEXT_WINDOW],
+          ),
+      ),
+    ),
+  );
+  return matches
+    ? []
+    : [
+        `/spec/inferenceProviders/${providerIndex}/serving does not match the sandbox runtime or route model`,
+      ];
+}
+
 function semanticProblems(config: NemoClawConfig): string[] {
   const problems = [
     ...duplicateProblems(
@@ -132,6 +158,10 @@ function semanticProblems(config: NemoClawConfig): string[] {
   ];
   const providers = new Set(config.spec.inferenceProviders.map(({ name }) => name));
   for (const [providerIndex, provider] of config.spec.inferenceProviders.entries()) {
+    if ("serving" in provider) {
+      problems.push(...managedProviderProblems(config, provider, providerIndex));
+      continue;
+    }
     const endpointViolation = unsafeEndpointUrlViolation(provider.endpoint);
     if (endpointViolation)
       problems.push(

--- a/src/lib/domain/config/export-document.ts
+++ b/src/lib/domain/config/export-document.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { EXPORTED_VLLM_CONTEXT_WINDOW } from "../../config/model";
 import type {
   NemoClawConfig,
   NemoClawConfigDocumentName,
@@ -21,6 +22,14 @@ function inferenceProvider(
   source: VerifiedExportSource,
   name: string,
 ): NemoClawInferenceProviderConfig {
+  if ("serving" in source.inference) {
+    return {
+      name,
+      provider: source.inference.provider,
+      api: source.inference.api,
+      serving: source.inference.serving,
+    };
+  }
   const provider = {
     name,
     provider: source.inference.provider,
@@ -42,7 +51,8 @@ export function buildExportConfig(
   source: VerifiedExportSource,
   identity: ExportConfigBuildIdentity,
 ): NemoClawConfig {
-  const providerName = providerLocalName(source.inference.provider);
+  const providerName =
+    "serving" in source.inference ? "managed-vllm" : providerLocalName(source.inference.provider);
   const candidate = {
     apiVersion: "nemoclaw.nvidia.com/v1",
     kind: "NemoClawConfig",
@@ -74,7 +84,12 @@ export function buildExportConfig(
                   {
                     name: "primary",
                     providerRef: providerName,
-                    overrides: { model: source.inference.model },
+                    overrides: {
+                      model: source.inference.model,
+                      ...("serving" in source.inference
+                        ? { contextWindow: EXPORTED_VLLM_CONTEXT_WINDOW }
+                        : {}),
+                    },
                   },
                 ],
               },

--- a/src/lib/domain/config/export-evidence.ts
+++ b/src/lib/domain/config/export-evidence.ts
@@ -4,6 +4,7 @@
 import type * as TypeBoxModule from "typebox" with { "resolution-mode": "import" };
 import {
   BoundedTextSchema,
+  NemoClawManagedVllmServingSchema,
   CredentialEnvironmentReferenceNameSchema,
   ImmutableImageReferenceSchema,
   InferenceEndpointSchema,
@@ -61,6 +62,7 @@ export const EXPORT_REGISTRY_EVIDENCE_KEYS = [
   "provider",
   "sandboxGpuDevice",
   "sandboxGpuEnabled",
+  "servingProfileProvenance",
   "toolDisclosure",
   "webSearchEnabled",
   "webSearchProvider",
@@ -90,6 +92,13 @@ export interface ObservedExportEndpointEvidence {
     readonly name: string;
     readonly id: string;
     readonly resourceVersion: string;
+    readonly profileWorkspace?: string;
+    readonly managedProfile?: {
+      readonly id: "brave" | "openai";
+      readonly source: "builtin" | "user";
+      readonly scope: "" | "platform" | "workspace";
+      readonly resourceVersion: string;
+    };
   };
   readonly endpoint: string;
   readonly source:
@@ -118,6 +127,14 @@ export interface ObservedExportWebSearchProvider {
   };
 }
 
+export interface ObservedManagedVllmRuntime {
+  readonly serving: import("../../config/model").NemoClawManagedVllmServing;
+  readonly containerId: string;
+  readonly imageId: string;
+  readonly networkId: string;
+  readonly startedAt: string;
+}
+
 export interface ObservedExportInference {
   readonly topology: "hosted" | "managed" | "local" | "unknown";
   readonly provider: string;
@@ -127,6 +144,7 @@ export interface ObservedExportInference {
   readonly endpoint: string;
   readonly endpointEvidence: ObservedExportEndpointEvidence | null;
   readonly credentialEnv: string | null;
+  readonly managedServing?: ObservedManagedVllmRuntime;
 }
 
 export interface ObservedExportPolicy {
@@ -153,6 +171,7 @@ export type ExportSnapshotReadStage =
   | "inference-route"
   | "provider-metadata"
   | "web-search-provider"
+  | "managed-serving"
   | "effective-policy";
 
 /** One complete, untrusted read from all export evidence owners. */
@@ -205,7 +224,7 @@ export interface ExportFinding {
 export type NonEmptyExportFindings = readonly [ExportFinding, ...ExportFinding[]];
 
 // Runtime refinements preserve semantic checks that are not part of JSON Schema.
-const ExportInferenceSchema = Type.Object({
+const HostedExportInferenceSchema = Type.Object({
   provider: Type.Refine(BoundedTextSchema, isValidNemoClawBoundedText),
   model: Type.Refine(BoundedTextSchema, isValidNemoClawBoundedText),
   api: NemoClawInferenceApiSchema,
@@ -214,6 +233,19 @@ const ExportInferenceSchema = Type.Object({
     Type.Refine(CredentialEnvironmentReferenceNameSchema, isCredentialEnvironmentReferenceName),
   ),
 });
+
+const ExportInferenceSchema = Type.Union([
+  HostedExportInferenceSchema,
+  Type.Object(
+    {
+      provider: Type.Literal("vllm-local"),
+      model: Type.Refine(BoundedTextSchema, isValidNemoClawBoundedText),
+      api: Type.Literal("openai-completions"),
+      serving: NemoClawManagedVllmServingSchema,
+    },
+    { additionalProperties: false },
+  ),
+]);
 
 /** Representable values only; provenance and policy qualification remain separate. */
 export const ExportSourceValuesSchema = Type.Object({

--- a/src/lib/domain/config/verify-export-source.ts
+++ b/src/lib/domain/config/verify-export-source.ts
@@ -13,6 +13,8 @@ import { readManagedWorkloadAuthority } from "../../onboard/workload/authority";
 import { sortCanonicalMappings } from "../../config/canonical-mapping";
 import {
   isCredentialEnvironmentReferenceName,
+  EXPORTED_VLLM_PROFILE_ID,
+  EXPORTED_VLLM_CONTEXT_WINDOW,
   isImmutableImageReference,
   isValidNemoClawBoundedText,
   isValidNemoClawInferenceEndpoint,
@@ -24,6 +26,7 @@ import {
 } from "../../config/model";
 import { fingerprintOpenShellSandboxId } from "../sandbox/openshell-identity";
 import { ExportSourceValuesSchema } from "./export-evidence";
+import { validateManagedServing } from "./verify-managed-serving";
 import type {
   CanonicalExportPolicy,
   ExportFinding,
@@ -239,7 +242,7 @@ export function classifyExportRegistry(entry: ObservedExportRegistry): ExportFin
       finding(
         "spec.inferenceProviders",
         "unsupported",
-        "V1 export supports hosted external inference only.",
+        "This local inference topology is not represented by v1 export.",
       ),
     );
   return findings;
@@ -287,7 +290,10 @@ function expectedManagedStartupProfile(entry: ObservedExportRegistry): ManagedSt
     messagingPlan: null,
     dcodeAutoApprovalMode: null,
     observabilityEnabled: null,
-    environment: {},
+    environment:
+      entry.servingProfileProvenance?.preset.id === EXPORTED_VLLM_PROFILE_ID
+        ? { NEMOCLAW_CONTEXT_WINDOW: String(EXPORTED_VLLM_CONTEXT_WINDOW) }
+        : {},
     corporateCa: null,
   }).profile;
 }
@@ -538,15 +544,26 @@ function validateGateway(snapshot: QualifiedExportSnapshot): ExportFinding[] {
 function validateInferenceSelection(snapshot: QualifiedExportSnapshot): ExportFinding[] {
   const { registry: entry, inference } = snapshot;
   const findings: ExportFinding[] = [];
-  if (inference.topology !== "hosted")
+  if (inference.topology !== "hosted" && inference.topology !== "managed")
     findings.push(
       finding(
         "spec.inferenceProviders",
         "unsupported",
-        "V1 export supports hosted external inference only.",
+        "This local inference topology is not represented by v1 export.",
       ),
     );
 
+  if (
+    inference.topology !== "managed" &&
+    (entry.servingProfileProvenance || inference.managedServing)
+  )
+    findings.push(
+      finding(
+        "spec.inferenceProviders[].serving",
+        "unsupported",
+        "Recorded managed serving requires complete live managed runtime evidence.",
+      ),
+    );
   const selected = normalizeInferenceSelection(entry);
   if (
     !isDeepStrictEqual(
@@ -578,6 +595,7 @@ function validateInferenceSelection(snapshot: QualifiedExportSnapshot): ExportFi
 
 function validateInferenceRepresentation(snapshot: QualifiedExportSnapshot): ExportFinding[] {
   const { inference } = snapshot;
+  if (inference.topology === "managed") return validateManagedServing(snapshot);
   const findings: ExportFinding[] = [];
   if (
     [inference.provider, inference.model, inference.api, inference.endpoint].some((value) => !value)
@@ -627,7 +645,7 @@ function validateEndpointEvidence(snapshot: QualifiedExportSnapshot): ExportFind
   }
   const findings: ExportFinding[] = [];
 
-  if (!isValidNemoClawInferenceEndpoint(evidence.endpoint))
+  if (inference.topology !== "managed" && !isValidNemoClawInferenceEndpoint(evidence.endpoint))
     findings.push(
       finding(
         "source.inference.endpoint",
@@ -664,6 +682,7 @@ function validateEndpointEvidence(snapshot: QualifiedExportSnapshot): ExportFind
 
 function validateCredentialReference(snapshot: QualifiedExportSnapshot): ExportFinding[] {
   const { inference } = snapshot;
+  if (inference.topology === "managed") return [];
   const findings: ExportFinding[] = [];
   if (
     inference.credentialEnv !== null &&
@@ -773,13 +792,21 @@ function completeVerifiedSource(
       : {}),
     runtime: { provider: entry.openshellDriver, imageRef: authority?.receipt.reference },
     gateway: { name: snapshot.gateway.name, port: snapshot.gateway.port },
-    inference: {
-      provider: selected.provider,
-      model: selected.model,
-      api: selected.preferredInferenceApi,
-      endpoint: selected.endpointUrl,
-      ...(selected.credentialEnv === null ? {} : { credentialEnv: selected.credentialEnv }),
-    },
+    inference:
+      snapshot.inference.topology === "managed"
+        ? {
+            provider: selected.provider,
+            model: selected.model,
+            api: selected.preferredInferenceApi,
+            serving: snapshot.inference.managedServing?.serving,
+          }
+        : {
+            provider: selected.provider,
+            model: selected.model,
+            api: selected.preferredInferenceApi,
+            endpoint: selected.endpointUrl,
+            ...(selected.credentialEnv === null ? {} : { credentialEnv: selected.credentialEnv }),
+          },
   };
   if (!Check(ExportSourceValuesSchema, values)) {
     return {

--- a/src/lib/domain/config/verify-managed-serving.ts
+++ b/src/lib/domain/config/verify-managed-serving.ts
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { isDeepStrictEqual } from "node:util";
+import type * as TypeBoxValueModule from "typebox/value" with { "resolution-mode": "import" };
+import {
+  EXPORTED_VLLM_PROFILE_ID,
+  EXPORTED_VLLM_RECIPE_ID,
+  NemoClawManagedVllmServingSchema,
+  type NemoClawManagedVllmServing,
+} from "../../config/model";
+import type { ServingProfileProvenance } from "../../inference/serving/types";
+import type {
+  ExportFinding,
+  QualifiedExportSnapshot,
+  ObservedManagedVllmRuntime,
+  ObservedExportEndpointEvidence,
+} from "./export-evidence";
+
+const { Check } = require("typebox/value") as typeof TypeBoxValueModule;
+
+function validRuntimeIdentity(observed: ObservedManagedVllmRuntime): boolean {
+  return (
+    Check(NemoClawManagedVllmServingSchema, observed.serving) &&
+    /^[a-f0-9]{64}$/.test(observed.containerId) &&
+    /^sha256:[a-f0-9]{64}$/.test(observed.imageId) &&
+    /^[a-f0-9]{64}$/.test(observed.networkId) &&
+    observed.startedAt.length > 0 &&
+    observed.startedAt.length <= 64
+  );
+}
+
+function matchesProvenance(
+  serving: NemoClawManagedVllmServing,
+  recorded: ServingProfileProvenance,
+): boolean {
+  return isDeepStrictEqual(
+    [
+      recorded.schemaVersion,
+      recorded.catalogDigest,
+      recorded.preset.id,
+      recorded.preset.digest,
+      recorded.recipe.id,
+      recorded.recipe.digest,
+      recorded.recipe.backend,
+      recorded.model,
+      recorded.runtimeImage,
+    ],
+    [
+      1,
+      serving.catalogDigest,
+      EXPORTED_VLLM_PROFILE_ID,
+      serving.profile.digest,
+      EXPORTED_VLLM_RECIPE_ID,
+      serving.recipe.digest,
+      "vllm",
+      { id: serving.model.id, revision: serving.model.revision },
+      serving.runtime.image.ref,
+    ],
+  );
+}
+
+function validProfileVersion(version: string): boolean {
+  return /^(0|[1-9][0-9]{0,19})$/.test(version) && BigInt(version) <= 18446744073709551615n;
+}
+
+function hasManagedOpenAiProfile(evidence: ObservedExportEndpointEvidence | null): boolean {
+  if (!evidence) return false;
+  const { provider } = evidence;
+  const profile = provider.managedProfile;
+  if (!profile) return false;
+  const version = profile.resourceVersion;
+  if (profile.id !== "openai" || !validProfileVersion(version)) return false;
+  if (profile.source === "builtin")
+    return isDeepStrictEqual([provider.profileWorkspace, profile.scope, version], ["", "", "0"]);
+  return (
+    profile.source === "user" &&
+    version !== "0" &&
+    [
+      ["", "platform"],
+      [provider.workspace, "workspace"],
+    ].some((binding) => isDeepStrictEqual([provider.profileWorkspace, profile.scope], binding))
+  );
+}
+
+export function validateManagedServing(snapshot: QualifiedExportSnapshot): ExportFinding[] {
+  const { registry: entry, inference } = snapshot;
+  const observed = inference.managedServing;
+  const recorded = entry.servingProfileProvenance;
+  const invalid = () => [
+    {
+      field: "spec.inferenceProviders[].serving",
+      category: "drifted" as const,
+      diagnostic: "The fixed managed serving identity, provenance, or route could not be verified.",
+    },
+  ];
+  if (!observed || !recorded) return invalid();
+  const serving = observed.serving;
+  if (
+    !validRuntimeIdentity(observed) ||
+    !isDeepStrictEqual(
+      [
+        entry.agent,
+        entry.openshellDriver,
+        entry.workload?.kind,
+        entry.workload?.kind === "managed-image" ? entry.workload.platform : null,
+        snapshot.sandbox.providerNames.filter((name) => name === inference.provider),
+        inference.provider,
+        inference.api,
+        inference.credentialEnv,
+        inference.model,
+        inference.endpoint,
+      ],
+      [
+        "openclaw",
+        "docker",
+        "managed-image",
+        "linux/amd64",
+        ["vllm-local"],
+        "vllm-local",
+        "openai-completions",
+        null,
+        serving.model.servedName,
+        `http://host.openshell.internal:${String(serving.hostPort)}/v1`,
+      ],
+    ) ||
+    !hasManagedOpenAiProfile(inference.endpointEvidence) ||
+    !matchesProvenance(observed.serving, recorded)
+  )
+    return invalid();
+  return [];
+}

--- a/src/lib/inference/config.ts
+++ b/src/lib/inference/config.ts
@@ -17,6 +17,7 @@ import type { ManagedLlamaCppOwnership } from "./llama-cpp/managed-state";
 import { DEFAULT_OLLAMA_MODEL_TAG as DEFAULT_OLLAMA_MODEL } from "./ollama-model-registry";
 import { OLLAMA_LOCAL_CREDENTIAL_ENV } from "./ollama/contract";
 import { OPENROUTER_CREDENTIAL_ENV, OPENROUTER_PROVIDER_NAME } from "./openrouter";
+import { VLLM_LOCAL_CREDENTIAL_ENV } from "./serving/vllm-credential-contract";
 
 export { isSafeModelId };
 export { OLLAMA_LOCAL_CREDENTIAL_ENV };
@@ -75,7 +76,7 @@ export const DEFAULT_ROUTE_CREDENTIAL_ENV = "OPENAI_API_KEY";
 // Dedicated credential env names for local inference. Decoupled from
 // OPENAI_API_KEY so the sandbox-side OpenClaw and the host-side gateway
 // never read the user's host OpenAI key for local providers. See GH #2519.
-export const VLLM_LOCAL_CREDENTIAL_ENV = "NEMOCLAW_VLLM_LOCAL_TOKEN";
+export { VLLM_LOCAL_CREDENTIAL_ENV };
 export const LLAMA_CPP_LOCAL_CREDENTIAL_ENV = LLAMA_CPP_CREDENTIAL_ENV;
 export const MANAGED_PROVIDER_ID = "inference";
 export { DEFAULT_OLLAMA_MODEL };

--- a/src/lib/inference/serving/host-local-vllm-selection.ts
+++ b/src/lib/inference/serving/host-local-vllm-selection.ts
@@ -6,7 +6,7 @@ import os from "node:os";
 import { getBuildIdentity } from "../../core/version.js";
 import { createHostReadinessReport } from "../../readiness/host.js";
 import type { VllmProfile } from "../vllm.js";
-import type { VllmModelDef } from "../vllm-models.js";
+import type { VllmModelDef, VllmPlatform } from "../vllm-models.js";
 import { VLLM_EXTRA_ARGS_ENV } from "../vllm-models.js";
 import {
   HOST_LOCAL_VLLM_LIFECYCLE_REF,
@@ -24,6 +24,7 @@ import type {
   HostLocalInferenceServingRecipe,
   ManagedInferenceReadinessSource,
   ResolvedHostLocalInferenceSelection,
+  VllmDirectInstallPolicy,
 } from "./types.js";
 
 export interface MaterializedHostLocalVllmSelection {
@@ -38,13 +39,8 @@ export type HostLocalVllmSelectionResult =
   | { readonly kind: "rejected"; readonly reason: string }
   | ({ readonly kind: "selected" } & MaterializedHostLocalVllmSelection);
 
-function positiveIntegerArgument(
-  selection: ResolvedHostLocalInferenceSelection,
-  name: string,
-): number {
-  const matches = selection.recipe.spec.serve?.arguments?.filter(
-    (argument) => argument.name === name,
-  );
+function positiveIntegerArgument(recipe: HostLocalInferenceServingRecipe, name: string): number {
+  const matches = recipe.spec.serve?.arguments?.filter((argument) => argument.name === name);
   const value = matches?.length === 1 ? matches[0]!.value : undefined;
   const parsed =
     typeof value === "number"
@@ -58,6 +54,51 @@ function positiveIntegerArgument(
   return parsed;
 }
 
+/** Materialize the same fixed model command for installation and read-only runtime verification. */
+export function materializeHostLocalVllmModel(
+  recipe: HostLocalInferenceServingRecipe,
+  directInstall: VllmDirectInstallPolicy,
+  platform: VllmPlatform,
+): VllmModelDef {
+  const runtime = recipe.spec.runtime;
+  const serveEnvironment = {
+    ...runtime.environment,
+    HF_HOME: runtime.modelCache.target,
+    HF_HUB_OFFLINE: "1",
+    TRANSFORMERS_OFFLINE: "1",
+  };
+  const gpuMemoryUtilization = hostLocalVllmGpuMemoryUtilization(recipe);
+  return {
+    id: recipe.spec.model.id,
+    label: recipe.spec.model.displayName,
+    envValue: recipe.spec.model.environmentValue,
+    downloadSizeBytes: recipe.spec.model.downloadSizeBytes,
+    maxModelLen: positiveIntegerArgument(recipe, "--max-model-len"),
+    revision: recipe.spec.model.revision,
+    servedModelId: recipe.spec.model.servedName,
+    modelArgs: hostLocalVllmModelArguments(recipe),
+    gated: recipe.spec.model.gated,
+    platforms: [platform],
+    minComputeCapability: runtime.minimumComputeCapability,
+    ...(Object.keys(serveEnvironment).length > 0 ? { serveEnv: serveEnvironment } : {}),
+    runtime: {
+      image: runtime.image,
+      imageDownloadSizeBytes: runtime.imageDownloadSizeBytes,
+      modelDownloadSizeBytes: recipe.spec.model.downloadSizeBytes,
+      loadTimeoutSec: recipe.spec.readiness.timeoutSeconds,
+      pullTimeoutSec: runtime.pullTimeoutSeconds,
+      minComputeCapability: runtime.minimumComputeCapability,
+      minGpuMemoryBytes: runtime.minimumGpuMemoryBytes,
+      gpuMemoryUtilization,
+      dockerRunArgs: hostLocalVllmDockerRunArguments(recipe),
+      dockerRunArgsMode: "replace",
+    },
+    installFastSafetensors: recipe.spec.model.installFastSafetensors,
+    ...(directInstall.authentication === "bearer" ? { managedBearerAuth: true as const } : {}),
+    ...(directInstall.fixedArguments ? { fixedServeCommand: true as const } : {}),
+  };
+}
+
 export function materializeHostLocalVllmSelection(
   selection: ResolvedHostLocalInferenceSelection,
   baseProfile: VllmProfile,
@@ -65,8 +106,7 @@ export function materializeHostLocalVllmSelection(
   const { recipe, preset } = selection;
   if (
     recipe.spec.backend !== "vllm" ||
-    recipe.spec.execution.materializerRef !==
-      HOST_LOCAL_VLLM_MATERIALIZER_REF ||
+    recipe.spec.execution.materializerRef !== HOST_LOCAL_VLLM_MATERIALIZER_REF ||
     recipe.spec.execution.lifecycleRef !== HOST_LOCAL_VLLM_LIFECYCLE_REF
   ) {
     throw new Error("selected serving preset is not a host-local vLLM recipe");
@@ -77,15 +117,8 @@ export function materializeHostLocalVllmSelection(
     : recipe.spec.serve.directInstall;
   const hostArchitecture = baseProfile.architecture ?? process.arch;
   const expectedRuntimeArchitecture =
-    hostArchitecture === "x64"
-      ? "amd64"
-      : hostArchitecture === "arm64"
-        ? "arm64"
-        : null;
-  if (
-    !expectedRuntimeArchitecture ||
-    runtime.architecture !== expectedRuntimeArchitecture
-  ) {
+    hostArchitecture === "x64" ? "amd64" : hostArchitecture === "arm64" ? "arm64" : null;
+  if (!expectedRuntimeArchitecture || runtime.architecture !== expectedRuntimeArchitecture) {
     throw new Error(
       `host-local vLLM recipe architecture ${runtime.architecture} does not match host architecture ${hostArchitecture}`,
     );
@@ -102,52 +135,10 @@ export function materializeHostLocalVllmSelection(
     !directInstall ||
     !recipe.spec.readiness?.timeoutSeconds
   ) {
-    throw new Error(
-      "host-local vLLM recipe is missing required runtime or model fields",
-    );
+    throw new Error("host-local vLLM recipe is missing required runtime or model fields");
   }
-  const serveEnvironment = {
-    ...runtime.environment,
-    HF_HOME: runtime.modelCache.target,
-    HF_HUB_OFFLINE: "1",
-    TRANSFORMERS_OFFLINE: "1",
-  };
+  const model = materializeHostLocalVllmModel(recipe, directInstall, baseProfile.platform);
   const gpuMemoryUtilization = hostLocalVllmGpuMemoryUtilization(recipe);
-  const model: VllmModelDef = {
-    id: recipe.spec.model.id,
-    label: recipe.spec.model.displayName,
-    envValue: recipe.spec.model.environmentValue,
-    downloadSizeBytes: recipe.spec.model.downloadSizeBytes,
-    maxModelLen: positiveIntegerArgument(selection, "--max-model-len"),
-    revision: recipe.spec.model.revision,
-    servedModelId,
-    modelArgs: hostLocalVllmModelArguments(recipe),
-    gated: recipe.spec.model.gated,
-    platforms: [baseProfile.platform],
-    minComputeCapability: runtime.minimumComputeCapability,
-    ...(Object.keys(serveEnvironment).length > 0
-      ? { serveEnv: serveEnvironment }
-      : {}),
-    runtime: {
-      image: runtime.image,
-      imageDownloadSizeBytes: runtime.imageDownloadSizeBytes,
-      modelDownloadSizeBytes: recipe.spec.model.downloadSizeBytes,
-      loadTimeoutSec: recipe.spec.readiness.timeoutSeconds,
-      pullTimeoutSec: runtime.pullTimeoutSeconds,
-      minComputeCapability: runtime.minimumComputeCapability,
-      minGpuMemoryBytes: runtime.minimumGpuMemoryBytes,
-      gpuMemoryUtilization,
-      dockerRunArgs: hostLocalVllmDockerRunArguments(recipe),
-      dockerRunArgsMode: "replace",
-    },
-    installFastSafetensors: recipe.spec.model.installFastSafetensors,
-    ...(directInstall.authentication === "bearer"
-      ? { managedBearerAuth: true as const }
-      : {}),
-    ...(directInstall.fixedArguments
-      ? { fixedServeCommand: true as const }
-      : {}),
-  };
   return {
     presetId: preset.metadata.id,
     recipeId: recipe.metadata.id,
@@ -158,9 +149,7 @@ export function materializeHostLocalVllmSelection(
       imageDownloadSizeBytes: runtime.imageDownloadSizeBytes,
       imageUnpackedSizeBytes:
         runtime.imageUnpackedSizeBytes ??
-        (runtime.image === baseProfile.image
-          ? baseProfile.imageUnpackedSizeBytes
-          : undefined),
+        (runtime.image === baseProfile.image ? baseProfile.imageUnpackedSizeBytes : undefined),
       pullTimeoutSec: runtime.pullTimeoutSeconds,
       loadTimeoutSec: recipe.spec.readiness.timeoutSeconds,
       modelDownloadSizeBytes: recipe.spec.model.downloadSizeBytes,
@@ -191,8 +180,7 @@ export function resolveHostLocalVllmSelection(
 ): HostLocalVllmSelectionResult {
   const presetId = String(env.NEMOCLAW_SERVING_PRESET ?? "").trim();
   const model = String(env.NEMOCLAW_VLLM_MODEL ?? "").trim();
-  if (!presetId && !model && !options.automatic)
-    return { kind: "not-selected" };
+  if (!presetId && !model && !options.automatic) return { kind: "not-selected" };
   if (presetId && model) {
     return {
       kind: "rejected",

--- a/src/lib/inference/serving/vllm-credential-contract.ts
+++ b/src/lib/inference/serving/vllm-credential-contract.ts
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/** Internal OpenShell credential slot; never a public user credential reference. */
+export const VLLM_LOCAL_CREDENTIAL_ENV = "NEMOCLAW_VLLM_LOCAL_TOKEN";

--- a/src/lib/inference/serving/vllm-export-runtime.test.ts
+++ b/src/lib/inference/serving/vllm-export-runtime.test.ts
@@ -1,0 +1,286 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EXPORTED_VLLM_PROFILE_ID } from "../../config/model";
+import { loadServingCatalog } from "./catalog-loader";
+import { servingProfileProvenance } from "./profile-provenance";
+import { runtimeAuthFingerprint } from "./runtime-auth-fingerprint";
+import {
+  HOST_LOCAL_VLLM_AUTH_LABEL,
+  HOST_LOCAL_VLLM_CATALOG_LABEL,
+  HOST_LOCAL_VLLM_MANAGED_LABEL,
+  HOST_LOCAL_VLLM_PRESET_DIGEST_LABEL,
+  HOST_LOCAL_VLLM_PRESET_LABEL,
+  HOST_LOCAL_VLLM_RECIPE_DIGEST_LABEL,
+  HOST_LOCAL_VLLM_RECIPE_LABEL,
+  persistHostLocalVllmRuntimeReceipt,
+} from "./vllm-host-local-lifecycle";
+import { observeManagedVllmForExport, type VllmExportRuntimeOptions } from "./vllm-export-runtime";
+
+const temporaryDirectories: string[] = [];
+const key = "e".repeat(64);
+const containerId = "a".repeat(64);
+const imageId = `sha256:${"b".repeat(64)}`;
+const profile = () => servingProfileProvenance(loadServingCatalog(), EXPORTED_VLLM_PROFILE_ID);
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0))
+    fs.rmSync(directory, { recursive: true, force: true });
+});
+
+function fixture() {
+  const provenance = profile();
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-vllm-export-"));
+  temporaryDirectories.push(directory);
+  const fingerprint = runtimeAuthFingerprint(key);
+  persistHostLocalVllmRuntimeReceipt(
+    {
+      containerId,
+      authFingerprint: fingerprint,
+      serving: {
+        catalogDigest: provenance.catalogDigest,
+        presetId: provenance.preset.id,
+        presetDigest: provenance.preset.digest,
+        recipeId: provenance.recipe.id,
+        recipeDigest: provenance.recipe.digest,
+      },
+    },
+    directory,
+  );
+  const image = { Id: imageId, Os: "linux", Architecture: "amd64", Environment: ["PATH=/usr/bin"] };
+  const network = {
+    Id: "c".repeat(64),
+    Name: "openshell-docker",
+    Driver: "bridge",
+    Config: [{ Gateway: "172.18.0.1", Subnet: "172.18.0.0/16" }],
+  };
+  const container = {
+    Id: containerId,
+    Name: "/nemoclaw-vllm",
+    Image: imageId,
+    StartedAt: "2026-09-10T10:00:00Z",
+    Matches: true,
+    State: { Running: true },
+    Config: {
+      Env: [`VLLM_API_KEY=${key}`],
+      Labels: {
+        [HOST_LOCAL_VLLM_AUTH_LABEL]: fingerprint,
+        [HOST_LOCAL_VLLM_MANAGED_LABEL]: "true",
+        [HOST_LOCAL_VLLM_CATALOG_LABEL]: provenance.catalogDigest,
+        [HOST_LOCAL_VLLM_PRESET_LABEL]: provenance.preset.id,
+        [HOST_LOCAL_VLLM_PRESET_DIGEST_LABEL]: provenance.preset.digest,
+        [HOST_LOCAL_VLLM_RECIPE_LABEL]: provenance.recipe.id,
+        [HOST_LOCAL_VLLM_RECIPE_DIGEST_LABEL]: provenance.recipe.digest,
+      },
+    },
+    NetworkSettings: {
+      Ports: {
+        "8000/tcp": [
+          { HostIp: "127.0.0.1", HostPort: "18000" },
+          { HostIp: "172.18.0.1", HostPort: "18000" },
+        ],
+      },
+    },
+  };
+  const capture = vi.fn<NonNullable<VllmExportRuntimeOptions["capture"]>>((args) => {
+    return JSON.stringify(
+      { image, network, container }[args[0] as "image" | "network" | "container"],
+    );
+  });
+  const loadApiKey = vi.fn(() => key);
+  const options = {
+    capture,
+    platform: "linux",
+    architecture: "x64",
+    authentication: { stateDir: directory, loadApiKey },
+  };
+  return { provenance, directory, image, network, container, capture, loadApiKey, options };
+}
+
+describe("fixed managed vLLM export observation", () => {
+  it("binds one running runtime to the current catalog and nondefault listener", () => {
+    const f = fixture();
+    const result = observeManagedVllmForExport(f.provenance, f.options);
+    expect(result).toMatchObject({
+      containerId,
+      imageId,
+      networkId: f.network.Id,
+      startedAt: f.container.StartedAt,
+      serving: {
+        profile: { id: EXPORTED_VLLM_PROFILE_ID },
+        model: f.provenance.model,
+        hostPort: 18000,
+      },
+    });
+    expect(f.loadApiKey).toHaveBeenCalledOnce();
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain(key);
+    expect(serialized).not.toContain(runtimeAuthFingerprint(key));
+    expect(serialized).not.toContain("VLLM_API_KEY");
+    expect(serialized).not.toContain(f.directory);
+    expect(f.capture.mock.calls.map(([args]) => args.slice(0, 2))).toEqual([
+      ["image", "inspect"],
+      ["network", "inspect"],
+      ["container", "inspect"],
+    ]);
+    expect(f.capture.mock.calls.map(([args]) => args[2])).toEqual([
+      "--format",
+      "--format",
+      "--format",
+    ]);
+    expect(JSON.stringify(f.capture.mock.calls.map(([args]) => args))).not.toContain(key);
+    const boundedCapture = expect.objectContaining({
+      env: expect.objectContaining({ DOCKER_CONTEXT: "default" }),
+      timeout: 5000,
+      maxBuffer: 65536,
+    });
+    expect(f.capture.mock.calls.map(([, options]) => options)).toEqual([
+      boundedCapture,
+      boundedCapture,
+      boundedCapture,
+    ]);
+  });
+
+  it.each([
+    [
+      "foreign container",
+      (f: ReturnType<typeof fixture>) => {
+        f.container.Id = "d".repeat(64);
+      },
+    ],
+    [
+      "stopped container",
+      (f: ReturnType<typeof fixture>) => {
+        f.container.State.Running = false;
+      },
+    ],
+    [
+      "changed fixed configuration",
+      (f: ReturnType<typeof fixture>) => {
+        f.container.Matches = false;
+      },
+    ],
+    [
+      "substituted image",
+      (f: ReturnType<typeof fixture>) => {
+        f.container.Image = `sha256:${"d".repeat(64)}`;
+      },
+    ],
+    [
+      "foreign serving label",
+      (f: ReturnType<typeof fixture>) => {
+        f.container.Config.Labels[HOST_LOCAL_VLLM_RECIPE_DIGEST_LABEL] = `sha256:${"d".repeat(64)}`;
+      },
+    ],
+    [
+      "mismatched token",
+      (f: ReturnType<typeof fixture>) => {
+        f.container.Config.Env = [`VLLM_API_KEY=${"d".repeat(64)}`];
+      },
+    ],
+    [
+      "additional credential payload",
+      (f: ReturnType<typeof fixture>) => {
+        f.container.Config.Env.push("SECRET=private-value");
+      },
+    ],
+    [
+      "public listener",
+      (f: ReturnType<typeof fixture>) => {
+        f.container.NetworkSettings.Ports["8000/tcp"][0]!.HostIp = "0.0.0.0";
+      },
+    ],
+    [
+      "different bridge listener",
+      (f: ReturnType<typeof fixture>) => {
+        f.network.Config[0]!.Gateway = "172.19.0.1";
+      },
+    ],
+    [
+      "additional port",
+      (f: ReturnType<typeof fixture>) => {
+        Object.assign(f.container.NetworkSettings.Ports, { "9000/tcp": [] });
+      },
+    ],
+    [
+      "unsafe bridge",
+      (f: ReturnType<typeof fixture>) => {
+        f.network.Config[0]!.Gateway = "169.254.169.254";
+      },
+    ],
+    [
+      "wrong architecture",
+      (f: ReturnType<typeof fixture>) => {
+        f.image.Architecture = "arm64";
+      },
+    ],
+    [
+      "duplicate image environment",
+      (f: ReturnType<typeof fixture>) => {
+        f.image.Environment.push(f.image.Environment[0]!);
+      },
+    ],
+    [
+      "missing receipt",
+      (f: ReturnType<typeof fixture>) => {
+        fs.unlinkSync(path.join(f.directory, "host-local-vllm-runtime.json"));
+      },
+    ],
+    [
+      "oversized receipt",
+      (f: ReturnType<typeof fixture>) => {
+        fs.writeFileSync(path.join(f.directory, "host-local-vllm-runtime.json"), " ".repeat(65537));
+      },
+    ],
+  ])("rejects %s without leaking private observations", (_label, change) => {
+    const f = fixture();
+    change(f);
+    expect(() => observeManagedVllmForExport(f.provenance, f.options)).toThrow(
+      "The fixed managed vLLM runtime could not be verified for export.",
+    );
+  });
+
+  it.each(["{malformed", "x".repeat(65537)])("redacts failed or malformed inspection", (value) => {
+    const f = fixture();
+    f.capture.mockReturnValue(value);
+    expect(() => observeManagedVllmForExport(f.provenance, f.options)).toThrow(
+      "The fixed managed vLLM runtime could not be verified for export.",
+    );
+    expect(f.loadApiKey).not.toHaveBeenCalled();
+  });
+
+  it("redacts runtime inspection failures before private authentication access", () => {
+    const f = fixture();
+    f.capture.mockImplementation(() => {
+      throw new Error("timeout credential-canary");
+    });
+    expect(() => observeManagedVllmForExport(f.provenance, f.options)).toThrow(
+      "The fixed managed vLLM runtime could not be verified for export.",
+    );
+    expect(f.loadApiKey).not.toHaveBeenCalled();
+  });
+
+  it("rejects stale catalog identity before Docker and credential access", () => {
+    const f = fixture();
+    expect(() =>
+      observeManagedVllmForExport(
+        { ...f.provenance, catalogDigest: `sha256:${"f".repeat(64)}` },
+        f.options,
+      ),
+    ).toThrow();
+    expect(f.capture).not.toHaveBeenCalled();
+    expect(f.loadApiKey).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unqualified host before runtime inspection", () => {
+    const f = fixture();
+    expect(() =>
+      observeManagedVllmForExport(f.provenance, { ...f.options, architecture: "arm64" }),
+    ).toThrow();
+    expect(f.capture).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/inference/serving/vllm-export-runtime.ts
+++ b/src/lib/inference/serving/vllm-export-runtime.ts
@@ -1,0 +1,315 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import os from "node:os";
+import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
+import type * as TypeBoxModule from "typebox" with { "resolution-mode": "import" };
+import type * as TypeBoxValueModule from "typebox/value" with { "resolution-mode": "import" };
+import { dockerCapture } from "../../adapters/docker/local-model-runtime";
+import {
+  EXPORTED_VLLM_PROFILE_ID,
+  EXPORTED_VLLM_CONTEXT_WINDOW,
+  EXPORTED_VLLM_RECIPE_ID,
+  isImmutableImageReference,
+  type NemoClawManagedVllmServing,
+} from "../../config/model";
+import type { ObservedManagedVllmRuntime } from "../../domain/config/export-evidence";
+import { buildVllmServeCommand } from "../vllm-models";
+import { buildLocalManagedVllmDockerEnv } from "../vllm-docker-env";
+import { isHostLocalInferenceServingRecipe } from "./adapter-registry";
+import { loadManagedInferenceCatalog, loadServingCatalog } from "./catalog-loader";
+import { materializeHostLocalVllmModel } from "./host-local-vllm-selection";
+import { assertServingProfileProvenanceCurrent } from "./profile-provenance";
+import type { ServingProfileProvenance } from "./types";
+import {
+  HOST_LOCAL_VLLM_AUTH_LABEL,
+  HOST_LOCAL_VLLM_CATALOG_LABEL,
+  HOST_LOCAL_VLLM_CONTAINER_NAME,
+  HOST_LOCAL_VLLM_MANAGED_LABEL,
+  HOST_LOCAL_VLLM_PRESET_DIGEST_LABEL,
+  HOST_LOCAL_VLLM_PRESET_LABEL,
+  HOST_LOCAL_VLLM_RECIPE_DIGEST_LABEL,
+  HOST_LOCAL_VLLM_RECIPE_LABEL,
+  recoverHostLocalManagedVllmEndpoint,
+  type RecoverHostLocalManagedVllmOptions,
+} from "./vllm-host-local-lifecycle";
+import { validateManagedVllmBridgeHost } from "./vllm-host-local-network";
+
+const { Type } = require("typebox") as typeof TypeBoxModule;
+const { Check } = require("typebox/value") as typeof TypeBoxValueModule;
+const MAX_INSPECTION_BYTES = 64 * 1024;
+const INSPECTION_TIMEOUT_MS = 5_000;
+const Id = Type.String({ pattern: "^[a-f0-9]{64}$" });
+const ImageId = Type.String({ pattern: "^sha256:[a-f0-9]{64}$" });
+const Text = Type.String({ maxLength: 8192 });
+const ImageSchema = Type.Object(
+  {
+    Id: ImageId,
+    Os: Type.Literal("linux"),
+    Architecture: Type.Literal("amd64"),
+    Environment: Type.Array(Text, { maxItems: 128 }),
+  },
+  { additionalProperties: false },
+);
+const NetworkSchema = Type.Object(
+  {
+    Id,
+    Name: Type.Literal("openshell-docker"),
+    Driver: Type.Literal("bridge"),
+    Config: Type.Array(Type.Object({ Gateway: Text, Subnet: Text }), { minItems: 1, maxItems: 1 }),
+  },
+  { additionalProperties: false },
+);
+const ContainerSchema = Type.Object(
+  {
+    Id,
+    Name: Type.Literal("/nemoclaw-vllm"),
+    Image: ImageId,
+    StartedAt: Type.String({ minLength: 1, maxLength: 64 }),
+    Matches: Type.Literal(true),
+    State: Type.Object({ Running: Type.Literal(true) }),
+    Config: Type.Object({
+      Env: Type.Array(Type.String({ pattern: "^VLLM_API_KEY=[a-f0-9]{64}$" }), {
+        minItems: 1,
+        maxItems: 1,
+      }),
+      Labels: Type.Record(Type.String(), Type.String({ maxLength: 512 })),
+    }),
+    NetworkSettings: Type.Object({
+      Ports: Type.Object(
+        {
+          "8000/tcp": Type.Array(Type.Object({ HostIp: Text, HostPort: Text }), {
+            minItems: 2,
+            maxItems: 2,
+          }),
+        },
+        { additionalProperties: false },
+      ),
+    }),
+  },
+  { additionalProperties: false },
+);
+
+export interface VllmExportRuntimeOptions {
+  readonly capture?: typeof dockerCapture;
+  readonly platform?: string;
+  readonly architecture?: string;
+  readonly homeDirectory?: string;
+  /** Test seam; production authentication remains inside the existing lifecycle owner. */
+  readonly authentication?: Pick<RecoverHostLocalManagedVllmOptions, "stateDir" | "loadApiKey">;
+}
+
+function fail(): never {
+  throw new Error("The fixed managed vLLM runtime could not be verified for export.");
+}
+
+function parse<T extends TypeBoxModule.Type.TSchema>(
+  source: string,
+  schema: T,
+): TypeBoxModule.Type.Static<T> {
+  if (!source || Buffer.byteLength(source) > MAX_INSPECTION_BYTES) fail();
+  const value: unknown = JSON.parse(source);
+  if (!Check(schema, value)) fail();
+  return value;
+}
+
+function equalJson(expression: string, expected: unknown): string {
+  // Go quoted strings contain only validated catalog/image data, never credentials.
+  return `(eq (json ${expression}) ${JSON.stringify(JSON.stringify(expected))})`;
+}
+
+function emptyArray(expression: string): string {
+  return `(or ${equalJson(expression, null)} ${equalJson(expression, [])})`;
+}
+
+function expectedRuntime(recorded: ServingProfileProvenance) {
+  const catalog = loadServingCatalog();
+  const current = assertServingProfileProvenanceCurrent(recorded, catalog);
+  const recipe = loadManagedInferenceCatalog().recipes.find(
+    ({ metadata }) => metadata.id === EXPORTED_VLLM_RECIPE_ID,
+  );
+  const imageRef = current.runtimeImage;
+  if (
+    current.preset.id !== EXPORTED_VLLM_PROFILE_ID ||
+    current.recipe.id !== EXPORTED_VLLM_RECIPE_ID ||
+    !recipe ||
+    !isHostLocalInferenceServingRecipe(recipe) ||
+    recipe.spec.runtime.architecture !== "amd64" ||
+    !recipe.spec.serve.directInstall ||
+    recipe.spec.serve.directInstall.authentication !== "bearer" ||
+    !recipe.spec.serve.directInstall.fixedArguments ||
+    !recipe.spec.serve.directInstall.catalogReceipt ||
+    recipe.spec.runtime.temporaryFilesystems.length !== 0 ||
+    recipe.spec.runtime.devices.length !== 0 ||
+    recipe.spec.runtime.gpuRequest !== "all" ||
+    !isImmutableImageReference(imageRef)
+  )
+    fail();
+  const model = materializeHostLocalVllmModel(recipe, recipe.spec.serve.directInstall, "linux");
+  if (model.maxModelLen !== EXPORTED_VLLM_CONTEXT_WINDOW) fail();
+  return { current, recipe, imageRef, command: buildVllmServeCommand(model, {}) };
+}
+
+function containerFormat(
+  expected: ReturnType<typeof expectedRuntime>,
+  image: TypeBoxModule.Type.Static<typeof ImageSchema>,
+  homeDirectory: string,
+): string {
+  const { runtime } = expected.recipe.spec;
+  // Compare image defaults in Docker. A modified container environment never leaves the daemon,
+  // except for the single managed key consumed by the existing private authentication verifier.
+  const environmentCheck = image.Environment.map(
+    (value) =>
+      `{{$found := false}}{{range .Config.Env}}{{if eq . ${JSON.stringify(value)}}}{{$found = true}}{{end}}{{end}}{{if not $found}}{{$environment = false}}{{end}}`,
+  ).join("");
+  const labels = [
+    HOST_LOCAL_VLLM_AUTH_LABEL,
+    HOST_LOCAL_VLLM_CATALOG_LABEL,
+    HOST_LOCAL_VLLM_MANAGED_LABEL,
+    HOST_LOCAL_VLLM_PRESET_DIGEST_LABEL,
+    HOST_LOCAL_VLLM_PRESET_LABEL,
+    HOST_LOCAL_VLLM_RECIPE_DIGEST_LABEL,
+    HOST_LOCAL_VLLM_RECIPE_LABEL,
+    "com.nvidia.nemoclaw.vllm-role",
+  ]
+    .map(
+      (key) =>
+        `${JSON.stringify(key)}:{{json (or (index .Config.Labels ${JSON.stringify(key)}) "")}}`,
+    )
+    .join(",");
+  const ulimitCheck = [
+    ["memlock", runtime.ulimits.memlock === "unlimited" ? -1 : runtime.ulimits.memlock],
+    ["stack", runtime.ulimits.stackBytes],
+  ]
+    .map(
+      ([name, value]) =>
+        `{{$found := false}}{{range .HostConfig.Ulimits}}{{if and (eq .Name ${JSON.stringify(name)}) ${equalJson(".Hard", value)} ${equalJson(".Soft", value)}}}{{$found = true}}{{end}}{{end}}{{if not $found}}{{$ulimits = false}}{{end}}`,
+    )
+    .join("");
+  const conditions = [
+    equalJson(".Config.Cmd", ["-lc", expected.command]),
+    equalJson(".Config.Entrypoint", ["/bin/bash"]),
+    `(eq .Config.Image ${JSON.stringify(expected.current.runtimeImage)})`,
+    `(eq .Image ${JSON.stringify(image.Id)})`,
+    `(eq .HostConfig.NetworkMode "bridge")`,
+    `(eq .HostConfig.IpcMode ${JSON.stringify(runtime.ipcMode)})`,
+    equalJson(".HostConfig.ShmSize", runtime.sharedMemoryBytes),
+    `(eq .HostConfig.RestartPolicy.Name "unless-stopped")`,
+    `.HostConfig.Init`,
+    `(not .HostConfig.Privileged)`,
+    emptyArray(".HostConfig.Devices"),
+    emptyArray(".HostConfig.CapAdd"),
+    emptyArray(".HostConfig.SecurityOpt"),
+    `(eq (len .HostConfig.Ulimits) 2)`,
+    "$ulimits",
+    `(or ${equalJson(".HostConfig.Tmpfs", null)} ${equalJson(".HostConfig.Tmpfs", {})})`,
+    equalJson(".HostConfig.Memory", 0),
+    equalJson(".HostConfig.NanoCpus", 0),
+    `(eq (len .HostConfig.DeviceRequests) 1)`,
+    equalJson("(index .HostConfig.DeviceRequests 0).Count", -1),
+    emptyArray("(index .HostConfig.DeviceRequests 0).DeviceIDs"),
+    equalJson("(index .HostConfig.DeviceRequests 0).Capabilities", [["gpu"]]),
+    `(eq (len .Mounts) 1)`,
+    `(eq (index .Mounts 0).Type "bind")`,
+    `(eq (index .Mounts 0).Source ${JSON.stringify(path.join(homeDirectory, ".cache/huggingface/hub"))})`,
+    `(eq (index .Mounts 0).Destination ${JSON.stringify(`${runtime.modelCache.target}/hub`)})`,
+    `(not (index .Mounts 0).RW)`,
+    `(eq (len .Config.Env) ${String(image.Environment.length + 1)})`,
+    "$environment",
+  ];
+  return `{{$environment := true}}{{$ulimits := true}}${environmentCheck}${ulimitCheck}{"Id":{{json .Id}},"Name":{{json .Name}},"Image":{{json .Image}},"StartedAt":{{json .State.StartedAt}},"Matches":{{and ${conditions.join(" ")}}},"State":{"Running":{{json .State.Running}}},"Config":{"Labels":{${labels}},"Env":[{{range .Config.Env}}{{if eq (index (split . "=") 0) "VLLM_API_KEY"}}{{json .}}{{end}}{{end}}]},"NetworkSettings":{"Ports":{{json .NetworkSettings.Ports}}}}`;
+}
+
+/** Read the fixed runtime; authentication stays inside existing private lifecycle verification. */
+export function observeManagedVllmForExport(
+  recorded: ServingProfileProvenance,
+  options: VllmExportRuntimeOptions = {},
+): ObservedManagedVllmRuntime {
+  try {
+    if (
+      (options.platform ?? process.platform) !== "linux" ||
+      (options.architecture ?? process.arch) !== "x64"
+    )
+      fail();
+    const expected = expectedRuntime(recorded);
+    const capture = options.capture ?? dockerCapture;
+    const env = buildLocalManagedVllmDockerEnv();
+    const inspect = (kind: string, name: string, format: string) =>
+      capture([kind, "inspect", "--format", format, name], {
+        env,
+        timeout: INSPECTION_TIMEOUT_MS,
+        maxBuffer: MAX_INSPECTION_BYTES,
+      });
+    const image = parse(
+      inspect(
+        "image",
+        expected.imageRef,
+        '{"Id":{{json .Id}},"Os":{{json .Os}},"Architecture":{{json .Architecture}},"Environment":{{json .Config.Env}}}',
+      ),
+      ImageSchema,
+    );
+    if (
+      new Set(image.Environment).size !== image.Environment.length ||
+      image.Environment.some((value) => value.startsWith("VLLM_API_KEY="))
+    )
+      fail();
+    const network = parse(
+      inspect(
+        "network",
+        "openshell-docker",
+        '{"Id":{{json .Id}},"Name":{{json .Name}},"Driver":{{json .Driver}},"Config":{{json .IPAM.Config}}}',
+      ),
+      NetworkSchema,
+    );
+    const bridge = validateManagedVllmBridgeHost(network.Config[0]!.Gateway);
+    const row = parse(
+      inspect(
+        "container",
+        HOST_LOCAL_VLLM_CONTAINER_NAME,
+        containerFormat(expected, image, options.homeDirectory ?? os.homedir()),
+      ),
+      ContainerSchema,
+    );
+    const identity = {
+      [HOST_LOCAL_VLLM_CATALOG_LABEL]: expected.current.catalogDigest,
+      [HOST_LOCAL_VLLM_PRESET_LABEL]: expected.current.preset.id,
+      [HOST_LOCAL_VLLM_PRESET_DIGEST_LABEL]: expected.current.preset.digest,
+      [HOST_LOCAL_VLLM_RECIPE_LABEL]: expected.current.recipe.id,
+      [HOST_LOCAL_VLLM_RECIPE_DIGEST_LABEL]: expected.current.recipe.digest,
+    };
+    if (Object.entries(identity).some(([key, value]) => row.Config.Labels[key] !== value)) fail();
+    const recovered = recoverHostLocalManagedVllmEndpoint({
+      ...options.authentication,
+      dockerInspect: () => JSON.stringify([row]),
+      resolveBridgeHost: () => bridge,
+    });
+    if (!recovered || recovered.containerId !== row.Id || row.Image !== image.Id) fail();
+    const hostPort = Number(new URL(recovered.baseUrl).port);
+    const serving: NemoClawManagedVllmServing = {
+      backend: "vllm",
+      catalogDigest: expected.current.catalogDigest,
+      profile: { id: EXPORTED_VLLM_PROFILE_ID, digest: expected.current.preset.digest },
+      recipe: { id: EXPORTED_VLLM_RECIPE_ID, digest: expected.current.recipe.digest },
+      model: { ...expected.current.model, servedName: expected.recipe.spec.model.servedName },
+      runtime: { image: { ref: expected.imageRef } },
+      hostPort,
+    };
+    if (
+      !isDeepStrictEqual(expected.current.model, {
+        id: expected.recipe.spec.model.id,
+        revision: expected.recipe.spec.model.revision,
+      })
+    )
+      fail();
+    return {
+      serving,
+      containerId: row.Id,
+      imageId: row.Image,
+      networkId: network.Id,
+      startedAt: row.StartedAt,
+    };
+  } catch {
+    fail();
+  }
+}

--- a/src/lib/inference/serving/vllm-host-local-lifecycle.ts
+++ b/src/lib/inference/serving/vllm-host-local-lifecycle.ts
@@ -126,6 +126,8 @@ function readRuntimeReceipt(stateDir: string): unknown {
     const stat = fs.fstatSync(fd);
     if (
       !stat.isFile() ||
+      stat.size < 2 ||
+      stat.size > 64 * 1024 ||
       (stat.mode & 0o077) !== 0 ||
       (typeof process.getuid === "function" && stat.uid !== process.getuid())
     ) {

--- a/test/e2e/live/network-policy.test.ts
+++ b/test/e2e/live/network-policy.test.ts
@@ -364,9 +364,9 @@ test(
     expect(document.spec.sandboxes[0].runtime.image.ref).toBe(
       entry.workload?.kind === "managed-image" ? entry.workload.reference : null,
     );
-    expect(document.spec.inferenceProviders[0].endpoint).toBe(
-      requireHostedInferenceConfig(secrets).endpointUrl,
-    );
+    const exportedProvider = document.spec.inferenceProviders[0];
+    const exportedEndpoint = "endpoint" in exportedProvider ? exportedProvider.endpoint : undefined;
+    expect(exportedEndpoint).toBe(requireHostedInferenceConfig(secrets).endpointUrl);
     expect(document.spec.sandboxes[0].network.policy.explicit).toEqual(
       policy.ok ? YAML.parse(policy.value.document) : null,
     );
@@ -397,7 +397,7 @@ test(
     await artifacts.writeJson("config-export-live-evidence.json", {
       sandboxName: SANDBOX_NAME,
       image: document.spec.sandboxes[0].runtime.image.ref,
-      endpoint: document.spec.inferenceProviders[0].endpoint,
+      endpoint: exportedEndpoint,
       effectivePolicyMatches: true,
       identityDriftPreventedPublication: true,
     });

--- a/test/onboarding/vllm-export-docker-format.test.ts
+++ b/test/onboarding/vllm-export-docker-format.test.ts
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { dockerClientAvailable, startVllmExportFormatFixture } from "./vllm-export-format-fixture";
+
+type Fixture = Awaited<ReturnType<typeof startVllmExportFormatFixture>>;
+
+describe.skipIf(!dockerClientAvailable)("managed vLLM Docker format boundary", () => {
+  let fixture: Fixture;
+  beforeEach(async () => {
+    fixture = await startVllmExportFormatFixture();
+  });
+  afterEach(async () => {
+    await fixture?.close();
+  });
+
+  it("renders the fixed runtime through the actual Docker client", () => {
+    expect(fixture.run().serving.hostPort).toBe(18000);
+    expect(JSON.stringify(fixture.calls)).not.toContain(fixture.key);
+  });
+
+  it("accepts reordered equivalent resource limits", () => {
+    fixture.objects.container.HostConfig.Ulimits.reverse();
+    expect(fixture.run().serving.hostPort).toBe(18000);
+  });
+
+  it("accepts Docker null defaults for unused runtime settings", () => {
+    Object.assign(fixture.objects.container.HostConfig, {
+      Devices: null,
+      CapAdd: null,
+      SecurityOpt: null,
+      Tmpfs: null,
+    });
+    Object.assign(fixture.objects.container.HostConfig.DeviceRequests[0]!, { DeviceIDs: null });
+    expect(fixture.run().serving.hostPort).toBe(18000);
+  });
+
+  it.each([
+    [
+      "additional capability",
+      (f: Fixture) => Object.assign(f.objects.container.HostConfig, { CapAdd: ["SYS_ADMIN"] }),
+    ],
+    [
+      "malformed optional settings",
+      (f: Fixture) => Object.assign(f.objects.container.HostConfig, { CapAdd: false }),
+    ],
+    ["command", (f: Fixture) => f.objects.container.Config.Cmd.push("--unrepresented")],
+    [
+      "environment injection",
+      (f: Fixture) => f.objects.container.Config.Env.push('INJECTION={{printf "unsafe"}}'),
+    ],
+    [
+      "entrypoint",
+      (f: Fixture) => {
+        f.objects.container.Config.Entrypoint = ["/bin/sh"];
+      },
+    ],
+    [
+      "stopped container",
+      (f: Fixture) => {
+        f.objects.container.State.Running = false;
+      },
+    ],
+    [
+      "GPU request",
+      (f: Fixture) => {
+        f.objects.container.HostConfig.DeviceRequests = [];
+      },
+    ],
+    [
+      "resource limit",
+      (f: Fixture) => {
+        f.objects.container.HostConfig.Ulimits[0]!.Soft = 1;
+      },
+    ],
+    [
+      "writable mount",
+      (f: Fixture) => {
+        f.objects.container.Mounts[0]!.RW = true;
+      },
+    ],
+    [
+      "shared memory",
+      (f: Fixture) => {
+        f.objects.container.HostConfig.ShmSize = 1;
+      },
+    ],
+  ])("rejects changed %s at the Docker format boundary", (_name, change) => {
+    change(fixture);
+    expect(fixture.run).toThrow("The fixed managed vLLM runtime could not be verified for export.");
+  });
+
+  it("keeps quoted image defaults literal and private authentication out of observations", () => {
+    const literal = 'LITERAL={{printf "unsafe"}}';
+    fixture.objects.image.Config.Env.push(literal);
+    fixture.objects.container.Config.Env.push(literal);
+    const observation = JSON.stringify(fixture.run());
+    expect(observation).not.toContain(fixture.key);
+    expect(observation).not.toContain(fixture.fingerprint);
+    expect(observation).not.toContain(fixture.directory);
+    expect(observation).not.toContain(literal);
+    expect(observation).not.toContain("VLLM_API_KEY");
+    expect(JSON.stringify(fixture.calls)).not.toContain(fixture.key);
+  });
+});

--- a/test/onboarding/vllm-export-format-fixture.ts
+++ b/test/onboarding/vllm-export-format-fixture.ts
@@ -1,0 +1,203 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { Worker } from "node:worker_threads";
+import {
+  observeManagedVllmForExport,
+  type VllmExportRuntimeOptions,
+} from "../../src/lib/inference/serving/vllm-export-runtime";
+import { EXPORTED_VLLM_PROFILE_ID, EXPORTED_VLLM_RECIPE_ID } from "../../src/lib/config/model";
+import {
+  loadManagedInferenceCatalog,
+  loadServingCatalog,
+} from "../../src/lib/inference/serving/catalog-loader";
+import { isHostLocalInferenceServingRecipe } from "../../src/lib/inference/serving/adapter-registry";
+import { servingProfileProvenance } from "../../src/lib/inference/serving/profile-provenance";
+import { materializeHostLocalVllmModel } from "../../src/lib/inference/serving/host-local-vllm-selection";
+import { buildVllmServeCommand } from "../../src/lib/inference/vllm-models";
+import * as lifecycle from "../../src/lib/inference/serving/vllm-host-local-lifecycle";
+import { runtimeAuthFingerprint } from "../../src/lib/inference/serving/runtime-auth-fingerprint";
+
+export function vllmExportFormatFixture(directory: string) {
+  const provenance = servingProfileProvenance(loadServingCatalog(), EXPORTED_VLLM_PROFILE_ID);
+  const recipe = loadManagedInferenceCatalog().recipes.find(
+    ({ metadata }) => metadata.id === EXPORTED_VLLM_RECIPE_ID,
+  );
+  if (!recipe || !isHostLocalInferenceServingRecipe(recipe) || !recipe.spec.serve.directInstall)
+    throw new Error("Fixture requires the fixed host-local recipe");
+  const model = materializeHostLocalVllmModel(recipe, recipe.spec.serve.directInstall, "linux");
+  const { runtime } = recipe.spec;
+  const key = "e".repeat(64);
+  const fingerprint = runtimeAuthFingerprint(key);
+  const containerId = "a".repeat(64);
+  const imageId = `sha256:${"b".repeat(64)}`;
+  const labels = {
+    [lifecycle.HOST_LOCAL_VLLM_AUTH_LABEL]: fingerprint,
+    [lifecycle.HOST_LOCAL_VLLM_MANAGED_LABEL]: "true",
+    [lifecycle.HOST_LOCAL_VLLM_CATALOG_LABEL]: provenance.catalogDigest,
+    [lifecycle.HOST_LOCAL_VLLM_PRESET_LABEL]: provenance.preset.id,
+    [lifecycle.HOST_LOCAL_VLLM_PRESET_DIGEST_LABEL]: provenance.preset.digest,
+    [lifecycle.HOST_LOCAL_VLLM_RECIPE_LABEL]: provenance.recipe.id,
+    [lifecycle.HOST_LOCAL_VLLM_RECIPE_DIGEST_LABEL]: provenance.recipe.digest,
+  };
+  lifecycle.persistHostLocalVllmRuntimeReceipt(
+    {
+      containerId,
+      authFingerprint: fingerprint,
+      serving: {
+        catalogDigest: provenance.catalogDigest,
+        presetId: provenance.preset.id,
+        presetDigest: provenance.preset.digest,
+        recipeId: provenance.recipe.id,
+        recipeDigest: provenance.recipe.digest,
+      },
+    },
+    directory,
+  );
+  return {
+    provenance,
+    key,
+    fingerprint,
+    objects: {
+      image: {
+        Id: imageId,
+        Os: "linux",
+        Architecture: "amd64",
+        Config: { Env: ["PATH=/usr/bin"] },
+      },
+      network: {
+        Id: "c".repeat(64),
+        Name: "openshell-docker",
+        Driver: "bridge",
+        IPAM: { Config: [{ Gateway: "172.18.0.1", Subnet: "172.18.0.0/16" }] },
+      },
+      container: {
+        Id: containerId,
+        Name: "/nemoclaw-vllm",
+        Image: imageId,
+        State: { Running: true, StartedAt: "2026-09-10T10:00:00Z" },
+        Config: {
+          Image: provenance.runtimeImage,
+          Cmd: ["-lc", buildVllmServeCommand(model, {})],
+          Entrypoint: ["/bin/bash"],
+          Env: ["PATH=/usr/bin", `VLLM_API_KEY=${key}`],
+          Labels: labels,
+        },
+        HostConfig: {
+          NetworkMode: "bridge",
+          IpcMode: runtime.ipcMode,
+          ShmSize: runtime.sharedMemoryBytes,
+          RestartPolicy: { Name: "unless-stopped" },
+          Init: true,
+          Privileged: false,
+          Devices: [],
+          CapAdd: [],
+          SecurityOpt: [],
+          Memory: 0,
+          NanoCpus: 0,
+          Tmpfs: {},
+          Ulimits: [
+            { Name: "memlock", Hard: -1, Soft: -1 },
+            { Name: "stack", Hard: runtime.ulimits.stackBytes, Soft: runtime.ulimits.stackBytes },
+          ],
+          DeviceRequests: [{ Count: -1, DeviceIDs: [], Capabilities: [["gpu"]] }],
+        },
+        Mounts: [
+          {
+            Type: "bind",
+            Source: "/home/fixture/.cache/huggingface/hub",
+            Destination: `${runtime.modelCache.target}/hub`,
+            RW: false,
+          },
+        ],
+        NetworkSettings: {
+          Ports: {
+            "8000/tcp": [
+              { HostIp: "127.0.0.1", HostPort: "18000" },
+              { HostIp: "172.18.0.1", HostPort: "18000" },
+            ],
+          },
+        },
+      },
+    },
+  };
+}
+
+export const dockerClientAvailable =
+  process.platform !== "win32" &&
+  spawnSync("docker", ["--version"], { timeout: 5000, stdio: "ignore" }).status === 0;
+
+// A private fake API exercises the installed Docker client's real Go template renderer.
+// No host Docker daemon, container, GPU, image pull, or external network is involved.
+const daemonSource = `
+const { parentPort, workerData } = require("node:worker_threads");
+const http = require("node:http");
+const fs = require("node:fs");
+const server = http.createServer((request, response) => {
+  const route = decodeURIComponent(request.url).replace(/^\\/v[0-9.]+/, "");
+  const objects = JSON.parse(fs.readFileSync(workerData.objects, "utf8"));
+  const result = route.startsWith("/images/") ? objects.image : route.startsWith("/networks/") ? objects.network : route.startsWith("/containers/") ? objects.container : null;
+  response.writeHead(result ? 200 : 404, { "Content-Type": "application/json" });
+  response.end(JSON.stringify(result ?? { message: "Unexpected request" }));
+});
+server.listen(workerData.socket, () => parentPort.postMessage("ready"));
+`;
+
+export async function startVllmExportFormatFixture() {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nc-vllm-format-"));
+  const socket = path.join(directory, "docker.sock");
+  const objectsPath = path.join(directory, "objects.json");
+  const fixture = vllmExportFormatFixture(directory);
+  const daemon = new Worker(daemonSource, {
+    eval: true,
+    workerData: { socket, objects: objectsPath },
+  });
+  const close = async () => {
+    await daemon.terminate();
+    fs.rmSync(directory, { recursive: true, force: true });
+  };
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("Fixture server deadline exceeded")), 5000);
+      daemon.once("error", (error) => {
+        clearTimeout(timer);
+        reject(error);
+      });
+      daemon.once("message", () => {
+        clearTimeout(timer);
+        resolve();
+      });
+    });
+  } catch (error) {
+    await close();
+    throw error;
+  }
+  const calls: string[][] = [];
+  const capture: NonNullable<VllmExportRuntimeOptions["capture"]> = (args, options) => {
+    calls.push([...args]);
+    const env: NodeJS.ProcessEnv = { ...options?.env, DOCKER_API_VERSION: "1.52" };
+    delete env.DOCKER_CONTEXT;
+    const result = spawnSync("docker", ["--host", `unix://${socket}`, ...args], {
+      ...options,
+      env,
+      encoding: "utf8",
+    });
+    if (result.status !== 0) throw new Error("Docker format inspection failed");
+    return result.stdout;
+  };
+  const run = () => {
+    fs.writeFileSync(objectsPath, JSON.stringify(fixture.objects));
+    return observeManagedVllmForExport(fixture.provenance, {
+      capture,
+      platform: "linux",
+      architecture: "x64",
+      homeDirectory: "/home/fixture",
+      authentication: { stateDir: directory, loadApiKey: () => fixture.key },
+    });
+  };
+  return { ...fixture, directory, run, calls, close };
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome
`nemoclaw config export` can represent the fixed managed Linux amd64 Lightning vLLM deployment, including its current catalog, model and image identity, required context window and observed host port. Unsupported recipes, missing ownership evidence and runtime drift still prevent export.

## Reason
Existing managed serving deployments cannot currently export their desired configuration. This slice adds one bounded recipe while preserving the private runtime credential boundary.

### Related issues
Refs #10904. This PR stacks on `codex/config-export-brave` for its resolved provider-profile reader.

## Changes
- Add a strict managed-serving provider representation and preserve the recipe-required context window of 65536.
- Verify retained provenance against the current catalog, bounded Docker observations and the existing private authentication owner before constructing public output.
- Require the exact OpenAI provider attachment and stable source snapshots. Exported YAML omits generated credentials, internal route URLs and private paths.
- Reuse the fixed model command materializer for installation and observation. Runtime drift, authority failures and Docker formatter behavior have focused regression coverage.

## Verification
- Focused CLI, SDK and Docker formatter tests: 454 tests across 11 files passed after rebasing onto the completed Brave branch and merged SDK policy implementation.
- `npm run build:cli` — passed.
- `NODE_OPTIONS=--max-old-space-size=5120 npm run typecheck:cli` — passed.
- `NODE_OPTIONS=--max-old-space-size=5120 npm run validate:pr` — passed in an isolated ARM container with canonical dependencies and validators, no contributor-host credentials, and networking disabled; source tree remained clean.
- The diff contains no secrets, API keys or credentials. Test credential canaries are synthetic.

## Review notes
This draft depends on the Brave provider-profile reader. Its isolated feature diff is reviewed against that branch; merge the dependency first.

Sensitive paths are `src/lib/inference/config.ts` and the changed files under `src/lib/inference/serving/`. The coordinator reviewed the rebased NVIDIA/NemoClaw candidate a6c2ab9007bfe36d43d7324d6e54c51966b02575 against the preserved implementation and peer-review evidence, including the private credential owner, bounded Docker observation, fixed catalog identity and refusal of stale or foreign resources. No remaining local finding is recorded. The Brave dependency also changes the sensitive `tools/e2e/target-catalogue.mts` ownership metadata; its local self-review at `58afee35457257226879e3991a2d17eb97884c86` found no remaining issue and is recorded in that PR. Independent PR review is still required; no approval or CI waiver is claimed.

Real qualification on the exact Linux amd64 GPU profile remains required. Local Docker formatter tests use a disposable fake Docker API and do not prove model startup or successful routed inference. The reviewed GPU runner fixture is retained separately while the canonical assertion-growth guard rejects its budget increase.

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>
