### PR TITLE
fix(cli): prevent leading hyphens in download paths from being parsed as flags

### DIFF
--- a/src/lib/actions/sandbox/download.test.ts
+++ b/src/lib/actions/sandbox/download.test.ts
@@ -99,9 +99,8 @@ describe("downloadFromSandbox", () => {
     });
 
     expect(captureMock).toHaveBeenCalledTimes(2);
-    for (const [args] of captureMock.mock.calls) {
-      expect(args).toEqual(expect.arrayContaining(["./-payload"]));
-    }
+    expect(captureMock.mock.calls[0]?.[0]).toEqual(expect.arrayContaining(["./-payload"]));
+    expect(captureMock.mock.calls[1]?.[0]).toEqual(expect.arrayContaining(["./-payload"]));
     expect(runMock).toHaveBeenCalledWith(
       ["sandbox", "download", "alpha", "./-payload", stagedArtifact],
       expect.objectContaining({

--- a/src/lib/actions/sandbox/download.test.ts
+++ b/src/lib/actions/sandbox/download.test.ts
@@ -91,6 +91,30 @@ describe("downloadFromSandbox", () => {
     expect(fs.rmSync).toHaveBeenCalledWith(stagingDir, { recursive: true, force: true });
   });
 
+  it("normalizes a leading-hyphen sandbox path before probing and download (#11378)", async () => {
+    const result = await downloadFromSandbox({
+      sandboxName: "alpha",
+      sandboxPath: "-payload",
+      hostDest: "./out",
+    });
+
+    expect(captureMock).toHaveBeenCalledTimes(2);
+    for (const [args] of captureMock.mock.calls) {
+      expect(args).toEqual(expect.arrayContaining(["./-payload"]));
+    }
+    expect(runMock).toHaveBeenCalledWith(
+      ["sandbox", "download", "alpha", "./-payload", stagedArtifact],
+      expect.objectContaining({
+        ignoreError: true,
+        stdio: "inherit",
+      }),
+    );
+    expect(result).toEqual({
+      sandboxPath: "./-payload",
+      hostDest: path.resolve(process.cwd(), "out"),
+    });
+  });
+
   it("does not apply a fixed timeout to a valid staged download (#10636)", async () => {
     await downloadFromSandbox({
       sandboxName: "alpha",

--- a/src/lib/actions/sandbox/download.test.ts
+++ b/src/lib/actions/sandbox/download.test.ts
@@ -99,8 +99,10 @@ describe("downloadFromSandbox", () => {
     });
 
     expect(captureMock).toHaveBeenCalledTimes(2);
-    expect(captureMock.mock.calls[0]?.[0]).toEqual(expect.arrayContaining(["./-payload"]));
-    expect(captureMock.mock.calls[1]?.[0]).toEqual(expect.arrayContaining(["./-payload"]));
+    // The probe script reads the source as "$1", which is the final argv entry,
+    // so assert that position rather than mere presence in the argument list.
+    expect((captureMock.mock.calls[0]?.[0] as string[])?.at(-1)).toBe("./-payload");
+    expect((captureMock.mock.calls[1]?.[0] as string[])?.at(-1)).toBe("./-payload");
     expect(runMock).toHaveBeenCalledWith(
       ["sandbox", "download", "alpha", "./-payload", stagedArtifact],
       expect.objectContaining({

--- a/src/lib/actions/sandbox/download.ts
+++ b/src/lib/actions/sandbox/download.ts
@@ -141,11 +141,14 @@ export async function downloadFromSandbox(
 async function downloadFromSandboxUnlocked(
   opts: SandboxDownloadOptions,
 ): Promise<SandboxDownloadResult> {
-  const sandboxPath = (opts.sandboxPath ?? "").trim();
+  let sandboxPath = (opts.sandboxPath ?? "").trim();
   if (!sandboxPath) {
     throw new Error(
       `No sandbox path provided; usage: ${CLI_NAME} ${opts.sandboxName} download <sandbox-path> [host-dest]`,
     );
+  }
+  if (sandboxPath.startsWith("-")) {
+    sandboxPath = "./" + sandboxPath;
   }
   const hostDest = resolveHostPathFromCwd((opts.hostDest ?? "").trim() || ".");
 


### PR DESCRIPTION
Fixes #11378

When passing a relative sandbox path that starts with a hyphen (e.g., `-download-root/file.txt`) to `nemoclaw <sandbox> download`, the underlying `openshell sandbox download` wrapper treats the path as a CLI flag and fails.

This patch normalizes relative paths starting with a hyphen by prepending `./` before passing them down, ensuring they are correctly treated as positional arguments rather than unknown options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sandbox downloads for paths beginning with `-`, ensuring they are handled as file paths rather than command options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->