### PR TITLE
ci(e2e): preserve queued Launchable runs

### DIFF
--- a/.agents/skills/nemoclaw-maintainer-e2e/SKILL.md
+++ b/.agents/skills/nemoclaw-maintainer-e2e/SKILL.md
@@ -73,7 +73,8 @@ record exists only after the job confirms workspace absence. A preparation failu
 artifact. A later failure can retain only `lane.log` and the phase artifacts created before exit.
 
 The job uses the `staging-brev-launchable-cpu` concurrency group without cancelling a running job.
-GitHub keeps at most one pending job in that group, so a newer job can replace an older pending job.
+All Launchable consumers use `queue: max`, which preserves up to 100 pending entries.
+GitHub cancels new entries when the queue is full.
 A queued, waiting, or accepted dispatch is not a successful result.
 
 ## Inspect the Newest Full Main Run

--- a/.agents/skills/nemoclaw-maintainer-e2e/references/main-runs.md
+++ b/.agents/skills/nemoclaw-maintainer-e2e/references/main-runs.md
@@ -145,7 +145,8 @@ Wait for completion:
 gh run watch "$RUN_ID" --repo NVIDIA/NemoClaw
 ```
 
-The Launchable concurrency group does not cancel a running E2E job. GitHub can replace an older pending run with a newer pending run in the same group.
+The Launchable concurrency group runs one entry at a time and preserves up to 100 pending entries
+with `queue: max`. GitHub cancels new entries when the queue is full.
 
 ## Verify and Report
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -104,7 +104,7 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: e2e-${{ github.ref }}-${{ inputs.checkout_sha != '' && format('pr-{0}', inputs.pr_number) || (inputs.include_staging_brev_launchable && inputs.jobs == '' && inputs.targets == '' && format('full-{0}', github.run_id)) || inputs.targets || 'supported' }}-${{ inputs.checkout_sha != '' && 'manual-pr' || inputs.jobs || 'all-jobs' }}
+  group: e2e-${{ github.ref }}-${{ (inputs.jobs == 'staging-brev-launchable' || inputs.jobs == 'staging-brev-launchable-identity' || inputs.include_staging_brev_launchable) && format('launchable-{0}', github.run_id) || inputs.checkout_sha != '' && format('pr-{0}', inputs.pr_number) || inputs.targets || 'supported' }}-${{ inputs.checkout_sha != '' && 'manual-pr' || inputs.jobs || 'all-jobs' }}
   cancel-in-progress: ${{ inputs.checkout_sha != '' && !inputs.allow_jetson_dispatch && !contains(format(',{0},', inputs.jobs), ',staging-brev-launchable,') && !contains(format(',{0},', inputs.jobs), ',staging-brev-launchable-identity,') && !inputs.include_staging_brev_launchable }}
 
 env:
@@ -2587,6 +2587,7 @@ jobs:
       contents: read
     concurrency:
       group: staging-brev-launchable-cpu
+      queue: max
       cancel-in-progress: false
     env:
       CANDIDATE_SHA: ${{ inputs.checkout_sha || github.sha }}
@@ -2653,6 +2654,7 @@ jobs:
       contents: read
     concurrency:
       group: staging-brev-launchable-cpu
+      queue: max
       cancel-in-progress: false
     env:
       CANDIDATE_SHA: ${{ github.sha }}

--- a/.github/workflows/staging-launchable-full.yaml
+++ b/.github/workflows/staging-launchable-full.yaml
@@ -11,6 +11,7 @@ permissions:
 
 concurrency:
   group: staging-brev-launchable-cpu
+  queue: max
   cancel-in-progress: false
 
 jobs:

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1041,17 +1041,19 @@ Brev Launchable`. The workflow names this selection `E2E full main`, with the
 correlation ID when one was supplied, so maintainers can find the newest full
 manual run without scanning every run's jobs.
 
-Each full dispatch uses `github.run_id` in its workflow concurrency identity, so
-another full dispatch cannot supersede it while it waits. The trusted `main`
+Each full or focused Launchable dispatch uses `github.run_id` in its workflow concurrency identity,
+so another dispatch cannot supersede it while it waits. The trusted `main`
 workflow dispatch verifies that the dispatching and rerunning actors have
 repository `maintain` or `admin` permission before the Launchable path's source
 checkout. That automatic role check authorizes `staging-brev-launchable` and
 `staging-brev-launchable-identity`; neither job uses GitHub environment
 approval.
 
-Both Launchable jobs use the `staging-brev-launchable-cpu` concurrency group
-without cancelling a running job. GitHub keeps at most one pending job in that
-group, so a newer job can replace an older pending job.
+Both Launchable jobs and `.github/workflows/staging-launchable-full.yaml` share the
+`staging-brev-launchable-cpu` concurrency group with `queue: max` and `cancel-in-progress: false`.
+One job or workflow runs at a time, and up to 100 pending entries wait without replacing each other.
+GitHub cancels new entries when the queue is full. Entries run in the order they enter the group;
+that order can differ from workflow dispatch order.
 
 For a full manual run dispatched against `main`, `Release qualification` waits
 for every E2E job that does not require a separate opt-in, including `Exact staging Brev Launchable`. The strict aggregate reports whether that full run

--- a/test/e2e/support/staging-brev-launchable-identity-workflow-boundary.test.ts
+++ b/test/e2e/support/staging-brev-launchable-identity-workflow-boundary.test.ts
@@ -146,6 +146,35 @@ const workflowMutations: Array<[string, (value: Workflow) => void, string]> = [
 ];
 
 describe("staging Brev Launchable identity workflow boundary", () => {
+  it.each(["staging-brev-launchable", JOB])(
+    "rejects %s scheduling that replaces waiting jobs or cancels an active job",
+    (jobName) => {
+      const value = workflow();
+      const validationError =
+        jobName === JOB
+          ? `${JOB} must share the Launchable concurrency group with queue: max and no cancellation`
+          : "staging-brev-launchable concurrency must queue pending jobs in its Launchable group without cancelling the running job";
+      expect(validateE2eWorkflow(value)).not.toContain(validationError);
+
+      delete value.jobs[jobName]!.concurrency!.queue;
+      expect(validateE2eWorkflow(value)).toContain(validationError);
+
+      value.jobs[jobName]!.concurrency!.queue = "max";
+      value.jobs[jobName]!.concurrency!["cancel-in-progress"] = true;
+      expect(validateE2eWorkflow(value)).toContain(validationError);
+    },
+  );
+
+  it("rejects outer concurrency that lets focused Launchable dispatches replace each other", () => {
+    const value = readWorkflow();
+    const validationError =
+      "workflow concurrency must isolate each Launchable dispatch with github.run_id";
+    expect(validateE2eWorkflow(value)).not.toContain(validationError);
+    (value.concurrency as Record<string, unknown>).group =
+      "e2e-${{ github.ref }}-${{ inputs.jobs }}";
+    expect(validateE2eWorkflow(value)).toContain(validationError);
+  });
+
   it("keeps the explicit trusted-main identity job valid (#9925)", () => {
     expect(validateE2eWorkflow(workflow())).toEqual([]);
   });

--- a/tools/e2e/workflow-boundary.mts
+++ b/tools/e2e/workflow-boundary.mts
@@ -2063,9 +2063,9 @@ function validateInferenceModeGeneration(
 function validateFullE2eConcurrency(errors: string[], workflow: WorkflowRecord): void {
   const concurrency = asRecord(workflow.concurrency);
   const expectedGroup =
-    "e2e-${{ github.ref }}-${{ inputs.checkout_sha != '' && format('pr-{0}', inputs.pr_number) || (inputs.include_staging_brev_launchable && inputs.jobs == '' && inputs.targets == '' && format('full-{0}', github.run_id)) || inputs.targets || 'supported' }}-${{ inputs.checkout_sha != '' && 'manual-pr' || inputs.jobs || 'all-jobs' }}";
+    "e2e-${{ github.ref }}-${{ (inputs.jobs == 'staging-brev-launchable' || inputs.jobs == 'staging-brev-launchable-identity' || inputs.include_staging_brev_launchable) && format('launchable-{0}', github.run_id) || inputs.checkout_sha != '' && format('pr-{0}', inputs.pr_number) || inputs.targets || 'supported' }}-${{ inputs.checkout_sha != '' && 'manual-pr' || inputs.jobs || 'all-jobs' }}";
   if (concurrency.group !== expectedGroup) {
-    errors.push("workflow concurrency must isolate each full dispatch with github.run_id");
+    errors.push("workflow concurrency must isolate each Launchable dispatch with github.run_id");
   }
   if (
     concurrency["cancel-in-progress"] !==
@@ -2146,11 +2146,11 @@ function validateStagingBrevLaunchableJob(errors: string[], jobs: WorkflowRecord
   const concurrency = asRecord(job.concurrency);
   if (
     concurrency.group !== "staging-brev-launchable-cpu" ||
-    Object.hasOwn(concurrency, "queue") ||
+    concurrency.queue !== "max" ||
     concurrency["cancel-in-progress"] !== false
   ) {
     errors.push(
-      "staging-brev-launchable concurrency must preserve its Launchable group without cancelling the running job or using unsupported queue keys",
+      "staging-brev-launchable concurrency must queue pending jobs in its Launchable group without cancelling the running job",
     );
   }
   const steps = asSteps(job.steps);
@@ -2255,10 +2255,12 @@ function validateStagingBrevLaunchableIdentityJob(errors: string[], jobs: Workfl
   const concurrency = asRecord(job.concurrency);
   if (
     concurrency.group !== "staging-brev-launchable-cpu" ||
-    Object.hasOwn(concurrency, "queue") ||
+    concurrency.queue !== "max" ||
     concurrency["cancel-in-progress"] !== false
   ) {
-    errors.push(`${jobName} must share the non-cancelling Launchable concurrency group`);
+    errors.push(
+      `${jobName} must share the Launchable concurrency group with queue: max and no cancellation`,
+    );
   }
 
   const jobEnv = asRecord(job.env);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

Staging Brev Launchable runs now wait in one shared queue instead of newer pending runs replacing older ones. Full and focused Launchable dispatches keep distinct outer workflow identities while the shared queue continues to run one Launchable consumer at a time.

## Reason

GitHub concurrency groups preserve only one pending entry by default. During staging validation, newer Launchable runs replaced older waiting runs before those runs could obtain the shared staging resource.

## Changes

- Set `queue: max` on both Launchable jobs in `e2e.yaml` and on the focused staging workflow. GitHub then preserves up to 100 pending entries while `cancel-in-progress: false` protects the active run.
- Give each full or focused Launchable dispatch a `github.run_id` based outer concurrency identity. The shared job queue remains the single owner of Launchable serialization.
- Extend the existing workflow boundary tests to reject missing queue preservation, active-run cancellation, and outer focused-dispatch replacement.
- Update the E2E maintainer guidance with the queue limit and ordering behavior.

## Verification

- `npx vitest run --project e2e-support test/e2e/support/staging-brev-launchable-identity-workflow-boundary.test.ts test/e2e/support/jetson-workflow-boundary.test.ts` — 2 files and 32 tests passed.
- Credential-isolated `NODE_OPTIONS=--max-old-space-size=5120 npm run validate:pr` — passed in a network-disabled Linux ARM64 container against canonical `main` at `f1a5bc1031babb1d7ed15baa8fa2a6a53c76b6df`.
- The validation gate included the repository secret scan; no secrets, API keys, or credentials were added.

## Review notes

This PR changes `.github/workflows/**`, a contributor-sensitive path. Self-review covered commit `dc7f3153e89f5462e02b830b33e037e2719bf669` and all seven changed paths; it found no candidate-owned defect. Independent review is pending.

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved E2E and Launchable run scheduling to preserve pending runs instead of replacing older queued runs.
  - Added run-specific isolation to prevent unrelated Launchable dispatches from interfering with one another.
  - Queued up to 100 pending runs and only canceled new runs when the queue is full.

- **Tests**
  - Added coverage validating per-run isolation, queue behavior, and workflow-level concurrency rules.

- **Documentation**
  - Updated E2E and Launchable concurrency guidance to reflect the new queueing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->