### PR TITLE
fix(status): keep configured routes per sandbox

### DIFF
--- a/src/lib/inventory/index.test.ts
+++ b/src/lib/inventory/index.test.ts
@@ -1311,21 +1311,6 @@ describe("inventory commands", () => {
     expect(lines).toContain("      Inference (configured): ollama-local / qwen3.5:9b");
   });
 
-  it("prefers live gateway provider for the default sandbox in the Inference line (#2604)", async () => {
-    const lines: string[] = [];
-    await showStatusCommand({
-      listSandboxes: () => ({
-        sandboxes: [{ name: "alpha", model: "stored-model", provider: "stored-provider" }],
-        defaultSandbox: "alpha",
-      }),
-      getLiveInference: () => ({ provider: "live-provider", model: "live-model" }),
-      showServiceStatus: vi.fn(),
-      log: (message = "") => lines.push(message),
-    });
-
-    expect(lines).toContain("      Inference (configured): live-provider / live-model");
-  });
-
   it("emits an SSH sessions line per sandbox when getActiveSessionCount is provided (#2604)", async () => {
     const lines: string[] = [];
     await showStatusCommand({

--- a/src/lib/inventory/index.ts
+++ b/src/lib/inventory/index.ts
@@ -481,13 +481,10 @@ export async function listSandboxesCommand(deps: ListSandboxesCommandDeps): Prom
 async function buildStatusSandboxRow(
   sandbox: SandboxEntry,
   defaultSandbox: string | null,
-  liveInference: GatewayInference | null,
   portablePhase: "pending" | "configuring" | "active" | null,
   getPolicyPresets?: (sandboxName: string) => string[] | Promise<string[]>,
 ): Promise<StatusSandboxRow> {
   const isDefault = sandbox.name === defaultSandbox;
-  const liveModel = isDefault ? liveInference?.model : null;
-  const liveProvider = isDefault ? liveInference?.provider : null;
   const inference = getSandboxEntryDisplayInference(sandbox);
   const dashboardPort =
     typeof sandbox.dashboardPort === "number" && Number.isFinite(sandbox.dashboardPort)
@@ -499,8 +496,8 @@ async function buildStatusSandboxRow(
       : sandbox.gpuEnabled === true;
   return {
     name: safeStatusString(sandbox.name) || sandbox.name,
-    model: safeStatusString(liveModel || inference.model),
-    provider: safeStatusString(liveProvider || inference.provider),
+    model: safeStatusString(inference.model),
+    provider: safeStatusString(inference.provider),
     gpuEnabled: sandbox.gpuEnabled === true,
     hostGpuDetected: sandbox.hostGpuDetected === true,
     sandboxGpuEnabled,
@@ -603,7 +600,6 @@ export async function getStatusReport(deps: ShowStatusCommandDeps): Promise<Stat
       buildStatusSandboxRow(
         sandbox,
         resolvedDefault,
-        liveInference,
         portablePhases.get(sandbox.name) ?? null,
         deps.getPolicyPresets,
       ),
@@ -670,12 +666,10 @@ export async function showStatusCommand(deps: ShowStatusCommandDeps): Promise<vo
       // Prefer the live gateway model for the default sandbox so `status`
       // agrees with `openshell inference get` (#2369).
       const liveModel = isDefault && live ? live.model : null;
-      const liveProvider = isDefault && live ? live.provider : null;
       const inference = getSandboxEntryDisplayInference(sb);
-      const model = liveModel || inference.model;
-      const provider = liveProvider || inference.provider;
+      const displayModel = liveModel || inference.model;
       const portSuffix = sb.dashboardPort != null ? ` :${sb.dashboardPort}` : "";
-      log(`    ${sb.name}${def}${model ? ` (${model})` : ""}${portSuffix}`);
+      log(`    ${sb.name}${def}${displayModel ? ` (${displayModel})` : ""}${portSuffix}`);
       const portablePhase = portablePhases.get(sb.name);
       if (portablePhase) log(`      agent: hermes  phase: ${portablePhase}`);
       if (isDefault && liveModel && liveModel !== inference.model) {
@@ -685,8 +679,8 @@ export async function showStatusCommand(deps: ShowStatusCommandDeps): Promise<vo
       // SSH-session count as labeled fields. Bare `nemoclaw status` previously
       // only had the model in parens above — users had to run
       // `nemoclaw <name> status` to see provider and session state.
-      if (provider || model) {
-        const parts = [provider, model].filter(Boolean).join(" / ");
+      if (inference.provider || inference.model) {
+        const parts = [inference.provider, inference.model].filter(Boolean).join(" / ");
         log(`      Inference (configured): ${parts}`);
       }
       if (deps.getActiveSessionCount && !portablePhase) {

--- a/src/lib/inventory/status-configured-route.test.ts
+++ b/src/lib/inventory/status-configured-route.test.ts
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+import { getStatusReport, showStatusCommand } from "./index";
+
+describe("global status configured inference routes", () => {
+  it("keeps JSON sandbox routes recorded while reporting the live gateway separately (#11412)", async () => {
+    const report = await getStatusReport({
+      listSandboxes: () => ({
+        sandboxes: [
+          { name: "alpha", provider: "provider-a", model: "model-a" },
+          { name: "beta", provider: "provider-b", model: "model-b" },
+        ],
+        defaultSandbox: "beta",
+      }),
+      getLiveInference: () => ({ provider: "provider-a", model: "model-a" }),
+      showServiceStatus: vi.fn(),
+    });
+
+    expect(report.liveInference).toEqual({ provider: "provider-a", model: "model-a" });
+    expect(report.sandboxes).toMatchObject([
+      { name: "alpha", provider: "provider-a", model: "model-a", isDefault: false },
+      { name: "beta", provider: "provider-b", model: "model-b", isDefault: true },
+    ]);
+  });
+
+  it("keeps the recorded route in text when the live gateway differs (#11412)", async () => {
+    const lines: string[] = [];
+    await showStatusCommand({
+      listSandboxes: () => ({
+        sandboxes: [{ name: "alpha", model: "stored-model", provider: "stored-provider" }],
+        defaultSandbox: "alpha",
+      }),
+      getLiveInference: () => ({ provider: "live-provider", model: "live-model" }),
+      showServiceStatus: vi.fn(),
+      log: (message = "") => lines.push(message),
+    });
+
+    expect(lines).toContain("    alpha * (live-model)");
+    expect(lines).toContain("      (onboarded: stored-model)");
+    expect(lines).toContain("      Inference (configured): stored-provider / stored-model");
+    expect(lines).not.toContain("      Inference (configured): live-provider / live-model");
+  });
+});

--- a/test/cli/status-root-json.test.ts
+++ b/test/cli/status-root-json.test.ts
@@ -133,8 +133,8 @@ describe("CLI root status JSON", () => {
         sandboxes: [
           {
             name: sandboxName,
-            model: "nvidia/nemotron",
-            provider: "nvidia-prod",
+            model: "configured-model",
+            provider: "configured-provider",
             gpuEnabled: true,
             agent: "openclaw",
             dashboardPort: 18789,


### PR DESCRIPTION
## Outcome

Global `nemoclaw status` now keeps each sandbox's recorded provider and model in its `Inference (configured)` line and JSON sandbox row. The shared gateway route remains available separately through the existing live inference field.

## Reason

A route change for one sandbox could make another sandbox's status report the wrong configuration because the default row was overwritten with the gateway's current live route.

### Related issues

Fixes #11412

## Changes

- keep per-sandbox status rows sourced from the durable registry
- preserve the live default model in the text row header without relabeling it as configured
- add text and JSON regressions for divergent recorded and live routes

## Verification

- `npm run build:cli` - passed
- `npm --prefix nemoclaw run build` - passed
- `npm run typecheck` - passed
- focused inventory tests - 56 passed
- focused CLI integration tests - 19 passed
- `npm run test:changed` - passed
- `npm run lint` - passed
- `npm run validate:pr` - passed
- `git diff --check` - passed

---
Signed-off-by: Sylvester Kaczmarek <16242628+sylvesterkaczmarek@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Sandbox status reports now consistently display each sandbox’s configured model and provider.
  - JSON status output preserves recorded sandbox routes and reports live gateway inference separately.
  - Text status output continues to show live inference for the default sandbox without replacing configured details.

- **Tests**
  - Added coverage for configured-route status reporting in JSON and text formats.
  - Updated status expectations to reflect configured model and provider values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->