### PR TITLE
fix(onboard): resolve sandbox name before non-interactive provider selection

### DIFF
--- a/src/lib/onboard/machine/handlers/provider-inference-route-containment.test.ts
+++ b/src/lib/onboard/machine/handlers/provider-inference-route-containment.test.ts
@@ -244,7 +244,7 @@ describe("provider route containment", () => {
     expect(calls.setupNim).toHaveBeenCalledOnce();
     expect(calls.preflightGatewayRouteDiscovery).toHaveBeenCalledWith({
       gatewayName: "nemoclaw-9090",
-      sandboxName: null,
+      sandboxName: "target-sandbox",
       route: {
         provider: "nvidia-prod",
         model: "nvidia/test",

--- a/src/lib/onboard/machine/handlers/provider-inference-sandbox-name.test.ts
+++ b/src/lib/onboard/machine/handlers/provider-inference-sandbox-name.test.ts
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { createSession } from "../../../state/onboard-session";
+import { handleProviderInferenceState } from "./provider-inference";
+import { baseOptions, createDeps } from "./provider-inference.test-support";
+
+describe("handleProviderInferenceState sandbox name resolution", () => {
+  it("resolves the sandbox name before provider selection in a fresh non-interactive run (#11440)", async () => {
+    const { deps, calls } = createDeps();
+    const session = createSession();
+    calls.complete.mockImplementation(async (...args: unknown[]) => {
+      session.steps.provider_selection.status =
+        args[0] === "provider_selection" ? "complete" : session.steps.provider_selection.status;
+      return session;
+    });
+
+    const result = await handleProviderInferenceState(baseOptions(deps, session));
+
+    expect(calls.promptName).toHaveBeenCalledOnce();
+    expect(calls.promptName.mock.invocationCallOrder[0]).toBeLessThan(
+      calls.setupNim.mock.invocationCallOrder[0]!,
+    );
+    expect(calls.setupNim).toHaveBeenCalledWith(
+      { type: "nvidia" },
+      "my-assistant",
+      null,
+      true,
+      "nemoclaw",
+      expect.any(Function),
+      expect.any(Function),
+      session.sessionId,
+      expect.any(Function),
+    );
+    expect(result.sandboxName).toBe("my-assistant");
+    expect(calls.setupInference.mock.calls[0]?.[0]).toBe("my-assistant");
+  });
+
+  it("forwards a requested sandbox name to selection without prompting (#11440)", async () => {
+    const { deps, calls } = createDeps();
+    const session = createSession();
+
+    const result = await handleProviderInferenceState({
+      ...baseOptions(deps, session),
+      sandboxName: "chosen-name",
+      requestedSandboxName: "chosen-name",
+    });
+
+    expect(calls.promptName).not.toHaveBeenCalled();
+    expect(calls.setupNim).toHaveBeenCalledWith(
+      { type: "nvidia" },
+      "chosen-name",
+      null,
+      false,
+      "nemoclaw",
+      expect.any(Function),
+      expect.any(Function),
+      session.sessionId,
+      expect.any(Function),
+    );
+    expect(result.sandboxName).toBe("chosen-name");
+  });
+
+  it("leaves name prompting at the review stage in interactive runs (#11440)", async () => {
+    const { deps, calls } = createDeps({ isNonInteractive: () => false });
+    const session = createSession();
+
+    const result = await handleProviderInferenceState(baseOptions(deps, session));
+
+    expect(calls.setupNim).toHaveBeenCalledWith(
+      { type: "nvidia" },
+      null,
+      null,
+      true,
+      "nemoclaw",
+      expect.any(Function),
+      expect.any(Function),
+      session.sessionId,
+      expect.any(Function),
+    );
+    expect(calls.promptName).toHaveBeenCalledOnce();
+    expect(calls.setupNim.mock.invocationCallOrder[0]).toBeLessThan(
+      calls.promptName.mock.invocationCallOrder[0]!,
+    );
+    expect(result.sandboxName).toBe("my-assistant");
+  });
+});

--- a/src/lib/onboard/machine/handlers/provider-inference.test.ts
+++ b/src/lib/onboard/machine/handlers/provider-inference.test.ts
@@ -49,7 +49,7 @@ describe("handleProviderInferenceState", () => {
     expect(calls.startStep).toHaveBeenNthCalledWith(1, "provider_selection");
     expect(calls.setupNim).toHaveBeenCalledWith(
       { type: "nvidia" },
-      null,
+      "my-assistant",
       null,
       true,
       "nemoclaw",
@@ -702,7 +702,7 @@ describe("handleProviderInferenceState", () => {
     const completedSelection = createSession({ sessionId: "resume-selection-session" });
     const { deps, calls } = createDeps({ isInferenceRouteReady: vi.fn(() => true) });
     calls.complete.mockResolvedValueOnce(completedSelection);
-    calls.promptName.mockResolvedValueOnce("tm");
+    calls.promptName.mockResolvedValue("tm");
 
     const result = await handleProviderInferenceState({
       ...baseOptions(deps, session),
@@ -1387,7 +1387,7 @@ describe("handleProviderInferenceState", () => {
     expect(setupNim).toHaveBeenNthCalledWith(
       1,
       { type: "nvidia" },
-      null,
+      "my-assistant",
       null,
       true,
       "nemoclaw",

--- a/src/lib/onboard/machine/handlers/provider-inference.ts
+++ b/src/lib/onboard/machine/handlers/provider-inference.ts
@@ -1109,6 +1109,21 @@ async function reviewProviderConfiguration<Agent>(
   }
 }
 
+async function resolveSelectionSandboxName<Agent>(
+  sandboxName: string | null,
+  agent: Agent,
+  deps: Pick<
+    ProviderInferenceStateOptions<unknown, Agent, unknown>["deps"],
+    "isNonInteractive" | "promptValidatedSandboxName"
+  >,
+): Promise<string | null> {
+  if (sandboxName || !deps.isNonInteractive()) return sandboxName;
+  // Non-interactive selection must hold the sandbox identity before provider
+  // selection: managed runtimes such as llama.cpp refuse a selection without
+  // it, and the review stage can no longer prompt.
+  return deps.promptValidatedSandboxName(agent);
+}
+
 export async function handleProviderInferenceState<Gpu, Agent, Host>({
   gatewayName,
   resume,
@@ -1432,6 +1447,7 @@ export async function handleProviderInferenceState<Gpu, Agent, Host>({
       // Station resume wrapper restores the exact provider/model as non-interactive env input,
       // so this re-runs the failed managed install without presenting selection prompts and
       // obtains a fresh checkpoint identity before the provider step is committed.
+      sandboxName = await resolveSelectionSandboxName(sandboxName, agent, deps);
       await deps.startRecordedStep("provider_selection");
       const recoverRecordedProvider = providerRecovery.shouldRecover();
       const selection = await withProviderSelectionTrace(


### PR DESCRIPTION
## Outcome
Fresh non-interactive onboarding no longer aborts at `Configuring inference provider` with `Managed llama.cpp requires a selected sandbox name.` when no sandbox name was passed, so Windows WSL express installs on qualified N1X hosts proceed past step [3/8]. Before: the run aborted immediately after printing `[non-interactive] Provider: install-llama-cpp`; after: the requested-or-default sandbox name (`my-assistant`, matching the installer's displayed summary) is resolved before provider selection. Interactive onboarding is unchanged.

## Reason
The Windows WSL express install branch displays `Sandbox name: my-assistant.` but never exports `NEMOCLAW_SANDBOX_NAME`, and a fresh non-interactive onboard reached provider selection with a null sandbox name: the only name resolution happened in the post-selection configuration review, which cannot prompt non-interactively. The managed llama.cpp selection requires the name up front and aborted the entire run.

### Related issues
Fixes #11440

## Changes
- `handleProviderInferenceState` resolves the requested-or-default sandbox name once via the new `resolveSelectionSandboxName` helper before calling `setupNim` on the fresh non-interactive path; the interactive path still prompts at the configuration review. Requirement: managed runtime selections (llama.cpp today) refuse a selection without a sandbox identity; consumer: the provider-selection call and its route preflight; protecting tests: `provider-inference-sandbox-name.test.ts`.
- New regression suite covering non-interactive default resolution, explicit-name pass-through without prompting, and unchanged interactive review-stage prompting.
- Updated two stale expectations that asserted a null name reached provider selection, plus the route preflight expectation, which now sees the resolved prospective sandbox.

## Verification
- `npx vitest run` on the eight onboard provider-inference handler suites — 87/87 pass
- `npm run test:changed` — 293/294; the single failure is the corporate-CA host fixture, which passes with `NEMOCLAW_CORPORATE_CA_ANCHOR_DIRS` isolated and fails identically on the base commit
- Full `src/lib/onboard` suite rerun against a stashed baseline — identical pre-existing environmental failures, no change-caused failures
- `npm run typecheck:cli` — pass
- `npm run test:package` — 1295/1300; the five failures (OpenShell SDK unavailable, CLI spawn timeouts) reproduce identically with the change stashed
- oxlint, oxfmt, pre-commit and pre-push hooks — pass
- The diff contains no secrets, API keys, or credentials

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Non-interactive setup now prompts for a sandbox name when one hasn’t been provided before provider selection.
  * Requested sandbox names are preserved and used throughout fresh setup and retry flows.
  * Interactive setup continues to request the sandbox name at the review stage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->