### PR TITLE
fix(ci): retain locked dependencies during E2E SDK installation

### DIFF
--- a/.github/workflows/e2e-standard-profile.yaml
+++ b/.github/workflows/e2e-standard-profile.yaml
@@ -434,7 +434,7 @@ jobs:
           mapfile -t archives < <(find "$RUNNER_TEMP/openshell-sdk" -maxdepth 1 -type f -name '*.tgz' -print)
           test "${#archives[@]}" -eq 1
           env -u NODE_AUTH_TOKEN -u GITHUB_TOKEN -u GH_TOKEN \
-            npm install --no-save --package-lock=false --ignore-scripts "${archives[0]}"
+            npm install --no-save --ignore-scripts "${archives[0]}"
           env -u NODE_AUTH_TOKEN -u GITHUB_TOKEN -u GH_TOKEN \
             node --input-type=module -e 'const { OpenShellClient } = await import("@nvidia/openshell-sdk"); if (typeof OpenShellClient?.connect !== "function") throw new Error("OpenShell SDK connection API is unavailable");'
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -3418,7 +3418,7 @@ jobs:
           mapfile -t archives < <(find "$RUNNER_TEMP/openshell-sdk" -maxdepth 1 -type f -name '*.tgz' -print)
           test "${#archives[@]}" -eq 1
           env -u NODE_AUTH_TOKEN -u GITHUB_TOKEN \
-            npm install --no-save --package-lock=false --ignore-scripts "${archives[0]}"
+            npm install --no-save --ignore-scripts "${archives[0]}"
 
       - name: Install OpenShell CLI
         run: env -u NODE_AUTH_TOKEN -u GITHUB_TOKEN bash scripts/install-openshell.sh

--- a/test/e2e/support/openshell-sdk-install.test.ts
+++ b/test/e2e/support/openshell-sdk-install.test.ts
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { spawnSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -14,6 +15,12 @@ const profile = YAML.parse(
   jobs: { run: { steps: Array<{ name?: string; run?: string }> } };
 };
 const installScript = profile.jobs.run.steps.find(
+  (step) => step.name === "Install reviewed OpenShell SDK archive without package credentials",
+)!.run!;
+const workflow = YAML.parse(fs.readFileSync(".github/workflows/e2e.yaml", "utf8")) as {
+  jobs: Record<string, { steps: Array<{ name?: string; run?: string }> }>;
+};
+const externalInstallScript = workflow.jobs["external-gateway-health"]!.steps.find(
   (step) => step.name === "Install reviewed OpenShell SDK archive without package credentials",
 )!.run!;
 
@@ -29,7 +36,115 @@ fs.writeFileSync(directory + "/package.json", JSON.stringify({ type: "module", e
 fs.writeFileSync(directory + "/index.js", process.env.SDK_SOURCE);
 `;
 
-describe("catalogue OpenShell SDK installation", () => {
+describe("reviewed OpenShell SDK installation", () => {
+  it.each([
+    { name: "catalogue", script: installScript },
+    { name: "external gateway health", script: externalInstallScript },
+  ])("uses locked dependencies during $name SDK installation (#11449)", ({ script }) => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-sdk-lockfile-"));
+    const archiveDirectory = path.join(directory, "openshell-sdk");
+    const cache = path.join(directory, "cache");
+    const env = {
+      PATH: process.env.PATH,
+      RUNNER_TEMP: directory,
+      npm_config_cache: cache,
+      npm_config_userconfig: path.join(directory, "user.npmrc"),
+      npm_config_globalconfig: path.join(directory, "global.npmrc"),
+      npm_config_offline: "true",
+      npm_config_audit: "false",
+      npm_config_fund: "false",
+    };
+    const npm = (args: string[], cwd = directory) =>
+      execFileSync("npm", args, { cwd, env, encoding: "utf8", timeout: 10_000 });
+    try {
+      fs.mkdirSync(archiveDirectory);
+      // Only tarballs enter the isolated cache. Resolving registry metadata must fail offline.
+      const pack = (name: string, destination: string) => {
+        const source = fs.mkdtempSync(path.join(directory, "package-"));
+        fs.writeFileSync(
+          path.join(source, "package.json"),
+          JSON.stringify({
+            name,
+            version: "1.0.0",
+            type: "module",
+            exports: "./index.js",
+            scripts: { install: "node -e \"throw new Error('Lifecycle script executed')\"" },
+          }),
+        );
+        fs.writeFileSync(
+          path.join(source, "index.js"),
+          "export class OpenShellClient { static connect() {} }",
+        );
+        const [{ filename }] = JSON.parse(
+          npm(["pack", "--ignore-scripts", "--json", "--pack-destination", destination], source),
+        ) as Array<{ filename: string }>;
+        return path.join(destination, filename!);
+      };
+      const dependencyArchive = pack("locked-dependency", directory);
+      pack("@nvidia/openshell-sdk", archiveDirectory);
+      npm(["cache", "add", dependencyArchive]);
+      const manifest = {
+        name: "sdk-install-fixture",
+        version: "1.0.0",
+        dependencies: { "locked-dependency": "^1.0.0" },
+      };
+      const lock = {
+        name: manifest.name,
+        version: manifest.version,
+        lockfileVersion: 3,
+        requires: true,
+        packages: {
+          "": manifest,
+          "node_modules/locked-dependency": {
+            version: "1.0.0",
+            resolved: "https://registry.npmjs.org/locked-dependency/-/locked-dependency-1.0.0.tgz",
+            integrity: `sha512-${createHash("sha512").update(fs.readFileSync(dependencyArchive)).digest("base64")}`,
+            hasInstallScript: true,
+          },
+        },
+      };
+      fs.writeFileSync(path.join(directory, "package.json"), JSON.stringify(manifest));
+      fs.writeFileSync(path.join(directory, "package-lock.json"), JSON.stringify(lock));
+      npm(["ci", "--ignore-scripts"]);
+      const manifestHashes = () =>
+        ["package.json", "package-lock.json"].map((filename) =>
+          createHash("sha256")
+            .update(fs.readFileSync(path.join(directory, filename)))
+            .digest("hex"),
+        );
+      const before = manifestHashes();
+
+      const result = spawnSync("bash", ["-c", script], {
+        cwd: directory,
+        env,
+        encoding: "utf8",
+        timeout: 10_000,
+      });
+      expect(result.error).toBeUndefined();
+      expect(result.signal).toBeNull();
+      expect(result.status, result.stderr).toBe(0);
+      expect(manifestHashes()).toEqual(before);
+      expect(
+        JSON.parse(
+          fs.readFileSync(
+            path.join(directory, "node_modules/locked-dependency/package.json"),
+            "utf8",
+          ),
+        ).version,
+      ).toBe("1.0.0");
+      expect(
+        JSON.parse(
+          fs.readFileSync(
+            path.join(directory, "node_modules/@nvidia/openshell-sdk/package.json"),
+            "utf8",
+          ),
+        ).version,
+      ).toBe("1.0.0");
+    } finally {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
   it.each([
     {
       name: "one reviewed archive",
@@ -92,7 +207,6 @@ describe("catalogue OpenShell SDK installation", () => {
               args: [
                 "install",
                 "--no-save",
-                "--package-lock=false",
                 "--ignore-scripts",
                 path.join(archiveDirectory, archives[0]!),
               ],

--- a/test/helpers/vitest-watch-triggers.ts
+++ b/test/helpers/vitest-watch-triggers.ts
@@ -28,6 +28,7 @@ const E2E_WORKFLOW_CONTRACTS = [
   "test/e2e/support/onboard-timeout-contract.test.ts",
   "test/e2e/support/openshell-gateway-auth-contract-workflow-boundary.test.ts",
   "test/e2e/support/openshell-gateway-upgrade-workflow-boundary.test.ts",
+  "test/e2e/support/openshell-sdk-install.test.ts",
   "test/e2e/support/prepare-e2e-workflow-boundary.test.ts",
   "test/e2e/support/runner-pressure-workflow-boundary.test.ts",
   "test/e2e/support/security-posture-workflow-boundary.test.ts",
@@ -325,7 +326,10 @@ export const vitestWatchTriggerPatterns: VitestWatchTriggerPattern[] = [
   },
   {
     pattern: /(?:^|\/)\.github\/workflows\/e2e-standard-profile\.yaml$/,
-    testsToRun: runTests("test/e2e/support/standard-profile-workflow-boundary.test.ts"),
+    testsToRun: runTests(
+      "test/e2e/support/standard-profile-workflow-boundary.test.ts",
+      "test/e2e/support/openshell-sdk-install.test.ts",
+    ),
   },
   {
     pattern: /(?:^|\/)\.github\/workflows\/portable-profile-e2e\.yaml$/,

--- a/test/repository/vitest-watch-triggers.test.ts
+++ b/test/repository/vitest-watch-triggers.test.ts
@@ -33,6 +33,7 @@ const E2E_WORKFLOW_CONTRACTS = [
   "test/e2e/support/onboard-timeout-contract.test.ts",
   "test/e2e/support/openshell-gateway-auth-contract-workflow-boundary.test.ts",
   "test/e2e/support/openshell-gateway-upgrade-workflow-boundary.test.ts",
+  "test/e2e/support/openshell-sdk-install.test.ts",
   "test/e2e/support/prepare-e2e-workflow-boundary.test.ts",
   "test/e2e/support/runner-pressure-workflow-boundary.test.ts",
   "test/e2e/support/security-posture-workflow-boundary.test.ts",
@@ -318,6 +319,7 @@ describe("Vitest opaque-input watch triggers", () => {
     expect(triggeredBy(".github/workflows/e2e.yaml")).toEqual(E2E_WORKFLOW_CONTRACTS);
     expect(triggeredBy(".github/workflows/e2e-standard-profile.yaml")).toEqual([
       "test/e2e/support/standard-profile-workflow-boundary.test.ts",
+      "test/e2e/support/openshell-sdk-install.test.ts",
     ]);
     expect(triggeredBy(".github/workflows/portable-profile-e2e.yaml")).toEqual([
       "test/e2e/support/portable-profile-rootless-runtime-workflow.test.ts",

--- a/tools/e2e/standard-profile-workflow-boundary.mts
+++ b/tools/e2e/standard-profile-workflow-boundary.mts
@@ -90,7 +90,7 @@ const SDK_INSTALL_SCRIPT = [
   "mapfile -t archives < <(find \"$RUNNER_TEMP/openshell-sdk\" -maxdepth 1 -type f -name '*.tgz' -print)",
   'test "${#archives[@]}" -eq 1',
   "env -u NODE_AUTH_TOKEN -u GITHUB_TOKEN -u GH_TOKEN \\",
-  '  npm install --no-save --package-lock=false --ignore-scripts "${archives[0]}"',
+  '  npm install --no-save --ignore-scripts "${archives[0]}"',
   "env -u NODE_AUTH_TOKEN -u GITHUB_TOKEN -u GH_TOKEN \\",
   '  node --input-type=module -e \'const { OpenShellClient } = await import("@nvidia/openshell-sdk"); if (typeof OpenShellClient?.connect !== "function") throw new Error("OpenShell SDK connection API is unavailable");\'',
   "",


### PR DESCRIPTION
## Outcome

E2E jobs install the reviewed OpenShell SDK archive using the dependency graph already installed by `npm ci`. This removes the shared `edgesOut` setup failure that prevented the runtime tests from starting.

## Reason

`--package-lock=false` disables lockfile reading as well as writing. During the additional SDK install, npm 10.9.8 resolves the dependency graph again and crashes in Arborist. The existing mocked-npm test checked the command and credential removal but could not detect dependency-resolution failures.

### Related issues

Fixes #11449. Unblocks qualification of #11382 and #11366.

## Changes

- Remove `--package-lock=false` from the catalogue profile and external gateway health job. Retain `--no-save`, `--ignore-scripts`, archive cardinality checks, and credential removal.
- Update the catalogue validator's expected command without relaxing its other requirements.
- Exercise both workflow scripts with real npm, an isolated offline cache, a locked dependency, and an SDK archive. Assert successful installation and unchanged manifests. The fixture's install script fails if lifecycle execution is enabled.
- Select these regressions when either owning workflow changes.

## Verification

- Real Linux ARM64 container, Node 22.23.2 / npm 10.9.8, main `7b4d000499e3abbedf51d817a8771588e69ecafc` package files, and SDK 0.0.106 from run 34487048057. The archive matched `ci/reviewed-npm-audit.json` SHA-512 integrity. No host credentials were mounted or passed. Fresh `npm ci --ignore-scripts` succeeded in both cases. The old command failed with `edgesOut`; the correction installed the SDK and passed the connection API import in 1.92 seconds. Both manifests remained byte-identical.
- SDK regressions: two failures before the fix; all six tests pass after it. All 16 standard-profile boundary tests also pass.
- Watch-trigger tests: 77 pass. Operations workflow tests pass. A wider local run hit two unchanged shared-workflow test deadlines during concurrent build work; all 11 shared-workflow tests pass in isolation. The original timeout results remain recorded.
- CLI and plugin builds pass. CLI type-check passes with an 8 GiB Node heap; the default heap exhausted memory.
- `npm run validate:pr` passes with canonical-main validation code and resolved executables. The changed boundary definition and watch mapping were temporarily replaced by canonical bytes for this independent gate, then restored. Their proposed behavior was tested separately above.
- The diff contains no secrets, API keys, or credentials.

## Review notes

Self-review covered all six changed files at `18b9f1f1f7c45c27bff72024ffa2d03aee0511d8` in NVIDIA/NemoClaw. The two workflows and `tools/e2e/standard-profile-workflow-boundary.mts` are sensitive paths. Independent review is pending; this PR remains a draft.

This repairs shared test setup. It does not establish live qualification for #11382: its 14 selected Docker/Podman jobs must run again after the repair reaches the trusted main workflow. Advisor review is also blocked by shared provider-budget exhaustion; no waiver is claimed.

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SDK archive installation to correctly handle package-lock files while continuing to avoid saving dependencies or running lifecycle scripts.

- **Tests**
  - Added offline end-to-end coverage for SDK installation, dependency versions, and manifest integrity.
  - Updated workflow checks to ensure SDK installation scenarios run consistently across supported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->