### PR TITLE
fix(e2e): use proxy-aware tunnel readiness

### DIFF
--- a/test/mcp/mcp-bridge-servers.test.ts
+++ b/test/mcp/mcp-bridge-servers.test.ts
@@ -270,6 +270,54 @@ describe("authenticated MCP live fixtures", () => {
     }
   });
 
+  it("uses the proxy-aware HTTPS probe when Node fetch cannot reach the public tunnel", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cloudflared-probe-"));
+    const cloudflared = path.join(directory, "cloudflared");
+    const curl = path.join(directory, "curl");
+    const priorPath = process.env.PATH;
+    fs.writeFileSync(
+      cloudflared,
+      [
+        "#!/bin/sh",
+        "printf '%s\\n' 'https://fixture-cleanup-123.trycloudflare.com' >&2",
+        "trap 'exit 0' TERM INT",
+        "sleep 2",
+        "",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    fs.writeFileSync(curl, "#!/bin/sh\nprintf '%s' '405'\n", { mode: 0o755 });
+    process.env.PATH = `${directory}:${priorPath ?? ""}`;
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValue(new TypeError("fetch failed"));
+    let cleanupProcess: (() => Promise<void>) | undefined;
+
+    try {
+      const tunnel = await startPublicMcpHttpsTunnel({
+        cloudflaredBin: cloudflared,
+        cleanup: {
+          add: (_name, run) => {
+            cleanupProcess = async () => {
+              await run();
+            };
+          },
+        },
+        label: "proxy-aware fixture",
+        progress: progressProbe().progress,
+        server: { port: 43123, close: async () => {} },
+      });
+
+      expect(tunnel.origin).toBe("https://fixture-cleanup-123.trycloudflare.com");
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      await cleanupProcess?.();
+      fetchMock.mockRestore();
+      priorPath === undefined ? delete process.env.PATH : (process.env.PATH = priorPath);
+      fs.rmSync(directory, { force: true, recursive: true });
+    }
+  });
+
   it("omits failed cloudflared child output from diagnostics", async () => {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cloudflared-redaction-"));
     const cloudflared = path.join(directory, "cloudflared");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

The public quick-tunnel readiness check will use the runner's proxy-aware HTTPS client. Managed-image MCP discovery will retain bounded retries, verified TLS, and exact status checks when Node fetch cannot reach the public tunnel.

## Reason

Managed-image run 34484915588 published a fresh quick-tunnel URL on every attempt, and each cloudflared process stayed alive. Both independent jobs still failed because the Node 22.19 fetch probe raised `TypeError` for every public `HEAD /mcp` request. The downstream E2E run 34485094547 then stopped before all requested tests.

## Changes

- Add a regression that simulates Node fetch transport failure while a proxy-aware HTTPS client can reach the public tunnel.
- Keep this draft scoped to the public tunnel readiness root cause. The fixture repair follows in the next commit.

## Verification

- Focused regression before the fix — failed in 10.5 seconds after the fixture discarded all three healthy tunnel processes.
- `NODE_OPTIONS=--max-old-space-size=8192 npm run validate:pr` — passed against `5b82037acb402862bb590ef57cb4d4c608e35ce7` after the default Node heap limit failed during CLI type-checking.
- GitHub marks commit `584c8acb379587782730eef17c174f2727efd019` as Verified.
- The diff contains no secrets, API keys, or credentials.

## Review notes

E2E root cause: MCP public tunnel fixture / readiness probe / Node fetch TypeError after quick-tunnel URL publication
Source run: https://github.com/NVIDIA/NemoClaw/actions/runs/34484915588 (run 34484915588, attempt 1)
Failed jobs: PR exact OpenClaw managed-image MCP discovery pass 1 (102906620499), pass 2 (102906620466)
Signature: cloudflared published a quick-tunnel URL but public HEAD /mcp failed (TypeError)
Scope: one root cause

The source run tested PR revision `041cf0aa25db8bbad7dbb1ef335a57e359f733e7`. The redacted artifacts confirm complete fixture cleanup and contain no deeper transport cause. Cloudflare documents quick tunnels as a testing service without an uptime guarantee, so the repair must preserve failure reporting and bounded retries.

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for HTTPS tunnel readiness when the default network request fails.
  * Verified that a local fallback can confirm tunnel availability and that resources are properly cleaned up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->