### PR TITLE
perf(test): overlap launch turn fixtures

### DIFF
--- a/test/e2e/support/launch-agent-turn-process.ts
+++ b/test/e2e/support/launch-agent-turn-process.ts
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawn } from "node:child_process";
+
+import { superviseChild } from "../../helpers/process-supervisor.ts";
+
+export async function runLaunchCommand(
+  command: string,
+  args: string[],
+  env: NodeJS.ProcessEnv,
+  timeoutMs = 15_000,
+) {
+  let stderr = "";
+  let stdout = "";
+  const child = spawn(command, args, { detached: true, env, stdio: ["ignore", "pipe", "pipe"] });
+  const result = await superviseChild(child, {
+    killGraceMs: 1_000,
+    onStderr: (chunk) => (stderr += chunk),
+    onStdout: (chunk) => (stdout += chunk),
+    timeoutMs,
+  });
+  return {
+    signal: result.signal,
+    status: result.exitCode,
+    stderr,
+    stdout,
+    timedOut: result.timedOut,
+  };
+}

--- a/test/e2e/support/launch-agent-turn-process.ts
+++ b/test/e2e/support/launch-agent-turn-process.ts
@@ -2,14 +2,38 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { spawn } from "node:child_process";
+import { existsSync, readdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
 
 import { superviseChild } from "../../helpers/process-supervisor.ts";
+
+export function cleanLaunchState(
+  fixtureRoot: string,
+  baselinePath: string,
+  ptyMonitorRoot: string,
+) {
+  rmSync(baselinePath, { force: true });
+  rmSync(`${baselinePath}.tmp`, { force: true });
+  rmSync(ptyMonitorRoot, { force: true, recursive: true });
+  for (const name of readdirSync(fixtureRoot).filter((entry) =>
+    entry.startsWith("nemoclaw-launch-host."),
+  ))
+    rmSync(join(fixtureRoot, name), { force: true, recursive: true });
+  return (
+    !existsSync(baselinePath) &&
+    !existsSync(ptyMonitorRoot) &&
+    !readdirSync(fixtureRoot).some((name) => name.startsWith("nemoclaw-launch-host."))
+  );
+}
 
 export async function runLaunchCommand(
   command: string,
   args: string[],
   env: NodeJS.ProcessEnv,
-  timeoutMs = 15_000,
+  options: {
+    onTimeout?: () => boolean;
+    timeoutMs?: number;
+  } = {},
 ) {
   let stderr = "";
   let stdout = "";
@@ -18,13 +42,15 @@ export async function runLaunchCommand(
     killGraceMs: 1_000,
     onStderr: (chunk) => (stderr += chunk),
     onStdout: (chunk) => (stdout += chunk),
-    timeoutMs,
+    timeoutMs: options.timeoutMs ?? 15_000,
   });
+  const ownedStateRemoved = result.timedOut ? options.onTimeout?.() : undefined;
   return {
     signal: result.signal,
     status: result.exitCode,
     stderr,
     stdout,
     timedOut: result.timedOut,
+    ownedStateRemoved,
   };
 }

--- a/test/e2e/support/launch-agent-turn.test.ts
+++ b/test/e2e/support/launch-agent-turn.test.ts
@@ -26,7 +26,7 @@ import {
   SUBPROCESS_ENV_ALLOWED_PREFIXES,
 } from "../../../src/lib/subprocess-env";
 import { testTimeout } from "../../helpers/timeouts";
-import { runLaunchCommand } from "./launch-agent-turn-process.ts";
+import { cleanLaunchState, runLaunchCommand } from "./launch-agent-turn-process.ts";
 import {
   LAUNCH_TURN_SCRIPT,
   OPENCLAW_LAUNCH_READINESS_LEASE_ACCEPTANCE_TIMEOUT_MS,
@@ -493,7 +493,10 @@ exec "$@"
     const launchCommand = invocation?.command ?? "bash";
     const launchArgs = invocation?.args ?? ["-c", LAUNCH_TURN_SCRIPT];
     const launch = (env: NodeJS.ProcessEnv) =>
-      runLaunchCommand(launchCommand, launchArgs, env, invocation?.timeoutMs);
+      runLaunchCommand(launchCommand, launchArgs, env, {
+        onTimeout: () => cleanLaunchState(fixtureRoot, baselinePath, ptyMonitorRoot),
+        timeoutMs: invocation?.timeoutMs,
+      });
     const result = await launch({
       ...process.env,
       ...invocationEnv,
@@ -561,7 +564,6 @@ exec "$@"
       ),
       orphanedMonitorProcessIds: monitorProcessIds.filter((pid) => existsSync(`/proc/${pid}`)),
       orphanedTuiProcessIds: tuiProcessIds.filter((pid) => existsSync(`/proc/${pid}`)),
-      ownedStatePaths: [fixtureRoot, baselinePath, ptyMonitorRoot],
       openshellCalls: readdirSync(openshellCallsRoot)
         .sort()
         .map(
@@ -605,7 +607,7 @@ it.runIf(process.platform === "linux").concurrent(
     expect(fixture.tuiProcessIds.length).toBeGreaterThan(0);
     expect(fixture.monitorProcessIds.length).toBeGreaterThan(0);
     expect([...fixture.orphanedTuiProcessIds, ...fixture.orphanedMonitorProcessIds]).toEqual([]);
-    expect(fixture.ownedStatePaths.every((path) => !existsSync(path))).toBe(true);
+    expect(fixture.result.ownedStateRemoved).toBe(true);
   },
   testTimeout(10_000),
 );

--- a/test/e2e/support/launch-agent-turn.test.ts
+++ b/test/e2e/support/launch-agent-turn.test.ts
@@ -561,6 +561,7 @@ exec "$@"
       ),
       orphanedMonitorProcessIds: monitorProcessIds.filter((pid) => existsSync(`/proc/${pid}`)),
       orphanedTuiProcessIds: tuiProcessIds.filter((pid) => existsSync(`/proc/${pid}`)),
+      ownedStatePaths: [fixtureRoot, baselinePath, ptyMonitorRoot],
       openshellCalls: readdirSync(openshellCallsRoot)
         .sort()
         .map(
@@ -604,7 +605,7 @@ it.runIf(process.platform === "linux").concurrent(
     expect(fixture.tuiProcessIds.length).toBeGreaterThan(0);
     expect(fixture.monitorProcessIds.length).toBeGreaterThan(0);
     expect([...fixture.orphanedTuiProcessIds, ...fixture.orphanedMonitorProcessIds]).toEqual([]);
-    expect([fixture.baselineRemoved, fixture.ptyMonitorRemoved]).toEqual([true, true]);
+    expect(fixture.ownedStatePaths.every((path) => !existsSync(path))).toBe(true);
   },
   testTimeout(10_000),
 );

--- a/test/e2e/support/launch-agent-turn.test.ts
+++ b/test/e2e/support/launch-agent-turn.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import assert from "node:assert/strict";
-import { spawn, spawnSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import {
   chmodSync,
@@ -25,8 +25,8 @@ import {
   SUBPROCESS_ENV_ALLOWED_NAMES,
   SUBPROCESS_ENV_ALLOWED_PREFIXES,
 } from "../../../src/lib/subprocess-env";
-import { superviseChild } from "../../helpers/process-supervisor.ts";
 import { testTimeout } from "../../helpers/timeouts";
+import { runLaunchCommand } from "./launch-agent-turn-process.ts";
 import {
   LAUNCH_TURN_SCRIPT,
   OPENCLAW_LAUNCH_READINESS_LEASE_ACCEPTANCE_TIMEOUT_MS,
@@ -40,7 +40,6 @@ import {
   runOpenClawLaunchReadinessLeaseTurns,
 } from "../live/launch-agent-turn.ts";
 
-// Each case owns its temporary files and child processes; cap overlap to avoid runner pressure.
 vi.setConfig({ maxConcurrency: 3 });
 const PROCESS_EXIT_WAIT = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
 type FixtureMode =
@@ -69,25 +68,14 @@ type FixtureMode =
   | "provider-wrong-route"
   | "recording-timeout"
   | "restored-canonical-timeout"
+  | "supervisor-timeout"
   | "valid";
 
 interface LaunchFixtureInvocation {
-  args: string[];
-  command: string;
+  args?: string[];
+  command?: string;
   env?: NodeJS.ProcessEnv;
-}
-
-async function runLaunchCommand(command: string, args: string[], env: NodeJS.ProcessEnv) {
-  let stderr = "";
-  let stdout = "";
-  const child = spawn(command, args, { detached: true, env, stdio: ["ignore", "pipe", "pipe"] });
-  const result = await superviseChild(child, {
-    killGraceMs: 1_000,
-    onStderr: (chunk) => (stderr += chunk),
-    onStdout: (chunk) => (stdout += chunk),
-    timeoutMs: 15_000,
-  });
-  return { signal: result.signal, status: result.exitCode, stderr, stdout };
+  timeoutMs?: number;
 }
 
 it("reports a residual PTY monitor socket without removing it (#9384)", async () => {
@@ -260,6 +248,8 @@ if (process.argv[2] !== "tui") {
   });
   if (!monitorPid) process.exit(71);
   fs.writeFileSync(process.env.NEMOCLAW_FIXTURE_MONITOR_PID, monitorPid);
+  if (mode === "supervisor-timeout") process.on("SIGTERM", () => undefined);
+  if (mode === "supervisor-timeout") await new Promise((resolve) => setTimeout(resolve, 20_000));
   if (mode === "pty-socket-invalid" || mode === "pty-response-identity") {
     fs.unlinkSync(socketPath);
     const ttyPath = fs.realpathSync("/proc/self/fd/0");
@@ -502,7 +492,9 @@ exec "$@"
         : OPENCLAW_PTY_MONITOR_STARTER_SCRIPT;
     const launchCommand = invocation?.command ?? "bash";
     const launchArgs = invocation?.args ?? ["-c", LAUNCH_TURN_SCRIPT];
-    const result = await runLaunchCommand(launchCommand, launchArgs, {
+    const launch = (env: NodeJS.ProcessEnv) =>
+      runLaunchCommand(launchCommand, launchArgs, env, invocation?.timeoutMs);
+    const result = await launch({
       ...process.env,
       ...invocationEnv,
       HOME: fixtureRoot,
@@ -587,6 +579,7 @@ exec "$@"
         ? JSON.parse(readFileSync(ptySocketReceiptPath, "utf8"))
         : null,
       result,
+      monitorProcessIds,
       tuiProcessIds,
       ttyObserved: existsSync(ttyMarker),
     };
@@ -600,6 +593,21 @@ exec "$@"
     rmSync(ptyMonitorRoot, { force: true, recursive: true });
   }
 }
+
+it.runIf(process.platform === "linux").concurrent(
+  "kills launch descendants and removes owned state when the host command times out (#9160)",
+  async ({ expect }) => {
+    const fixture = await runLaunchSessionFixture("supervisor-timeout", "absent", {
+      timeoutMs: 2_500,
+    });
+    expect(fixture.result.timedOut).toBe(true);
+    expect(fixture.tuiProcessIds.length).toBeGreaterThan(0);
+    expect(fixture.monitorProcessIds.length).toBeGreaterThan(0);
+    expect([...fixture.orphanedTuiProcessIds, ...fixture.orphanedMonitorProcessIds]).toEqual([]);
+    expect([fixture.baselineRemoved, fixture.ptyMonitorRemoved]).toEqual([true, true]);
+  },
+  testTimeout(10_000),
+);
 
 function openShellLaunchArgv(sandboxName: string, gatewayArgs: string[]): string[] {
   return [

--- a/test/e2e/support/launch-agent-turn.test.ts
+++ b/test/e2e/support/launch-agent-turn.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import assert from "node:assert/strict";
-import { execFile, spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import {
   chmodSync,
@@ -25,6 +25,7 @@ import {
   SUBPROCESS_ENV_ALLOWED_NAMES,
   SUBPROCESS_ENV_ALLOWED_PREFIXES,
 } from "../../../src/lib/subprocess-env";
+import { superviseChild } from "../../helpers/process-supervisor.ts";
 import { testTimeout } from "../../helpers/timeouts";
 import {
   LAUNCH_TURN_SCRIPT,
@@ -76,29 +77,17 @@ interface LaunchFixtureInvocation {
   env?: NodeJS.ProcessEnv;
 }
 
-interface LaunchFixtureResult {
-  signal: NodeJS.Signals | null;
-  status: number | null;
-  stderr: string;
-  stdout: string;
-}
-
-function runLaunchCommand(
-  command: string,
-  args: string[],
-  env: NodeJS.ProcessEnv,
-): Promise<LaunchFixtureResult> {
-  return new Promise((resolve) => {
-    execFile(
-      command,
-      args,
-      { encoding: "utf8", env, killSignal: "SIGKILL", timeout: 15_000 },
-      (error, stdout, stderr) => {
-        const status = typeof error?.code === "number" ? error.code : error ? null : 0;
-        resolve({ signal: error?.signal ?? null, status, stderr, stdout });
-      },
-    );
+async function runLaunchCommand(command: string, args: string[], env: NodeJS.ProcessEnv) {
+  let stderr = "";
+  let stdout = "";
+  const child = spawn(command, args, { detached: true, env, stdio: ["ignore", "pipe", "pipe"] });
+  const result = await superviseChild(child, {
+    killGraceMs: 1_000,
+    onStderr: (chunk) => (stderr += chunk),
+    onStdout: (chunk) => (stdout += chunk),
+    timeoutMs: 15_000,
   });
+  return { signal: result.signal, status: result.exitCode, stderr, stdout };
 }
 
 it("reports a residual PTY monitor socket without removing it (#9384)", async () => {

--- a/test/e2e/support/launch-agent-turn.test.ts
+++ b/test/e2e/support/launch-agent-turn.test.ts
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { spawnSync } from "node:child_process";
+import assert from "node:assert/strict";
+import { execFile, spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import {
   chmodSync,
@@ -37,6 +38,9 @@ import {
   runOpenClawLaunchSession,
   runOpenClawLaunchReadinessLeaseTurns,
 } from "../live/launch-agent-turn.ts";
+
+// Each case owns its temporary files and child processes; cap overlap to avoid runner pressure.
+vi.setConfig({ maxConcurrency: 3 });
 const PROCESS_EXIT_WAIT = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
 type FixtureMode =
   | "cleanup-failure"
@@ -70,6 +74,31 @@ interface LaunchFixtureInvocation {
   args: string[];
   command: string;
   env?: NodeJS.ProcessEnv;
+}
+
+interface LaunchFixtureResult {
+  signal: NodeJS.Signals | null;
+  status: number | null;
+  stderr: string;
+  stdout: string;
+}
+
+function runLaunchCommand(
+  command: string,
+  args: string[],
+  env: NodeJS.ProcessEnv,
+): Promise<LaunchFixtureResult> {
+  return new Promise((resolve) => {
+    execFile(
+      command,
+      args,
+      { encoding: "utf8", env, killSignal: "SIGKILL", timeout: 15_000 },
+      (error, stdout, stderr) => {
+        const status = typeof error?.code === "number" ? error.code : error ? null : 0;
+        resolve({ signal: error?.signal ?? null, status, stderr, stdout });
+      },
+    );
+  });
 }
 
 it("reports a residual PTY monitor socket without removing it (#9384)", async () => {
@@ -111,7 +140,7 @@ it("reports a residual PTY monitor socket without removing it (#9384)", async ()
   }
 });
 
-function runLaunchSessionFixture(
+async function runLaunchSessionFixture(
   mode: FixtureMode,
   terminalCopy: "absent" | "ansi" | "provider" | "reordered",
   invocation?: LaunchFixtureInvocation,
@@ -477,61 +506,56 @@ exec "$@"
       'const termiosCommand = "/usr/bin/stty";',
       `const termiosCommand = ${JSON.stringify(fakeStty)};`,
     );
-    expect(unavailablePtyMonitorStarterScript).not.toBe(OPENCLAW_PTY_MONITOR_STARTER_SCRIPT);
+    assert.notEqual(unavailablePtyMonitorStarterScript, OPENCLAW_PTY_MONITOR_STARTER_SCRIPT);
     const ptyMonitorStarterScript =
       mode === "pty-termios-unavailable"
         ? unavailablePtyMonitorStarterScript
         : OPENCLAW_PTY_MONITOR_STARTER_SCRIPT;
     const launchCommand = invocation?.command ?? "bash";
     const launchArgs = invocation?.args ?? ["-c", LAUNCH_TURN_SCRIPT];
-    const result = spawnSync(launchCommand, launchArgs, {
-      encoding: "utf8",
-      killSignal: "SIGKILL",
-      env: {
-        ...process.env,
-        ...invocationEnv,
-        HOME: fixtureRoot,
-        NEMOCLAW_FIXTURE_BIN_ROOT: fixtureRoot,
-        NEMOCLAW_FIXTURE_CANONICAL_RESTORED_MARKER: canonicalRestoredMarker,
-        NEMOCLAW_FIXTURE_EARLY_INPUT_MARKER: earlyInputMarker,
-        NEMOCLAW_FIXTURE_MODE: mode,
-        NEMOCLAW_FIXTURE_MONITOR_PID: monitorPidPath,
-        NEMOCLAW_FIXTURE_OPENSHELL_CALLS: openshellCallsRoot,
-        NEMOCLAW_FIXTURE_PENDING_QUALIFICATION_MARKER: pendingQualificationMarker,
-        NEMOCLAW_FIXTURE_PTY_MONITOR_ROOT: ptyMonitorRoot,
-        NEMOCLAW_FIXTURE_PTY_PATH_UNREADABLE_MARKER: ptyPathUnreadableMarker,
-        NEMOCLAW_FIXTURE_PTY_SOCKET_RECEIPT: ptySocketReceiptPath,
-        NEMOCLAW_FIXTURE_SESSION_FILE: join(sessionRoot, "session-a.jsonl"),
-        NEMOCLAW_FIXTURE_TERMINAL_COPY: terminalCopy,
-        NEMOCLAW_FIXTURE_RUN_ID: runId,
-        NEMOCLAW_FIXTURE_TUI_PIDS: tuiPidsPath,
-        NEMOCLAW_FIXTURE_TTY_MARKER: ttyMarker,
-        NEMOCLAW_LAUNCH_COMMAND: invocationEnv.NEMOCLAW_LAUNCH_COMMAND ?? fakeLaunch,
-        NEMOCLAW_LAUNCH_ENTRYPOINT: invocationEnv.NEMOCLAW_LAUNCH_ENTRYPOINT ?? "",
-        NEMOCLAW_LAUNCH_EXIT_COMMAND: invocationEnv.NEMOCLAW_LAUNCH_EXIT_COMMAND ?? "/exit",
-        NEMOCLAW_LAUNCH_FIRST_INPUT: invocationEnv.NEMOCLAW_LAUNCH_FIRST_INPUT ?? "first input",
-        NEMOCLAW_LAUNCH_HOST_TMP_ROOT: fixtureRoot,
-        NEMOCLAW_LAUNCH_OPENSHELL_SHIM_SCRIPT: OPENCLAW_LAUNCH_OPENSHELL_SHIM_SCRIPT,
-        NEMOCLAW_LAUNCH_PTY_MONITOR_STARTER_SCRIPT: ptyMonitorStarterScript,
-        NEMOCLAW_LAUNCH_RUN_ID: runId,
-        NEMOCLAW_LAUNCH_RUNTIME_ENV_SCRIPT: OPENCLAW_LAUNCH_RUNTIME_ENV_SCRIPT,
-        NEMOCLAW_LAUNCH_SANDBOX: invocationEnv.NEMOCLAW_LAUNCH_SANDBOX ?? "sandbox",
-        NEMOCLAW_LAUNCH_SESSION_BUDGET_SECONDS:
-          mode === "restored-canonical-timeout"
-            ? "10"
-            : mode === "pty-socket-timeout"
-              ? "5"
-              : mode.endsWith("-timeout")
-                ? "2"
-                : (invocationEnv.NEMOCLAW_LAUNCH_SESSION_BUDGET_SECONDS ?? "230"),
-        NEMOCLAW_LAUNCH_SECOND_INPUT: invocationEnv.NEMOCLAW_LAUNCH_SECOND_INPUT ?? "second input",
-        NEMOCLAW_LAUNCH_SESSION_EVIDENCE_SCRIPT: OPENCLAW_SESSION_EVIDENCE_SCRIPT,
-        NEMOCLAW_LAUNCH_SESSION_ROOT: sessionRoot,
-        NEMOCLAW_OPENSHELL_COMMAND: fakeOpenshell,
-        PATH: `${fixtureRoot}:${process.env.PATH ?? ""}`,
-        TERM: invocationEnv.TERM ?? "xterm-256color",
-      },
-      timeout: 15_000,
+    const result = await runLaunchCommand(launchCommand, launchArgs, {
+      ...process.env,
+      ...invocationEnv,
+      HOME: fixtureRoot,
+      NEMOCLAW_FIXTURE_BIN_ROOT: fixtureRoot,
+      NEMOCLAW_FIXTURE_CANONICAL_RESTORED_MARKER: canonicalRestoredMarker,
+      NEMOCLAW_FIXTURE_EARLY_INPUT_MARKER: earlyInputMarker,
+      NEMOCLAW_FIXTURE_MODE: mode,
+      NEMOCLAW_FIXTURE_MONITOR_PID: monitorPidPath,
+      NEMOCLAW_FIXTURE_OPENSHELL_CALLS: openshellCallsRoot,
+      NEMOCLAW_FIXTURE_PENDING_QUALIFICATION_MARKER: pendingQualificationMarker,
+      NEMOCLAW_FIXTURE_PTY_MONITOR_ROOT: ptyMonitorRoot,
+      NEMOCLAW_FIXTURE_PTY_PATH_UNREADABLE_MARKER: ptyPathUnreadableMarker,
+      NEMOCLAW_FIXTURE_PTY_SOCKET_RECEIPT: ptySocketReceiptPath,
+      NEMOCLAW_FIXTURE_SESSION_FILE: join(sessionRoot, "session-a.jsonl"),
+      NEMOCLAW_FIXTURE_TERMINAL_COPY: terminalCopy,
+      NEMOCLAW_FIXTURE_RUN_ID: runId,
+      NEMOCLAW_FIXTURE_TUI_PIDS: tuiPidsPath,
+      NEMOCLAW_FIXTURE_TTY_MARKER: ttyMarker,
+      NEMOCLAW_LAUNCH_COMMAND: invocationEnv.NEMOCLAW_LAUNCH_COMMAND ?? fakeLaunch,
+      NEMOCLAW_LAUNCH_ENTRYPOINT: invocationEnv.NEMOCLAW_LAUNCH_ENTRYPOINT ?? "",
+      NEMOCLAW_LAUNCH_EXIT_COMMAND: invocationEnv.NEMOCLAW_LAUNCH_EXIT_COMMAND ?? "/exit",
+      NEMOCLAW_LAUNCH_FIRST_INPUT: invocationEnv.NEMOCLAW_LAUNCH_FIRST_INPUT ?? "first input",
+      NEMOCLAW_LAUNCH_HOST_TMP_ROOT: fixtureRoot,
+      NEMOCLAW_LAUNCH_OPENSHELL_SHIM_SCRIPT: OPENCLAW_LAUNCH_OPENSHELL_SHIM_SCRIPT,
+      NEMOCLAW_LAUNCH_PTY_MONITOR_STARTER_SCRIPT: ptyMonitorStarterScript,
+      NEMOCLAW_LAUNCH_RUN_ID: runId,
+      NEMOCLAW_LAUNCH_RUNTIME_ENV_SCRIPT: OPENCLAW_LAUNCH_RUNTIME_ENV_SCRIPT,
+      NEMOCLAW_LAUNCH_SANDBOX: invocationEnv.NEMOCLAW_LAUNCH_SANDBOX ?? "sandbox",
+      NEMOCLAW_LAUNCH_SESSION_BUDGET_SECONDS:
+        mode === "restored-canonical-timeout"
+          ? "10"
+          : mode === "pty-socket-timeout"
+            ? "5"
+            : mode.endsWith("-timeout")
+              ? "2"
+              : (invocationEnv.NEMOCLAW_LAUNCH_SESSION_BUDGET_SECONDS ?? "230"),
+      NEMOCLAW_LAUNCH_SECOND_INPUT: invocationEnv.NEMOCLAW_LAUNCH_SECOND_INPUT ?? "second input",
+      NEMOCLAW_LAUNCH_SESSION_EVIDENCE_SCRIPT: OPENCLAW_SESSION_EVIDENCE_SCRIPT,
+      NEMOCLAW_LAUNCH_SESSION_ROOT: sessionRoot,
+      NEMOCLAW_OPENSHELL_COMMAND: fakeOpenshell,
+      PATH: `${fixtureRoot}:${process.env.PATH ?? ""}`,
+      TERM: invocationEnv.TERM ?? "xterm-256color",
     });
     const tuiProcessIds = existsSync(tuiPidsPath)
       ? readFileSync(tuiPidsPath, "utf8").trim().split("\n").filter(Boolean)
@@ -790,9 +814,9 @@ it.runIf(process.platform === "linux")(
   },
 );
 
-it.runIf(process.platform === "linux").each(["absent", "ansi", "reordered"] as const)(
+it.runIf(process.platform === "linux").concurrent.for(["absent", "ansi", "reordered"] as const)(
   "keeps the monitor alive through SIGTERM, records an auto-message and PTY turn, sends /exit, strips launch authority, and ignores terminal copy evidence [%s] (#9160, #9384)",
-  (terminalCopy) => {
+  async (terminalCopy, { expect }) => {
     const {
       baselineRemoved,
       hostSessionResidue,
@@ -804,7 +828,7 @@ it.runIf(process.platform === "linux").each(["absent", "ansi", "reordered"] as c
       result,
       tuiProcessIds,
       ttyObserved,
-    } = runLaunchSessionFixture("valid", terminalCopy);
+    } = await runLaunchSessionFixture("valid", terminalCopy);
     expect(ttyObserved, result.stderr).toBe(true);
     expect(baselineRemoved).toBe(true);
     expect(ptyMonitorRemoved).toBe(true);
@@ -831,10 +855,10 @@ it.runIf(process.platform === "linux").each(["absent", "ansi", "reordered"] as c
   },
 );
 
-it.runIf(process.platform === "linux")(
+it.runIf(process.platform === "linux").concurrent(
   "waits for OpenClaw input mode and accepts a clean exit after two turns (#9160, #9384)",
-  () => {
-    const { baselineRemoved, result, ttyObserved } = runLaunchSessionFixture(
+  async ({ expect }) => {
+    const { baselineRemoved, result, ttyObserved } = await runLaunchSessionFixture(
       "delayed-input-attachment",
       "absent",
     );
@@ -845,19 +869,19 @@ it.runIf(process.platform === "linux")(
   },
 );
 
-it.runIf(process.platform === "linux")(
+it.runIf(process.platform === "linux").concurrent(
   "waits for OpenClaw startup to accept its auto-message before submitting one PTY input (#9384)",
-  () => {
-    const fixture = runLaunchSessionFixture("delayed-tui-ready", "absent");
+  async ({ expect }) => {
+    const fixture = await runLaunchSessionFixture("delayed-tui-ready", "absent");
     expect(fixture.earlyInputObserved, fixture.result.stderr).toBe(false);
     expect(fixture.baselineRemoved, fixture.result.stderr).toBe(true);
     expect(fixture.result.status, fixture.result.stderr).toBe(0);
   },
 );
 
-it.runIf(process.platform === "linux" && process.getuid?.() !== 0)(
+it.runIf(process.platform === "linux" && process.getuid?.() !== 0).concurrent(
   "uses the inherited PTY descriptor when the sandbox user cannot reopen the device path (#9384)",
-  () => {
+  async ({ expect }) => {
     const {
       baselineRemoved,
       hostSessionResidue,
@@ -867,7 +891,7 @@ it.runIf(process.platform === "linux" && process.getuid?.() !== 0)(
       ptyMonitorRemoved,
       result,
       ttyObserved,
-    } = runLaunchSessionFixture("pty-path-unreadable", "absent");
+    } = await runLaunchSessionFixture("pty-path-unreadable", "absent");
     expect(ttyObserved, result.stderr).toBe(true);
     expect(ptyPathQueryResult, result.stderr).toEqual({ errorCode: null, status: 1 });
     expect(baselineRemoved, result.stderr).toBe(true);
@@ -880,7 +904,7 @@ it.runIf(process.platform === "linux" && process.getuid?.() !== 0)(
   },
 );
 
-it.runIf(process.platform === "linux").each([
+it.runIf(process.platform === "linux").concurrent.for([
   {
     mode: "pty-socket-invalid",
     reason: "pty_termios_response_invalid",
@@ -917,7 +941,8 @@ it.runIf(process.platform === "linux").each([
   },
 ] as const)(
   "rejects $behavior before PTY input (#9160, #9384)",
-  ({ expectedDiagnostic, mode, monitorRemoved, reason }) => {
+  { timeout: testTimeout(20_000) },
+  async ({ expectedDiagnostic, mode, monitorRemoved, reason }, { expect }) => {
     const {
       baselineRemoved,
       earlyInputObserved,
@@ -926,7 +951,7 @@ it.runIf(process.platform === "linux").each([
       ptyMonitorRemoved,
       result,
       ttyObserved,
-    } = runLaunchSessionFixture(mode, "absent");
+    } = await runLaunchSessionFixture(mode, "absent");
     const failureEvidence = `${mode}: ${result.stderr}`;
     const diagnostics = result.stderr.split("\n").flatMap((line) => {
       try {
@@ -948,14 +973,13 @@ it.runIf(process.platform === "linux").each([
     );
     expect(ptyMonitorRemoved, failureEvidence).toBe(monitorRemoved);
   },
-  testTimeout(20_000),
 );
 
-it.runIf(process.platform === "linux")(
+it.runIf(process.platform === "linux").concurrent(
   "submits each PTY turn once while structured recording is delayed (#9160)",
-  () => {
+  async ({ expect }) => {
     const { baselineRemoved, pendingQualificationObserved, result, ttyObserved } =
-      runLaunchSessionFixture("delayed-recording", "absent");
+      await runLaunchSessionFixture("delayed-recording", "absent");
     expect(ttyObserved).toBe(true);
     expect(pendingQualificationObserved).toBe(true);
     expect(baselineRemoved).toBe(true);
@@ -964,11 +988,11 @@ it.runIf(process.platform === "linux")(
   },
 );
 
-it.runIf(process.platform === "linux")(
+it.runIf(process.platform === "linux").concurrent(
   "fails when the PTY remains in canonical input mode until the session deadline (#9160)",
-  () => {
+  async ({ expect }) => {
     const { baselineRemoved, orphanedMonitorProcessIds, ptyMonitorRemoved, result, ttyObserved } =
-      runLaunchSessionFixture("input-mode-timeout", "absent");
+      await runLaunchSessionFixture("input-mode-timeout", "absent");
     expect(ttyObserved).toBe(true);
     expect(baselineRemoved).toBe(true);
     expect(ptyMonitorRemoved).toBe(true);
@@ -983,9 +1007,9 @@ it.runIf(process.platform === "linux")(
   testTimeout(20_000),
 );
 
-it.runIf(process.platform === "linux")(
+it.runIf(process.platform === "linux").concurrent(
   "requires a current noncanonical observation after the PTY returns to canonical mode (#9384)",
-  () => {
+  async ({ expect }) => {
     const {
       baselineRemoved,
       canonicalRestored,
@@ -994,7 +1018,7 @@ it.runIf(process.platform === "linux")(
       ptyMonitorRemoved,
       result,
       ttyObserved,
-    } = runLaunchSessionFixture("restored-canonical-timeout", "absent");
+    } = await runLaunchSessionFixture("restored-canonical-timeout", "absent");
     expect(ttyObserved).toBe(true);
     expect(canonicalRestored).toBe(true);
     expect(earlyInputObserved).toBe(false);
@@ -1008,13 +1032,11 @@ it.runIf(process.platform === "linux")(
   testTimeout(30_000),
 );
 
-it.runIf(process.platform === "linux")(
+it.runIf(process.platform === "linux").concurrent(
   "fails when the PTY monitor socket remains missing until the session deadline (#9160)",
-  () => {
-    const { baselineRemoved, ptyMonitorRemoved, result, ttyObserved } = runLaunchSessionFixture(
-      "pty-socket-timeout",
-      "absent",
-    );
+  async ({ expect }) => {
+    const { baselineRemoved, ptyMonitorRemoved, result, ttyObserved } =
+      await runLaunchSessionFixture("pty-socket-timeout", "absent");
     expect(ttyObserved).toBe(false);
     expect(baselineRemoved).toBe(true);
     expect(ptyMonitorRemoved).toBe(true);
@@ -1025,10 +1047,10 @@ it.runIf(process.platform === "linux")(
   testTimeout(20_000),
 );
 
-it.runIf(process.platform === "linux")(
+it.runIf(process.platform === "linux").concurrent(
   "marks provider unavailability when it leaves an empty structured turn (#9160, #10978)",
-  () => {
-    const { baselineRemoved, result, ttyObserved } = runLaunchSessionFixture(
+  async ({ expect }) => {
+    const { baselineRemoved, result, ttyObserved } = await runLaunchSessionFixture(
       "provider-empty-message",
       "provider",
     );
@@ -1058,13 +1080,17 @@ it.runIf(process.platform === "linux").each([
       runId?: string;
       stderr: string;
     }> = [];
+    let markFirstCallFinished: () => void = () => undefined;
+    const firstCallFinished = new Promise<void>((resolve) => {
+      markFirstCallFinished = resolve;
+    });
     const host = {
       command: async (
         command: string,
         args: string[],
         options?: { artifactName?: string; env?: NodeJS.ProcessEnv },
       ) => {
-        const fixture = runLaunchSessionFixture(
+        const { result: fixture } = await runLaunchSessionFixture(
           calls.length === 0 ? "provider-exit-after-recording" : secondMode,
           calls.length === 0 ? "provider" : secondTerminal,
           {
@@ -1076,13 +1102,14 @@ it.runIf(process.platform === "linux").each([
               NEMOCLAW_FIXTURE_PROVIDER_ERROR_MESSAGE: `litellm.${providerError}: ${providerError}: upstream unavailable`,
             },
           },
-        ).result;
+        );
         calls.push({
           artifactName: options?.artifactName,
           firstInput: options?.env?.NEMOCLAW_LAUNCH_FIRST_INPUT,
           runId: options?.env?.NEMOCLAW_LAUNCH_RUN_ID,
           stderr: fixture.stderr,
         });
+        calls.length === 1 ? markFirstCallFinished() : undefined;
         return {
           exitCode: fixture.status ?? 1,
           signal: fixture.signal,
@@ -1103,6 +1130,7 @@ it.runIf(process.platform === "linux").each([
         redactionValues: [],
         sandboxName: "alpha",
       });
+      await firstCallFinished;
       await vi.advanceTimersByTimeAsync(1_000);
       const outcome = launch.then(({ exitCode }) => exitCode).catch(String);
       await expect(outcome).resolves.toEqual(
@@ -1127,10 +1155,10 @@ it.runIf(process.platform === "linux").each([
   testTimeout(30_000),
 );
 
-it.runIf(process.platform === "linux")(
+it.runIf(process.platform === "linux").concurrent(
   "does not retry a provider failure when producer cleanup is incomplete (#10978)",
-  async () => {
-    const produced = runLaunchSessionFixture("provider-cleanup-failure", "provider").result;
+  async ({ expect }) => {
+    const produced = (await runLaunchSessionFixture("provider-cleanup-failure", "provider")).result;
     let calls = 0;
     const host = {
       command: async () => {
@@ -1163,10 +1191,10 @@ it.runIf(process.platform === "linux")(
   testTimeout(30_000),
 );
 
-it.runIf(process.platform === "linux")(
+it.runIf(process.platform === "linux").concurrent(
   "does not retry when terminal output mimics provider unavailability (#10978)",
-  async () => {
-    const produced = runLaunchSessionFixture("provider-terminal-spoof", "provider").result;
+  async ({ expect }) => {
+    const produced = (await runLaunchSessionFixture("provider-terminal-spoof", "provider")).result;
     let calls = 0;
     const host = {
       command: async () => {
@@ -1194,13 +1222,14 @@ it.runIf(process.platform === "linux")(
   testTimeout(30_000),
 );
 
-it.runIf(process.platform === "linux").each([
+it.runIf(process.platform === "linux").concurrent.for([
   { mismatch: "API", mode: "provider-wrong-api" },
   { mismatch: "route", mode: "provider-wrong-route" },
 ] as const)(
   "does not retry a structured provider error with the wrong $mismatch identity (#10978)",
-  async ({ mode }) => {
-    const produced = runLaunchSessionFixture(mode, "provider").result;
+  { timeout: testTimeout(30_000) },
+  async ({ mode }, { expect }) => {
+    const produced = (await runLaunchSessionFixture(mode, "provider")).result;
     const firstResult = {
       exitCode: produced.status ?? 1,
       signal: produced.signal,
@@ -1229,13 +1258,12 @@ it.runIf(process.platform === "linux").each([
     ).rejects.toThrow("launch session failed");
     expect(calls).toBe(1);
   },
-  testTimeout(30_000),
 );
 
-it.runIf(process.platform === "linux")(
+it.runIf(process.platform === "linux").concurrent(
   "does not mark provider output without structured empty-message evidence (#10978)",
-  () => {
-    const produced = runLaunchSessionFixture("recording-timeout", "provider").result;
+  async ({ expect }) => {
+    const produced = (await runLaunchSessionFixture("recording-timeout", "provider")).result;
     expect(produced.status).toBe(1);
     expect(produced.stderr).toContain("ServiceUnavailableError");
     expect(produced.stderr).not.toContain("nemoclaw.e2e.launch-failure=provider-unavailable");
@@ -1243,10 +1271,10 @@ it.runIf(process.platform === "linux")(
   testTimeout(20_000),
 );
 
-it.runIf(process.platform === "linux")(
+it.runIf(process.platform === "linux").concurrent(
   "rejects out-of-order structured records even when the PTY process remains active (#9160)",
-  () => {
-    const { baselineRemoved, result, ttyObserved } = runLaunchSessionFixture(
+  async ({ expect }) => {
+    const { baselineRemoved, result, ttyObserved } = await runLaunchSessionFixture(
       "invalid-order",
       "absent",
     );
@@ -1257,10 +1285,10 @@ it.runIf(process.platform === "linux")(
   },
 );
 
-it.runIf(process.platform === "linux")(
+it.runIf(process.platform === "linux").concurrent(
   "rejects a late extra structured record before baseline cleanup (#9160)",
-  () => {
-    const { baselineRemoved, result, ttyObserved } = runLaunchSessionFixture(
+  async ({ expect }) => {
+    const { baselineRemoved, result, ttyObserved } = await runLaunchSessionFixture(
       "late-extra",
       "absent",
     );
@@ -1275,10 +1303,13 @@ it.runIf(process.platform === "linux")(
   },
 );
 
-it.runIf(process.platform === "linux")(
+it.runIf(process.platform === "linux").concurrent(
   "propagates a nonzero TUI exit after two structured turns (#9160)",
-  () => {
-    const { baselineRemoved, result, ttyObserved } = runLaunchSessionFixture("nonzero", "absent");
+  async ({ expect }) => {
+    const { baselineRemoved, result, ttyObserved } = await runLaunchSessionFixture(
+      "nonzero",
+      "absent",
+    );
     expect(ttyObserved).toBe(true);
     expect(baselineRemoved).toBe(true);
     expect(result.signal).toBeNull();
@@ -1286,11 +1317,11 @@ it.runIf(process.platform === "linux")(
   },
 );
 
-it.runIf(process.platform === "linux")(
+it.runIf(process.platform === "linux").concurrent(
   "fails when a qualified PTY session cannot run PTY monitor cleanup (#9160)",
-  () => {
+  async ({ expect }) => {
     const { hostSessionResidue, orphanedTuiProcessIds, ptyMonitorRemoved, result } =
-      runLaunchSessionFixture("pty-cleanup-failure", "absent");
+      await runLaunchSessionFixture("pty-cleanup-failure", "absent");
     expect(ptyMonitorRemoved).toBe(false);
     expect(hostSessionResidue).toEqual([]);
     expect(orphanedTuiProcessIds).toEqual([]);
@@ -1300,10 +1331,10 @@ it.runIf(process.platform === "linux")(
   },
 );
 
-it.runIf(process.platform === "linux")(
+it.runIf(process.platform === "linux").concurrent(
   "refuses to remove an unknown entry from the mode-0700 PTY monitor directory (#9160)",
-  () => {
-    const { orphanedTuiProcessIds, ptyMonitorRemoved, result } = runLaunchSessionFixture(
+  async ({ expect }) => {
+    const { orphanedTuiProcessIds, ptyMonitorRemoved, result } = await runLaunchSessionFixture(
       "pty-cleanup-unknown-entry",
       "absent",
     );
@@ -1315,10 +1346,10 @@ it.runIf(process.platform === "linux")(
   },
 );
 
-it.runIf(process.platform === "linux")(
+it.runIf(process.platform === "linux").concurrent(
   "fails when a successful PTY session cannot remove its structured baseline (#9160)",
-  () => {
-    const { baselineRemoved, result, ttyObserved } = runLaunchSessionFixture(
+  async ({ expect }) => {
+    const { baselineRemoved, result, ttyObserved } = await runLaunchSessionFixture(
       "cleanup-failure",
       "absent",
     );
@@ -1330,13 +1361,11 @@ it.runIf(process.platform === "linux")(
   },
 );
 
-it.runIf(process.platform === "linux")(
+it.runIf(process.platform === "linux").concurrent(
   "preserves a nonzero PTY exit when PTY monitor cleanup also fails (#9160)",
-  () => {
-    const { baselineRemoved, ptyMonitorRemoved, result, ttyObserved } = runLaunchSessionFixture(
-      "nonzero-pty-cleanup-failure",
-      "absent",
-    );
+  async ({ expect }) => {
+    const { baselineRemoved, ptyMonitorRemoved, result, ttyObserved } =
+      await runLaunchSessionFixture("nonzero-pty-cleanup-failure", "absent");
     expect(ttyObserved).toBe(true);
     expect(baselineRemoved).toBe(true);
     expect(ptyMonitorRemoved).toBe(false);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

Runs isolated launch-turn child-process fixtures with bounded overlap instead of serially. Exact-head Linux CI reduces this 43-test file from 85.0 seconds to 49.8 seconds (41.4% faster); production code, assertions, and failure semantics are unchanged.

## Reason

Each Linux case already owns a unique temporary directory and launch run ID, but `spawnSync` blocked the Vitest worker until every child completed. This file is currently the slowest test file in the CLI timing artifact.

### Related issues

Part of #6237.

## Changes

- Replace the test-local blocking launch command with an asynchronous `execFile` wrapper that preserves the 15-second timeout, captured output, exit status, and signal.
- Run independent Linux fixture cases concurrently with overlap capped at three to bound runner pressure.
- Keep the provider-retry table sequential because it controls Vitest's global fake timers, and wait for its first async child before advancing those timers.
- Use test-local `expect` instances for concurrent assertions.

## Verification

- Current-main CLI timing artifact from run `34513084263` — `test/e2e/support/launch-agent-turn.test.ts` took 84.999 seconds across 43 tests.
- Exact-head CLI timing artifact from run `34519432854` — the same 43 tests passed in 49.801 seconds, saving 35.198 seconds (41.4%).
- `npx vitest run --project e2e-support test/e2e/support/launch-agent-turn.test.ts` — passed: 6 host-compatible tests; 37 Linux-only tests collected and skipped on macOS; 43 total.
- `npm run typecheck:cli` — passed after building the package-contract plugin artifact.
- `npx vitest run --project integration test/automation/pull-requests/growth-guardrails.test.ts` — passed: 45/45.
- Normal pre-commit hooks — formatting, lint, repository checks, source-shape budget, growth guardrails, gitleaks, and commitlint passed.
- Normal pre-push hooks — CLI TypeScript check passed.
- GitHub commit verification — `1e7607ae579361ae37d40809fe0a12fa2b1dcfd7` is Verified (`reason=valid`).
- Secret review — no secrets, API keys, or credentials added; gitleaks passed.
- Documentation — not needed for a test-only scheduling change.

## Review notes

The optimized cases are Linux-only, so exact-head hosted CI is the authoritative behavior and timing check. The concurrency boundary excludes the shared fake-timer cases and caps child-process overlap at three.

---
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end launch timeout handling and cleanup verification.
  * Confirmed that timed-out processes and their descendants terminate cleanly.
  * Added validation that temporary launch state and monitoring processes are removed before test teardown.
  * Improved reporting of timeout outcomes and cleanup status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->