### PR TITLE
fix(e2e): preserve unrelated systemd units during cleanup

### DIFF
--- a/.github/actions/restore-native-podman-e2e/action.yaml
+++ b/.github/actions/restore-native-podman-e2e/action.yaml
@@ -101,7 +101,10 @@ runs:
           remove_user_file "$RUNNER_TEMP/native-podman-e2e-info.json"
           service_unit_directory_preexisting="$(sudo -n jq -r '.serviceUnitDirectoryPreexisting' "$cleanup_state_path")"
           if [[ "$service_unit_directory_preexisting" == "false" && -d "$service_unit_directory" ]]; then
-            rmdir -- "$service_unit_directory"
+            if ! rmdir -- "$service_unit_directory" 2>/dev/null; then
+              [[ -d "$service_unit_directory" && ! -L "$service_unit_directory" ]]
+              [[ -n "$(find -P "$service_unit_directory" -mindepth 1 -maxdepth 1 -print -quit)" ]]
+            fi
           fi
           if [[ "$current_user_manager" == "active" ]]; then
             env \

--- a/.github/workflows/e2e-standard-profile.yaml
+++ b/.github/workflows/e2e-standard-profile.yaml
@@ -447,7 +447,7 @@ jobs:
           provenance-json: ${{ inputs.cli_artifact_provenance }}
 
       - name: Prepare native Podman E2E runtime
-        uses: NVIDIA/NemoClaw/.github/actions/setup-native-podman-e2e@3b03ce52141aad935bc28bd0100b997573e46539
+        uses: NVIDIA/NemoClaw/.github/actions/setup-native-podman-e2e@b39c9ee2bba1bffaabcfe97ae4a7787a5c603ee8
         with:
           enabled: ${{ inputs.runtime_provider == 'podman' && 'true' || 'false' }}
 
@@ -750,7 +750,7 @@ jobs:
 
       - name: Restore Docker CLI after native Podman E2E
         if: ${{ always() && inputs.runtime_provider == 'podman' }}
-        uses: NVIDIA/NemoClaw/.github/actions/restore-native-podman-e2e@3b03ce52141aad935bc28bd0100b997573e46539
+        uses: NVIDIA/NemoClaw/.github/actions/restore-native-podman-e2e@b39c9ee2bba1bffaabcfe97ae4a7787a5c603ee8
         with:
           enabled: "true"
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2844,7 +2844,7 @@ jobs:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
       - name: Prepare native Podman E2E runtime
-        uses: NVIDIA/NemoClaw/.github/actions/setup-native-podman-e2e@3b03ce52141aad935bc28bd0100b997573e46539
+        uses: NVIDIA/NemoClaw/.github/actions/setup-native-podman-e2e@b39c9ee2bba1bffaabcfe97ae4a7787a5c603ee8
         with:
           enabled: ${{ matrix.runtime_provider == 'podman' && 'true' || 'false' }}
 
@@ -2976,7 +2976,7 @@ jobs:
 
       - name: Restore Docker CLI after native Podman E2E
         if: ${{ always() && matrix.runtime_provider == 'podman' }}
-        uses: NVIDIA/NemoClaw/.github/actions/restore-native-podman-e2e@3b03ce52141aad935bc28bd0100b997573e46539
+        uses: NVIDIA/NemoClaw/.github/actions/restore-native-podman-e2e@b39c9ee2bba1bffaabcfe97ae4a7787a5c603ee8
         with:
           enabled: "true"
 
@@ -3027,7 +3027,7 @@ jobs:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
       - name: Prepare native Podman E2E runtime
-        uses: NVIDIA/NemoClaw/.github/actions/setup-native-podman-e2e@3b03ce52141aad935bc28bd0100b997573e46539
+        uses: NVIDIA/NemoClaw/.github/actions/setup-native-podman-e2e@b39c9ee2bba1bffaabcfe97ae4a7787a5c603ee8
         with:
           enabled: ${{ matrix.runtime_provider == 'podman' && 'true' || 'false' }}
 
@@ -3050,7 +3050,7 @@ jobs:
 
       - name: Restore Docker CLI after native Podman E2E
         if: ${{ always() && matrix.runtime_provider == 'podman' }}
-        uses: NVIDIA/NemoClaw/.github/actions/restore-native-podman-e2e@3b03ce52141aad935bc28bd0100b997573e46539
+        uses: NVIDIA/NemoClaw/.github/actions/restore-native-podman-e2e@b39c9ee2bba1bffaabcfe97ae4a7787a5c603ee8
         with:
           enabled: "true"
 
@@ -3710,7 +3710,7 @@ jobs:
         run: npx tsx tools/e2e/runner-comparison.mts initialize
 
       - name: Prepare native Podman E2E runtime
-        uses: NVIDIA/NemoClaw/.github/actions/setup-native-podman-e2e@3b03ce52141aad935bc28bd0100b997573e46539
+        uses: NVIDIA/NemoClaw/.github/actions/setup-native-podman-e2e@b39c9ee2bba1bffaabcfe97ae4a7787a5c603ee8
         with:
           enabled: ${{ matrix.runtime_provider == 'podman' && 'true' || 'false' }}
 
@@ -3798,7 +3798,7 @@ jobs:
 
       - name: Restore Docker CLI after native Podman E2E
         if: ${{ always() && matrix.runtime_provider == 'podman' }}
-        uses: NVIDIA/NemoClaw/.github/actions/restore-native-podman-e2e@3b03ce52141aad935bc28bd0100b997573e46539
+        uses: NVIDIA/NemoClaw/.github/actions/restore-native-podman-e2e@b39c9ee2bba1bffaabcfe97ae4a7787a5c603ee8
         with:
           enabled: "true"
 
@@ -3861,7 +3861,7 @@ jobs:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
       - name: Prepare native Podman E2E runtime
-        uses: NVIDIA/NemoClaw/.github/actions/setup-native-podman-e2e@3b03ce52141aad935bc28bd0100b997573e46539
+        uses: NVIDIA/NemoClaw/.github/actions/setup-native-podman-e2e@b39c9ee2bba1bffaabcfe97ae4a7787a5c603ee8
         with:
           enabled: ${{ matrix.runtime_provider == 'podman' && 'true' || 'false' }}
 
@@ -3941,7 +3941,7 @@ jobs:
 
       - name: Restore Docker CLI after native Podman E2E
         if: ${{ always() && matrix.runtime_provider == 'podman' }}
-        uses: NVIDIA/NemoClaw/.github/actions/restore-native-podman-e2e@3b03ce52141aad935bc28bd0100b997573e46539
+        uses: NVIDIA/NemoClaw/.github/actions/restore-native-podman-e2e@b39c9ee2bba1bffaabcfe97ae4a7787a5c603ee8
         with:
           enabled: "true"
 
@@ -4134,7 +4134,7 @@ jobs:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
       - name: Prepare native Podman E2E runtime
-        uses: NVIDIA/NemoClaw/.github/actions/setup-native-podman-e2e@3b03ce52141aad935bc28bd0100b997573e46539
+        uses: NVIDIA/NemoClaw/.github/actions/setup-native-podman-e2e@b39c9ee2bba1bffaabcfe97ae4a7787a5c603ee8
         with:
           enabled: ${{ matrix.runtime_provider == 'podman' && 'true' || 'false' }}
 
@@ -4202,7 +4202,7 @@ jobs:
 
       - name: Restore Docker CLI after native Podman E2E
         if: ${{ always() && matrix.runtime_provider == 'podman' }}
-        uses: NVIDIA/NemoClaw/.github/actions/restore-native-podman-e2e@3b03ce52141aad935bc28bd0100b997573e46539
+        uses: NVIDIA/NemoClaw/.github/actions/restore-native-podman-e2e@b39c9ee2bba1bffaabcfe97ae4a7787a5c603ee8
         with:
           enabled: "true"
 
@@ -5328,7 +5328,7 @@ jobs:
         run: npx tsx tools/e2e/runner-comparison.mts initialize
 
       - name: Prepare native Podman E2E runtime
-        uses: NVIDIA/NemoClaw/.github/actions/setup-native-podman-e2e@3b03ce52141aad935bc28bd0100b997573e46539
+        uses: NVIDIA/NemoClaw/.github/actions/setup-native-podman-e2e@b39c9ee2bba1bffaabcfe97ae4a7787a5c603ee8
         with:
           enabled: ${{ matrix.runtime_provider == 'podman' && 'true' || 'false' }}
 
@@ -5354,7 +5354,7 @@ jobs:
 
       - name: Restore Docker CLI after native Podman E2E
         if: ${{ always() && matrix.runtime_provider == 'podman' }}
-        uses: NVIDIA/NemoClaw/.github/actions/restore-native-podman-e2e@3b03ce52141aad935bc28bd0100b997573e46539
+        uses: NVIDIA/NemoClaw/.github/actions/restore-native-podman-e2e@b39c9ee2bba1bffaabcfe97ae4a7787a5c603ee8
         with:
           enabled: "true"
 
@@ -5506,12 +5506,12 @@ jobs:
 
       - name: Recover Docker CLI before native Podman E2E
         if: ${{ matrix.runtime_provider == 'podman' }}
-        uses: NVIDIA/NemoClaw/.github/actions/restore-native-podman-e2e@3b03ce52141aad935bc28bd0100b997573e46539
+        uses: NVIDIA/NemoClaw/.github/actions/restore-native-podman-e2e@b39c9ee2bba1bffaabcfe97ae4a7787a5c603ee8
         with:
           enabled: "true"
 
       - name: Prepare native Podman E2E runtime
-        uses: NVIDIA/NemoClaw/.github/actions/setup-native-podman-e2e@3b03ce52141aad935bc28bd0100b997573e46539
+        uses: NVIDIA/NemoClaw/.github/actions/setup-native-podman-e2e@b39c9ee2bba1bffaabcfe97ae4a7787a5c603ee8
         with:
           enabled: ${{ matrix.runtime_provider == 'podman' && 'true' || 'false' }}
 
@@ -5655,7 +5655,7 @@ jobs:
 
       - name: Restore Docker CLI after native Podman E2E
         if: ${{ always() && matrix.runtime_provider == 'podman' }}
-        uses: NVIDIA/NemoClaw/.github/actions/restore-native-podman-e2e@3b03ce52141aad935bc28bd0100b997573e46539
+        uses: NVIDIA/NemoClaw/.github/actions/restore-native-podman-e2e@b39c9ee2bba1bffaabcfe97ae4a7787a5c603ee8
         with:
           enabled: "true"
 
@@ -5777,7 +5777,7 @@ jobs:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
       - name: Prepare native Podman E2E runtime
-        uses: NVIDIA/NemoClaw/.github/actions/setup-native-podman-e2e@3b03ce52141aad935bc28bd0100b997573e46539
+        uses: NVIDIA/NemoClaw/.github/actions/setup-native-podman-e2e@b39c9ee2bba1bffaabcfe97ae4a7787a5c603ee8
         with:
           enabled: ${{ matrix.runtime_provider == 'podman' && 'true' || 'false' }}
 
@@ -5861,7 +5861,7 @@ jobs:
 
       - name: Restore Docker CLI after native Podman public install
         if: ${{ always() && matrix.runtime_provider == 'podman' }}
-        uses: NVIDIA/NemoClaw/.github/actions/restore-native-podman-e2e@3b03ce52141aad935bc28bd0100b997573e46539
+        uses: NVIDIA/NemoClaw/.github/actions/restore-native-podman-e2e@b39c9ee2bba1bffaabcfe97ae4a7787a5c603ee8
         with:
           enabled: "true"
 
@@ -5920,7 +5920,7 @@ jobs:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
 
       - name: Prepare native Podman E2E runtime
-        uses: NVIDIA/NemoClaw/.github/actions/setup-native-podman-e2e@3b03ce52141aad935bc28bd0100b997573e46539
+        uses: NVIDIA/NemoClaw/.github/actions/setup-native-podman-e2e@b39c9ee2bba1bffaabcfe97ae4a7787a5c603ee8
         with:
           enabled: ${{ matrix.runtime_provider == 'podman' && 'true' || 'false' }}
 
@@ -5953,7 +5953,7 @@ jobs:
 
       - name: Restore Docker CLI after native Podman E2E
         if: ${{ always() && matrix.runtime_provider == 'podman' }}
-        uses: NVIDIA/NemoClaw/.github/actions/restore-native-podman-e2e@3b03ce52141aad935bc28bd0100b997573e46539
+        uses: NVIDIA/NemoClaw/.github/actions/restore-native-podman-e2e@b39c9ee2bba1bffaabcfe97ae4a7787a5c603ee8
         with:
           enabled: "true"
 

--- a/test/e2e/support/native-podman-setup-action.test.ts
+++ b/test/e2e/support/native-podman-setup-action.test.ts
@@ -162,7 +162,11 @@ function writeExecutable(filePath: string, source: string): void {
   fs.writeFileSync(filePath, source, { mode: 0o700 });
 }
 
-function runPodmanCleanupFixture(withDockerState: boolean, podmanStopFails = false) {
+function runPodmanCleanupFixture(
+  withDockerState: boolean,
+  podmanStopFails = false,
+  withUnrelatedServiceUnit = false,
+) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-podman-cleanup-"));
   const runnerTemp = path.join(root, "runner-temp");
   const home = path.join(root, "home");
@@ -201,6 +205,13 @@ function runPodmanCleanupFixture(withDockerState: boolean, podmanStopFails = fal
     "owned\n",
   );
   fs.writeFileSync(path.join(serviceUnitDirectory, "nemoclaw-native-podman-e2e.socket"), "owned\n");
+  new Map<boolean, () => void>([
+    [
+      true,
+      () => fs.writeFileSync(path.join(serviceUnitDirectory, "unrelated.service"), "unowned\n"),
+    ],
+    [false, () => undefined],
+  ]).get(withUnrelatedServiceUnit)!();
   fs.writeFileSync(path.join(runnerTemp, "native-podman-e2e-service.env"), "owned\n");
   fs.writeFileSync(path.join(runnerTemp, "native-podman-e2e-storage.conf"), "owned\n");
   fs.writeFileSync(path.join(runnerTemp, "native-podman-e2e-containers.conf"), "owned\n");
@@ -539,6 +550,25 @@ describe("native Podman E2E setup boundary", () => {
       expect(fs.readFileSync(fixture.systemctlLog, "utf8")).toContain(
         "--user stop nemoclaw-native-podman-e2e.socket nemoclaw-native-podman-e2e.service",
       );
+    } finally {
+      fs.rmSync(fixture.root, { force: true, recursive: true });
+    }
+  });
+
+  it("preserves unrelated user units while completing native Podman cleanup", () => {
+    const fixture = runPodmanCleanupFixture(true, false, true);
+    const unrelatedServiceUnit = path.join(fixture.serviceUnitDirectory, "unrelated.service");
+
+    try {
+      expect(fixture.result.status, fixture.result.stderr).toBe(0);
+      expect(fs.readFileSync(unrelatedServiceUnit, "utf8")).toBe("unowned\n");
+      expect(
+        fs.existsSync(
+          path.join(fixture.serviceUnitDirectory, "nemoclaw-native-podman-e2e.service"),
+        ),
+      ).toBe(false);
+      expect(fs.existsSync(fixture.toolchainRoot)).toBe(false);
+      expect(fs.existsSync(fixture.destination)).toBe(true);
     } finally {
       fs.rmSync(fixture.root, { force: true, recursive: true });
     }

--- a/tools/e2e/workflow-boundary-policy.mts
+++ b/tools/e2e/workflow-boundary-policy.mts
@@ -9,13 +9,13 @@ export const E2E_ACTION_PROVENANCE = {
   },
   nativePodmanRuntime: {
     reference:
-      "NVIDIA/NemoClaw/.github/actions/setup-native-podman-e2e@3b03ce52141aad935bc28bd0100b997573e46539",
+      "NVIDIA/NemoClaw/.github/actions/setup-native-podman-e2e@b39c9ee2bba1bffaabcfe97ae4a7787a5c603ee8",
     contentSha256: "85f2fd3760a2ccff1946c8aa1390156cd106b51bbd8596ce59d626def7b78de9",
   },
   restoreNativePodmanRuntime: {
     reference:
-      "NVIDIA/NemoClaw/.github/actions/restore-native-podman-e2e@3b03ce52141aad935bc28bd0100b997573e46539",
-    contentSha256: "f47681fb2c2816c0ce7b7401e51dd75890c7a69857c791f15b0a05c3a17e5714",
+      "NVIDIA/NemoClaw/.github/actions/restore-native-podman-e2e@b39c9ee2bba1bffaabcfe97ae4a7787a5c603ee8",
+    contentSha256: "17a7b3c8675897fcc2f4da62b83a47ecd43ad46c37f7c42948aa99775d917f76",
   },
   stageNativePodmanToolchains: {
     reference:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

Native Podman E2E cleanup no longer turns a successful run red when another user systemd unit shares `$HOME/.config/systemd/user`. Cleanup still removes only NemoClaw-owned resources and fails closed when it cannot prove their state.

## Reason

The cloud-onboard Podman job completed its live test, then failed during cleanup because `rmdir` found an unrelated entry in the shared user-unit directory. That harmless non-empty directory blocked Docker recovery and made the E2E run fail.

## Changes

- Keep a newly created user-unit directory when it has gained unrelated entries, while proving it remains a non-symlink directory and is non-empty.
- Add a regression fixture that preserves `unrelated.service`, removes the NemoClaw unit, retires cleanup authority, and restores Docker.
- Pin the native Podman setup/restore action cohort to signed commit `b39c9ee2bba1bffaabcfe97ae4a7787a5c603ee8` and update the reviewed restore-action content hash.

## Verification

- `npx vitest run --project e2e-support test/e2e/support/native-podman-setup-action.test.ts test/e2e/support/e2e-host-dependency-workflow-boundary.test.ts` — 30 tests passed.
- `npm run test:projects:check` — exact membership confirmed for 2,661 candidate files across seven projects.
- Normal pre-commit hooks passed on both commits, including formatting, linting, YAML validation, repository checks, secret scanning, E2E semantic phase checks, and growth guardrails.
- Normal pre-push CLI TypeScript check passed after building the required CLI and plugin artifacts.
- GitHub reports both commits as Verified; both commit messages and this description include the contributor DCO declaration.
- Required documentation-writer review found no user-facing behavior or documentation change; no docs build was needed.
- An optional full local E2E-support sweep was not used as a gate because untouched fixtures hit existing host-load/order timeouts even with bounded workers. The directly affected boundary files passed in isolation, and PR CI remains authoritative for the aggregate lane.
- The diff contains no secrets, API keys, or credentials.

## Review notes

This changes a privileged cleanup path. It does not recursively remove the shared user-unit directory: after an `rmdir` failure, it accepts the retained directory only when it is still a non-symlink directory with at least one entry. The originating failure is visible in [E2E run 34514548479](https://github.com/NVIDIA/NemoClaw/actions/runs/34514548479). A local live rerun was unavailable because the configured Docker daemon is not reachable.

---
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved native Podman cleanup so non-empty, non-symlinked service directories no longer cause cleanup to fail.
  - Cleanup now preserves unrelated user service units while removing only the resources it manages.
  - Docker state is restored reliably during GPU-focused end-to-end testing.

- **Chores**
  - Updated pinned revisions for native Podman setup, cleanup, and Docker restoration workflows to improve CI consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->