### PR TITLE
fix(ci): stop advisor retries on exhausted budget

### DIFF
--- a/test/automation/pull-requests/advisor-session-runner.test.ts
+++ b/test/automation/pull-requests/advisor-session-runner.test.ts
@@ -59,7 +59,8 @@ const sdk = vi.hoisted(() => {
     omitAnalysis: false,
     omitAnalysisPrompts: 0,
     prompts: [] as string[],
-    retryResponses: [] as Array<"exhausted" | "success">,
+    retryCancelled: false,
+    retryResponses: [] as Array<"budget-exceeded" | "exhausted" | "success">,
     terminalResponses: [] as TerminalResponse[],
   };
 
@@ -76,6 +77,7 @@ const sdk = vi.hoisted(() => {
     state.omitAnalysis = false;
     state.omitAnalysisPrompts = 0;
     state.prompts = [];
+    state.retryCancelled = false;
     state.retryResponses = [];
     state.terminalResponses = [];
   };
@@ -179,7 +181,10 @@ const sdk = vi.hoisted(() => {
         Array.from({ length: terminalTool ? terminalPlan.failureCount : 0 }).forEach(() =>
           failTerminalTool(terminalTool as MockTool, emit),
         );
-        const retryError = "429 status code (no body)";
+        const retryError =
+          retryResponse === "budget-exceeded"
+            ? '429: {"message":"Budget has been exceeded!","code":"budget_exceeded"}'
+            : "429 status code (no body)";
         const retryAttemptEvents = [
           {
             type: "message_update",
@@ -209,12 +214,24 @@ const sdk = vi.hoisted(() => {
             { type: "auto_retry_end", success: false, attempt: 1, finalError: retryError },
           ],
         };
-        retryPlans[retryResponse ?? "none"].forEach(emit);
+        await (retryResponse === "budget-exceeded"
+          ? (async () => {
+              retryAttemptEvents.forEach(emit);
+              await Promise.resolve();
+              emit({
+                type: "auto_retry_end",
+                success: false,
+                attempt: 1,
+                finalError: state.retryCancelled ? "Retry cancelled" : retryError,
+              });
+            })()
+          : Promise.resolve(retryPlans[retryResponse ?? "none"].forEach(emit)));
         const omitThisAnalysis = state.omitAnalysis || state.omitAnalysisPrompts > 0;
         state.omitAnalysisPrompts = Math.max(0, state.omitAnalysisPrompts - 1);
         const shouldEmitText =
           !omitThisAnalysis &&
           retryResponse !== "exhausted" &&
+          retryResponse !== "budget-exceeded" &&
           !prompt.startsWith("Prepare ") &&
           (!prompt.includes("Emit no prose before or after") ||
             (state.emitCommitProse && !isRepairPrompt) ||
@@ -239,6 +256,9 @@ const sdk = vi.hoisted(() => {
           });
         emit({ type: "agent_end" });
       },
+      abortRetry: vi.fn(() => {
+        state.retryCancelled = true;
+      }),
       abort: vi.fn(async () => {}),
       exportToHtml: vi.fn(async (outputPath: string) => outputPath),
       dispose: vi.fn(),
@@ -271,6 +291,7 @@ import {
   ADVISOR_OPENSHELL_INFERENCE_BASE_URL,
   type AdvisorPromptTurn,
   advisorRetrySettings,
+  isAdvisorBudgetExceededError,
   READ_ONLY_TOOLS,
   runReadOnlyAdvisor,
 } from "../../../tools/advisors/session.mts";
@@ -372,6 +393,13 @@ afterEach(() => {
 });
 
 describe("advisor session runner", () => {
+  it("distinguishes terminal budget exhaustion from transient rate limiting", () => {
+    expect(isAdvisorBudgetExceededError('{"code":"budget_exceeded"}')).toBe(true);
+    expect(isAdvisorBudgetExceededError("Budget has been exceeded! Try later")).toBe(true);
+    expect(isAdvisorBudgetExceededError("429 status code (no body)")).toBe(false);
+    expect(isAdvisorBudgetExceededError("provider overloaded")).toBe(false);
+  });
+
   it("uses one bounded, specialist-spread retry layer for transient failures", () => {
     const behavior = advisorRetrySettings("azure/openai/gpt-5.6-terra", "pr-review-behavior");
     const dependencyUse = advisorRetrySettings(
@@ -429,6 +457,17 @@ describe("advisor session runner", () => {
 
     expect(result.fatalError).toBe("429 status code (no body)");
     expect(result.turnErrors).toEqual(["only-analysis: 429 status code (no body)"]);
+    expect(result.raw).toContain("retry_end success=false attempts=1");
+  });
+
+  it("cancels terminal provider budget retries without hiding the cause", async () => {
+    sdk.state.retryResponses = ["budget-exceeded"];
+    const result = await run([analysisTurn("only-analysis")]);
+
+    expect(result.fatalError).toContain("Budget has been exceeded");
+    expect(result.turnErrors).toHaveLength(1);
+    expect(result.turnErrors[0]).toContain("budget_exceeded");
+    expect(result.raw).toContain("retry_cancel terminal=budget_exceeded");
     expect(result.raw).toContain("retry_end success=false attempts=1");
   });
 

--- a/tools/advisors/session.mts
+++ b/tools/advisors/session.mts
@@ -485,6 +485,15 @@ export async function runReadOnlyAdvisor(
       return;
     }
     if (event.type === "auto_retry_start") {
+      if (isAdvisorBudgetExceededError(event.errorMessage)) {
+        currentTurnError = normalizeProviderError(event.errorMessage);
+        raw.append(
+          `[${options.logPrefix}] retry_cancel terminal=budget_exceeded: ${event.errorMessage}\n`,
+        );
+        options.logProgress("Advisor provider budget exhausted; cancelling retries");
+        queueMicrotask(() => session.abortRetry());
+        return;
+      }
       currentTurnError = undefined;
       raw.append(
         `[${options.logPrefix}] retry ${event.attempt}/${event.maxAttempts} delay_ms=${event.delayMs}: ${event.errorMessage}\n`,
@@ -498,8 +507,10 @@ export async function runReadOnlyAdvisor(
       if (event.success) {
         currentTurnError = undefined;
       } else if (event.finalError) {
-        currentTurnError = undefined;
-        captureTurnError("assistant_retry_exhausted", event.finalError);
+        if (!isAdvisorBudgetExceededError(currentTurnError)) {
+          currentTurnError = undefined;
+          captureTurnError("assistant_retry_exhausted", event.finalError);
+        }
       }
       raw.append(
         `[${options.logPrefix}] retry_end success=${event.success} attempts=${event.attempt}\n`,
@@ -764,6 +775,14 @@ function normalizeProviderError(message: string | undefined): string | undefined
   if (!message) return undefined;
   const normalized = message.trim().replace(/\s+/g, " ");
   return normalized || undefined;
+}
+
+export function isAdvisorBudgetExceededError(message: string | undefined): boolean {
+  const normalized = normalizeProviderError(message)?.toLowerCase();
+  return Boolean(
+    normalized &&
+    (normalized.includes("budget_exceeded") || normalized.includes("budget has been exceeded")),
+  );
 }
 
 function errorText(error: unknown): string {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

PR Review Advisor now stops retrying immediately when its provider explicitly reports that the shared budget is exhausted. Temporary provider failures, including ordinary 429 responses, keep the existing bounded retry behavior.

## Reason

A hard budget cap cannot recover during the same job, but each specialist currently spends roughly 8–10 minutes exhausting retries. Failing fast reduces queue pressure, runner waste, and noisy no-artifact failures.

### Related issues

Relates to #10791

## Changes

- Classify explicit `budget_exceeded` provider responses as terminal while preserving the original provider error.
- Abort the Pi SDK retry after its retry controller is installed; retain normal retries for transient 429s.
- Add focused regression coverage for terminal budget exhaustion, error preservation, and unchanged transient retry behavior.

## Verification

- `npx vitest run test/automation/pull-requests/advisor-session-runner.test.ts` — 35/35 tests passed.
- `npm --prefix nemoclaw run build` — passed.
- `npm run check:diff` — passed, including format, lint, repository checks, secret scan, growth guards, commit lint, and CLI typecheck.
- Normal pre-push hooks — passed.
- GitHub commit verification — `e06414cd666d067fa16864db4eb501ace5eb220b` is Verified (`reason=valid`).
- Diff inspection — no secrets, API keys, or credentials added.

## Review notes

This independent two-file fix was split from #11047 so it can reach trusted `main` before the guarded autofix lifecycle runs its final Advisor review. No public CLI, artifact, configuration, or workflow contract changes; existing Advisor documentation already covers fail-closed provider errors and workflow-log diagnostics.

---
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Advisor sessions now stop retrying when the provider reports that the usage budget has been exceeded.
  - Budget-exceeded errors are clearly identified and preserved in the final error reporting.
  - Cancellation and progress updates now accurately reflect terminal budget failures.
  - Transient rate-limit errors continue to be handled separately from terminal budget exhaustion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->