### PR TITLE
chore(onboard): apply pinned Oxfmt formatting

### DIFF
--- a/src/lib/onboard/managed-bootstrap/docker-runtime.test.ts
+++ b/src/lib/onboard/managed-bootstrap/docker-runtime.test.ts
@@ -357,7 +357,9 @@ describe("Docker managed-bootstrap GPU probe diagnostics", () => {
       thrown = error instanceof Error ? error.message : String(error);
     }
 
-    expect(thrown).toContain("Docker did not accept a compatibility GPU mode for managed bootstrap.");
+    expect(thrown).toContain(
+      "Docker did not accept a compatibility GPU mode for managed bootstrap.",
+    );
     expect(thrown).toContain("Error response from daemon: unauthorized");
     expect(thrown).toContain("@sha256:41eb2663a761...");
     expect(thrown).not.toContain(digest);

--- a/src/lib/onboard/managed-bootstrap/docker-runtime.ts
+++ b/src/lib/onboard/managed-bootstrap/docker-runtime.ts
@@ -204,10 +204,7 @@ function clampDiagnostic(text: string, limit: number, tailLength: number): strin
   if (text.length <= limit) return text;
   const omissionMarker = (count: number): string => ` ... [${count} characters omitted] ... `;
   // Reserve the marker at its widest: the omitted count never exceeds the text length.
-  const head = text.slice(
-    0,
-    Math.max(0, limit - tailLength - omissionMarker(text.length).length),
-  );
+  const head = text.slice(0, Math.max(0, limit - tailLength - omissionMarker(text.length).length));
   const tail = text.slice(-tailLength);
   return `${head}${omissionMarker(text.length - head.length - tail.length)}${tail}`;
 }


### PR DESCRIPTION
## Outcome

Apply the repository-pinned Oxfmt formatting to Docker managed-bootstrap code and its test so CI does not need to rewrite those files.

## Reason

The formatter hook group modified tracked files in [main static-checks job 103080855383](https://github.com/NVIDIA/NemoClaw/actions/runs/34540044091/job/103080855383), causing the job to fail.

## Changes

- Collapse the diagnostic prefix calculation onto one line.
- Wrap the Docker compatibility error assertion across lines.

## Verification

- Applied Oxfmt 0.63.0 using the repository configuration; it changed only these two files.
- Inspected the complete diff: only line wrapping and optional trailing commas changed. No behavior or test expectations changed.
- Local tests, hooks, and `npm run validate:pr` were skipped at the maintainer's explicit request in the task. CI remains required.
- No new test applies to this formatting-only change.
- The diff contains no secrets, API keys, or credentials.
- GitHub marks commit `8497658d4c0273f017dc9241c729ba3157b1d206` Verified.

## Review notes

Self-reviewed NVIDIA/NemoClaw commit `8497658d4c0273f017dc9241c729ba3157b1d206`, including sensitive paths `src/lib/onboard/managed-bootstrap/docker-runtime.ts` and `src/lib/onboard/managed-bootstrap/docker-runtime.test.ts`. The complete diff changes formatting only. No independent pre-publication review exists; both paths await independent review. This PR is a draft.

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted diagnostic output handling and GPU probe test assertions without changing functionality or user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->