### PR TITLE
fix(advisor): isolate owned gateway provider state

### DIFF
--- a/test/automation/pull-requests/pr-merge-conflict-fixer.test.ts
+++ b/test/automation/pull-requests/pr-merge-conflict-fixer.test.ts
@@ -587,11 +587,15 @@ describe("PR merge conflict fixer", () => {
 
   it("configures approved inference through a loopback gateway (#7542)", async () => {
     const env = resolverEnvironment();
+    env.OPENSHELL_DB_URL = "sqlite:///existing-provider-state.db";
     const tools = resolverTools(["/trusted/bin/openshell-sandbox"]);
     const stopGateway = vi.fn(async () => undefined);
     vi.mocked(tools.start).mockReturnValue(stopGateway);
 
     await configureOpenShellInference(env, tools);
+    expect(vi.mocked(tools.start).mock.calls[0]?.[2].env.OPENSHELL_DB_URL).toBe(
+      env.OPENSHELL_DB_URL,
+    );
 
     const gatewayDirectory = path.join(
       required(env.RUNNER_TEMP, "RUNNER_TEMP"),

--- a/test/automation/pull-requests/pr-review-advisor-openshell.test.ts
+++ b/test/automation/pull-requests/pr-review-advisor-openshell.test.ts
@@ -986,6 +986,7 @@ describe("PR review advisor OpenShell wrapper", () => {
 
   it("registers the selected model while confining the upstream key to provider creation", async () => {
     const env = advisorEnvironment();
+    env.OPENSHELL_DB_URL = "sqlite:///existing-provider-state.db";
     const tools = advisorTools();
 
     const gateway = startAdvisorOpenShellInference(env, tools);
@@ -1023,6 +1024,10 @@ describe("PR review advisor OpenShell wrapper", () => {
     });
     expect(calls.filter(([, , options]) => options.env.OPENAI_API_KEY)).toHaveLength(1);
     expect(vi.mocked(tools.start).mock.calls[0]?.[2].env.OPENAI_API_KEY).toBeUndefined();
+    expect(vi.mocked(tools.start).mock.calls[0]?.[2].env.OPENSHELL_DB_URL).toBe(
+      "sqlite::memory:?cache=shared",
+    );
+    expect(env.OPENSHELL_DB_URL).toBe("sqlite:///existing-provider-state.db");
     const gatewayConfig = fs.readFileSync(
       path.join(env.RUNNER_TEMP as string, "openshell-gateway", "gateway.toml"),
       "utf8",

--- a/tools/openshell-agent/runtime.mts
+++ b/tools/openshell-agent/runtime.mts
@@ -307,7 +307,9 @@ function startOpenShellInference(
   );
   const stopGateway =
     tools.start("openshell-gateway", ["--config", configurationPath], {
-      env: commandEnv,
+      env: input.ownGateway
+        ? { ...commandEnv, OPENSHELL_DB_URL: "sqlite::memory:?cache=shared" }
+        : commandEnv,
       logPath: path.join(gatewayDirectory, "gateway.log"),
     }) ?? (async () => undefined);
 

--- a/tools/pr-review-advisor/README.md
+++ b/tools/pr-review-advisor/README.md
@@ -179,6 +179,10 @@ The command attempts to remove its temporary snapshot, trusted dependencies, gat
 sandbox after success, failure, or a handled termination signal. It reports cleanup failures with the
 remaining resource name or path. Remove that named resource before retrying.
 
+Each locally owned gateway uses an in-memory database. Its provider records are discarded when the
+gateway process stops. The local runner ignores inherited
+database URLs for its gateway; it does not read or replace an existing gateway database.
+
 ## Output contract
 
 Each specialist returns a Markdown review grounded in repository evidence and shared trusted


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

Each locally owned Advisor gateway now uses a process-local in-memory database. Repeated reviews can register the `advisor` provider without colliding with a previous review or a host database.

## Reason

Local review of #11495 still failed after #11500 merged. On trusted `main` commit `05796cf4e47b717aa80b2d9c603946e0ec5aad0b`, the gateway became healthy, then `openshell provider create` failed with `provider already exists`. The gateway had inherited the default persistent database while the runner assumed a fresh provider namespace.

### Related issues

Relates to #11495. Follows #11500.

## Changes

- Set `OPENSHELL_DB_URL=sqlite::memory:?cache=shared` only for an owned gateway process. The existing SQLite backend provides isolation without adding a database-directory lifecycle or deleting host state.
- Keep non-owned gateway configuration unchanged. The merge-conflict-fixer regression test protects this sibling path.
- Extend the Advisor credential-boundary test to reject an inherited database URL and preserve the caller environment.
- Document local gateway database lifetime.

## Verification

- `TMPDIR=/private/tmp npx vitest run --project integration test/automation/pull-requests/pr-review-advisor-openshell.test.ts test/automation/pull-requests/pr-merge-conflict-fixer.test.ts --maxWorkers 1` — 61 passed.
- Two consecutive real owned-gateway lifecycles using OpenShell 0.0.106, Docker Desktop 28.3.2, a temporary HOME, and an inert provider credential — both registered `advisor`, configured an unverified inert model, and stopped successfully. No model requests or sandboxes were created. The temporary diagnostic files were removed and neither gateway listener remained.
- Normal pre-commit and commit-message hooks — passed.
- `NODE_OPTIONS=--max-old-space-size=5120 npm run validate:pr` — passed against canonical `main` `05796cf4e47b717aa80b2d9c603946e0ec5aad0b`; validation and hook execution code were unchanged from that base.
- Diff inspection — no secrets, API keys, credentials, or unrelated changes are included.

## Review notes

Repository: NVIDIA/NemoClaw. Reviewed commit: `8a0d8d7d0a0ef20e3ef3a4843c05909ca9f5bc71`. Self-review covered the runtime credential boundary, process ownership, inherited configuration, gateway failure cleanup, and the owning Advisor README. Provider data is disposable only for locally owned gateways; existing databases and non-owned behavior remain unchanged.

Full local Advisor clearance is not claimed: its trusted implementation comes from `main`, where the reproduced provider collision remains. This draft is for independent review and CI, not approval or merge. The initial review evidence consists of the focused tests, real process diagnostic, and direct diff review.

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Locally owned inference gateways now use an isolated in-memory database.
  - Database records created during a local gateway session are discarded when the gateway stops.
  - Existing database configuration is ignored for locally owned gateways, preventing unintended use of another gateway’s database.
  - Externally managed gateways continue using their existing environment configuration.

- **Documentation**
  - Local-run guidance now explains gateway database isolation, lifecycle, and configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->