### PR TITLE
fix(test): restore live export test imports

### DIFF
--- a/src/lib/adapters/config/live-export-source.test.ts
+++ b/src/lib/adapters/config/live-export-source.test.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { createHash } from "node:crypto";
 import os from "node:os";
 import { describe, expect, it, vi } from "vitest";
 import YAML from "yaml";
@@ -56,6 +57,7 @@ import type { ObservedManagedVllmRuntime } from "../../domain/config/export-evid
 import { getLiveGatewayInference } from "../../inference/live";
 import { resolveGatewayStateDirForPort } from "../../onboard/gateway/state-dir";
 import { buildManagedStartupProfile } from "../../onboard/managed-startup/profile-builder";
+import { encodeManagedStartupProfile } from "../../onboard/managed-startup/profile";
 import type { ManagedStartupProfileBuilderInput } from "../../onboard/managed-startup/profile-builder";
 import { getSandboxEntryInference } from "../../state/registry-entry-view";
 import { load as loadRegistry } from "../../state/registry/persistence";
@@ -69,6 +71,7 @@ import {
   readFailureCanary,
   imageRef,
   startupInput,
+  startup,
   entry,
   inventory,
   provider,


### PR DESCRIPTION
## Outcome
Restore the missing imports in the live export regression test so its identifiers resolve during type-aware linting and execution.

## Reason
Main's `oxlint-type-aware` hook reports four undefined-name errors in the direct tool selection test.

## Changes
Import `createHash`, `encodeManagedStartupProfile`, and the existing `startup` fixture used by that test.

## Verification
- Inspected the imports, fixture export, and test references: all three missing names have existing definitions.
- Local tests, hooks, and `npm run validate:pr` skipped with the requester's explicit authorization. CI validation remains pending.
- Reviewed the complete three-line diff: no secrets, API keys, credentials, or unrelated changes.

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test setup to include startup profile data and hashing utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->