### PR TITLE
fix(e2e): retry serialized portable lock loser

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -147,6 +147,10 @@ assembles one exact candidate catalog from the workflow's published contracts, u
 and sandbox, records the authenticated discovery diagnostics, scans the evidence for fixture
 credentials, and must pass.
 These are two required acceptance executions, not retries; either failure remains a failed check.
+The concurrent-add probe retries only the rejected command after status proves that the other
+command committed one coherent bridge. The rejected command must report either the exact portable
+host-lock timeout or the reviewed Hermes restart transport failure. The retry runs once, has its own
+command artifact, and must reject the committed duplicate as already present.
 The workflow records one publication cohort before its PR producer matrix runs. Failed-job reruns
 reuse that cohort and replace only the stable run-scoped artifact owned by each retried agent.
 Consumers accept one complete cohort from the same run at the current or an earlier attempt. They

--- a/test/e2e/live/mcp-bridge-reliability.ts
+++ b/test/e2e/live/mcp-bridge-reliability.ts
@@ -272,6 +272,8 @@ const HERMES_RESTART_SUCCESS_PREFIX = new RegExp(
   ].join("\n")}$`,
   "u",
 );
+const PORTABLE_HOST_LOCK_CONTENTION =
+  /^Error: Failed to acquire lock on \/[^\n]*\/\.nemoclaw-portable-host\.lock after 120 retries$/u;
 
 function normalizeHermesTransportDiagnostic(diagnostic: string): string {
   return diagnostic
@@ -665,7 +667,7 @@ export function isHermesRestartTransportFailure(adapter: string, diagnostic: str
   return HERMES_RESTART_SUCCESS_PREFIX.test(normalized.slice(0, -suffix.length));
 }
 
-export async function retryAfterHermesRestartTransportFailure<T>(options: {
+export async function retryAfterConcurrentAddTransientFailure<T>(options: {
   adapter: string;
   committedBridgeVerified: boolean;
   diagnostic: string;
@@ -673,11 +675,15 @@ export async function retryAfterHermesRestartTransportFailure<T>(options: {
   retry: () => Promise<T>;
 }): Promise<T> {
   if (!options.committedBridgeVerified) {
-    throw new Error("Hermes restart retry requires a verified committed bridge");
+    throw new Error("Concurrent add retry requires a verified committed bridge");
   }
   if (/already exists/iu.test(options.diagnostic)) return options.originalResult;
-  if (!isHermesRestartTransportFailure(options.adapter, options.diagnostic)) {
-    throw new Error("rejected concurrent add was not a known Hermes restart transport failure");
+  const diagnostic = normalizeHermesTransportDiagnostic(options.diagnostic);
+  if (
+    !PORTABLE_HOST_LOCK_CONTENTION.test(diagnostic) &&
+    !isHermesRestartTransportFailure(options.adapter, options.diagnostic)
+  ) {
+    throw new Error("rejected concurrent add was not a known transient failure");
   }
   return options.retry();
 }

--- a/test/e2e/live/mcp-bridge.test.ts
+++ b/test/e2e/live/mcp-bridge.test.ts
@@ -68,7 +68,7 @@ import {
   runOpenClawDeniedToolUpdateProof,
   restartBridgeWithoutHostSecret,
   retryOpenClawBaselineScopeOnboardFailure,
-  retryAfterHermesRestartTransportFailure,
+  retryAfterConcurrentAddTransientFailure,
   retryHermesGatewayDraining,
 } from "./mcp-bridge-reliability.ts";
 import {
@@ -340,7 +340,7 @@ async function assertConcurrentAddSerialized(
     policy: { registryPresent: true, gatewayPresent: true },
   });
   expect(statusObservation.registered).toBe(true);
-  const duplicateRejection = await retryAfterHermesRestartTransportFailure({
+  const duplicateRejection = await retryAfterConcurrentAddTransientFailure({
     adapter: options.expectedAdapter,
     committedBridgeVerified: true,
     diagnostic: resultText(rejected[0]!),

--- a/test/e2e/support/mcp-bridge-reliability.test.ts
+++ b/test/e2e/support/mcp-bridge-reliability.test.ts
@@ -22,7 +22,7 @@ import {
   MCP_BRIDGE_TEST_REDACTION_VALUES,
   readConcurrentMcpStatusAndConfirmHermesRegistration,
   restartBridgeWithoutHostSecret,
-  retryAfterHermesRestartTransportFailure,
+  retryAfterConcurrentAddTransientFailure,
   retryHermesGatewayDraining,
   retryOpenClawBaselineScopeOnboardFailure,
 } from "../live/mcp-bridge-reliability.ts";
@@ -640,7 +640,7 @@ describe("MCP bridge transient classification", () => {
     const retry = vi.fn(async () => ({ exitCode: 2 }));
 
     await expect(
-      retryAfterHermesRestartTransportFailure({
+      retryAfterConcurrentAddTransientFailure({
         adapter: "hermes-config",
         committedBridgeVerified: true,
         diagnostic: "server already exists",
@@ -656,10 +656,27 @@ describe("MCP bridge transient classification", () => {
     const retry = vi.fn(async () => retryResult);
 
     await expect(
-      retryAfterHermesRestartTransportFailure({
+      retryAfterConcurrentAddTransientFailure({
         adapter: "hermes-config",
         committedBridgeVerified: true,
         diagnostic: HERMES_BROKEN_PIPE,
+        originalResult: { exitCode: 1 },
+        retry,
+      }),
+    ).resolves.toBe(retryResult);
+    expect(retry).toHaveBeenCalledOnce();
+  });
+
+  it("retries the portable host lock loser after the committed bridge is verified", async () => {
+    const retryResult = { exitCode: 1 };
+    const retry = vi.fn(async () => retryResult);
+
+    await expect(
+      retryAfterConcurrentAddTransientFailure({
+        adapter: "mcporter",
+        committedBridgeVerified: true,
+        diagnostic:
+          "Error: Failed to acquire lock on /home/runner/.nemoclaw-portable-host.lock after 120 retries",
         originalResult: { exitCode: 1 },
         retry,
       }),
@@ -671,14 +688,23 @@ describe("MCP bridge transient classification", () => {
     const retry = vi.fn(async () => ({ exitCode: 1 }));
 
     await expect(
-      retryAfterHermesRestartTransportFailure({
+      retryAfterConcurrentAddTransientFailure({
         adapter: "hermes-config",
         committedBridgeVerified: true,
         diagnostic: "unexpected transport error",
         originalResult: { exitCode: 1 },
         retry,
       }),
-    ).rejects.toThrow("not a known Hermes restart transport failure");
+    ).rejects.toThrow("not a known transient failure");
+    await expect(
+      retryAfterConcurrentAddTransientFailure({
+        adapter: "mcporter",
+        committedBridgeVerified: true,
+        diagnostic: "Error: Failed to acquire lock on /tmp/other.lock after 120 retries",
+        originalResult: { exitCode: 1 },
+        retry,
+      }),
+    ).rejects.toThrow("not a known transient failure");
     expect(retry).not.toHaveBeenCalled();
   });
 
@@ -686,7 +712,7 @@ describe("MCP bridge transient classification", () => {
     const retry = vi.fn(async () => ({ exitCode: 1 }));
 
     await expect(
-      retryAfterHermesRestartTransportFailure({
+      retryAfterConcurrentAddTransientFailure({
         adapter: "hermes-config",
         committedBridgeVerified: false,
         diagnostic: HERMES_BROKEN_PIPE,


### PR DESCRIPTION
## Outcome

Concurrent OpenClaw MCP discovery now accepts the serialized portable-host lock loser only after the competing command has committed one coherent bridge, then retries that rejected command once and requires the duplicate to be rejected as already present. This removes the deterministic Images workflow failure introduced with portable-host fencing while preserving fail-closed behavior for unknown errors.

## Reason

Both OpenClaw MCP discovery jobs in Images runs 34544156685 and 34545930022 failed after one concurrent `mcp add` succeeded and the other exhausted the `.nemoclaw-portable-host.lock` retry budget. The test helper recognized only the existing Hermes restart transport signature, so it misclassified this expected serialized loser even though status proved the winner committed successfully.

## Changes

- Recognize only the exact portable-host lock timeout, alongside the already-reviewed Hermes restart transport signature.
- Require post-race status verification of the committed bridge before permitting one retry of the rejected command.
- Keep already-present duplicates unchanged and reject every unknown lock or transport diagnostic.
- Add focused regression tests and document the concurrent-add retry contract.

## Verification

- `npx vitest run --project e2e-support test/e2e/support/mcp-bridge-reliability.test.ts` — passed, 48/48 tests.
- `npm run e2e:assertions:check` — passed, 1,796 direct assertions across 86 files.
- `npm run test:e2e-phases:check` — passed, 135 tests across 88 files.
- `NODE_OPTIONS=--max-old-space-size=8192 npm run typecheck:cli` — passed.
- `npm run checks:repository` — passed.
- `NODE_OPTIONS=--max-old-space-size=8192 npm run validate:pr` — passed, including the repository-wide CLI typecheck. An initial run exhausted Node's default 4 GB local heap during that typecheck; no code or test assertion failed.
- `git diff --check origin/main...HEAD` and the pre-commit secret scan — passed; the diff contains no secrets, API keys, or credentials.

## Review notes

This is intentionally limited to E2E reconciliation and classification. It does not change production locking behavior. Real-run evidence is the identical two-job failure in merged-main Images run 34544156685 and OpenShell PR Images run 34545930022.

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>
<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when concurrent operations encounter temporary lock contention or service restarts.
  * Preserved validation that successful operations create only one coherent result and reject duplicates.

* **Tests**
  * Expanded coverage for retry behavior, bridge verification, unknown failures, and unverified results.
  * Added isolated probing for concurrent-operation scenarios.

* **Documentation**
  * Documented the concurrent-operation reliability probe and its accepted transient failure conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->