### PR TITLE
test(runtime): hold host fence in provider stop fixtures

### DIFF
--- a/src/lib/onboard/runtime-provider/podman.test.ts
+++ b/src/lib/onboard/runtime-provider/podman.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 import { createPodmanHostLocalInferenceTestHarness } from "../../../../test/helpers/podman-host-local-inference-test-harness";
 import { startSandbox } from "../../actions/sandbox/start";
 import { stopSandbox } from "../../actions/sandbox/stop";
+import { withCurrentPortableHostFence } from "../../state/portable-uninstall-retirement";
 import type { ContainerEngineCommandResult } from "../../adapters/container-engine";
 import {
   createPodmanContainerEngine,
@@ -284,16 +285,18 @@ describe("managed Podman runtime provider", () => {
           log: vi.fn(),
         }),
       ).resolves.toEqual({ exitCode: 0 });
-      expect(
-        stopSandbox(runtime.sandboxName, {
-          getSandbox: () => runtime.entry,
-          updateSandbox,
-          runtimeProviders: runtime.providers,
-          stopSandboxChannels,
-          teardownSandboxDashboardForward: vi.fn(),
-          log: vi.fn(),
-        }),
-      ).toEqual({ exitCode: 0 });
+      await expect(
+        withCurrentPortableHostFence(() =>
+          stopSandbox(runtime.sandboxName, {
+            getSandbox: () => runtime.entry,
+            updateSandbox,
+            runtimeProviders: runtime.providers,
+            stopSandboxChannels,
+            teardownSandboxDashboardForward: vi.fn(),
+            log: vi.fn(),
+          }),
+        ),
+      ).resolves.toEqual({ exitCode: 0 });
 
       expect(restoreStartupState).toHaveBeenCalledExactlyOnceWith(runtime.sandboxName);
       expect(verifyGateway).toHaveBeenCalledExactlyOnceWith(runtime.sandboxName);

--- a/src/lib/onboard/runtime-provider/runtime-provider-contract.test.ts
+++ b/src/lib/onboard/runtime-provider/runtime-provider-contract.test.ts
@@ -21,6 +21,7 @@ import { executeSandboxDestroy } from "../../actions/sandbox/destroy-execution";
 import { SANDBOX_DESTROY_TIMEOUT_MS } from "../../actions/sandbox/destroy-gateway";
 import { startSandbox } from "../../actions/sandbox/start";
 import { stopSandbox } from "../../actions/sandbox/stop";
+import { withCurrentPortableHostFence } from "../../state/portable-uninstall-retirement";
 import { loadAgent } from "../../agent/defs";
 import type { SandboxEntry, SandboxWorkloadReceipt } from "../../state/registry/types";
 import { cloneSandboxWorkloadReceipt } from "../../state/registry/workload";
@@ -1127,17 +1128,19 @@ describe("socket-free MXC action contract", () => {
           log: vi.fn(),
         }),
       ).resolves.toEqual({ exitCode: 0 });
-      expect(
-        stopSandbox(sandboxName, {
-          getSandbox,
-          updateSandbox,
-          runtimeProviders: providers,
-          stopSandboxChannels,
-          teardownSandboxDashboardForward,
-          log: vi.fn(),
-          warn: vi.fn(),
-        }),
-      ).toEqual({ exitCode: 0 });
+      await expect(
+        withCurrentPortableHostFence(() =>
+          stopSandbox(sandboxName, {
+            getSandbox,
+            updateSandbox,
+            runtimeProviders: providers,
+            stopSandboxChannels,
+            teardownSandboxDashboardForward,
+            log: vi.fn(),
+            warn: vi.fn(),
+          }),
+        ),
+      ).resolves.toEqual({ exitCode: 0 });
       expect(() => requireInferenceSetRuntimeAuthority(entry, providers)).not.toThrow();
       await expect(
         executeSandboxDestroy({


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

Provider lifecycle tests hold the current HOME host fence before calling synchronous sandbox stop. The Podman and socket-free provider fixtures pass for OpenClaw, Hermes, and Deep Agents Code.

## Reason

The lifecycle lock change in #11490 requires synchronous callers to hold the host fence. These two fixtures still called stop directly, causing six failures. The [main CLI shard failure](https://github.com/NVIDIA/NemoClaw/actions/runs/34549640442/job/103109915024) reports the Podman cases.

## Changes

Wrap both fixtures' stop calls in the existing `withCurrentPortableHostFence` and await their results. Preserve the real lifecycle lock and all existing assertions. Production code is unchanged.

The sibling stop unit tests already inject their lifecycle lock. The public CLI already acquires the host fence. The missed provider fixtures are now covered by the focused run below.

## Verification

- Before the fix: six failures across the two provider fixtures, all reporting the missing HOME fence.
- `npx vitest run --project cli src/lib/onboard/runtime-provider/podman.test.ts src/lib/onboard/runtime-provider/runtime-provider-contract.test.ts src/lib/actions/sandbox/lifecycle/lock.test.ts` — 102 tests passed after the fix, including lock enforcement tests.
- `NODE_OPTIONS=--max-old-space-size=8192 npm run typecheck:cli` — passed. Initial setup exhausted the default Node heap.
- `NODE_OPTIONS=--max-old-space-size=8192 npm run validate:pr` — passed against canonical `74c628ef625177a0dc3a227accdc0379bfd1e252`.
- Normal pre-commit and commit-message hooks — passed.

The diff contains no secrets, API keys, or credentials.

## Review notes

Self-review of NVIDIA/NemoClaw commit `4f8de45847007dbf34505e6c2ea3fd2ab6167281` covered both changed files under the sensitive `src/lib/onboard/**` path. The review checked the complete diff, sibling stop callers, and the host-fence enforcement tests. No production control changes or remaining fixture failures were found. Independent review is pending; this PR is a draft.

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved runtime-provider test reliability across Podman and socket-free environments.
  - Added coverage to ensure sandbox shutdown operations run within the appropriate host context.
  - Strengthened start/stop and contract test scenarios to reduce timing- and environment-related test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->