### PR TITLE
feat(onboard): support providerless component onboarding

### DIFF
--- a/docs/deployment/register-external-component.mdx
+++ b/docs/deployment/register-external-component.mdx
@@ -30,12 +30,14 @@ The component owner must operate its service, sockets, credentials, resources, a
 Version 1 does not support these operations or configurations:
 
 - Resume, reuse, repair, rebuild, recreation, or migration.
-- Providerless Agent Policy Framework (APF) interceptor onboarding.
+- Providerless component onboarding with NemoClaw-supplied initial policy.
 - An externally supervised OpenShell gateway.
 - More than one registered component.
 - Generic shell commands, repository commands, vendor adapters, or a new OpenShell provider attachment API.
 
 Onboarding without the declaration uses the existing onboarding behavior.
+Registration alone does not select providerless onboarding.
+Ordinary onboarding with a registered component keeps NemoClaw's initial policy and provider setup.
 
 ## Create the Declaration
 
@@ -128,6 +130,32 @@ The policy must contain the NemoClaw policy requirements and have a valid hash a
 The policy version must match the live sandbox observation.
 
 NemoClaw sends identity to the component only after these checks pass.
+
+<AgentOnly variant="openclaw">
+
+### Select Interceptor-Supplied Policy
+
+To use the registered component for fresh providerless onboarding, explicitly select `--apf-interceptor`:
+
+```bash
+nemoclaw onboard --fresh --apf-interceptor --name component-sandbox
+```
+
+The component must supply sandbox policy through the existing OpenShell `CreateSandbox` interceptor contract.
+A generic component can implement this contract; no specific policy framework is required.
+The [providerless onboarding prerequisites](../reference/commands#--apf-interceptor) also apply.
+
+NemoClaw supplies no initial policy, creates no providers, and handles no component credentials in this flow.
+Any providers required by the component's policy must resolve through existing OpenShell mechanisms before activation.
+Missing, invalid, or unresolved policy or provider requirements stop onboarding before activation.
+NemoClaw does not substitute its own policy or switch to ordinary onboarding.
+
+After OpenShell creates the sandbox, NemoClaw verifies its immutable identity and effective policy before invoking the same activation endpoint described below.
+Completion requires successful bounded activation and post-response verification.
+This flow skips ordinary agent configuration, policy selection, and inference setup.
+Providerless onboarding without a registered component retains its existing behavior.
+
+</AgentOnly>
 
 ## Implement the Activation Endpoint
 

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -449,7 +449,9 @@ Without the lock, it preserves the foreign reservation.
 
 #### `--apf-interceptor`
 
-Use this option to request a policyless sandbox creation for an APF-interceptor flow. This option currently supports providerless sandbox creation only. APF onboarding with an inference provider and model is not yet supported. APF onboarding with an OpenShell provider for a Model Context Protocol (MCP) server is also not yet supported. OpenShell cannot bind provider attachment to the new sandbox's verified immutable ID. If the prepared plan contains any provider, NemoClaw exits before it:
+Use this option to request sandbox creation without a NemoClaw-supplied policy.
+This option supports providerless onboarding only; NemoClaw does not configure an inference provider, model, or credential provider in this mode.
+If NemoClaw's prepared plan contains any provider, it exits before it:
 
 - Creates the sandbox.
 - Registers or changes credentials.
@@ -464,6 +466,12 @@ The option requires these conditions:
 - Do not select the Portable experimental profile.
 
 NemoClaw omits a caller policy from every sandbox creation attempt. After creation, NemoClaw binds the returned durable sandbox identity and verifies its effective policy. The policy must be sandbox-scoped and contain every policy entry required by the prepared configuration. NemoClaw stores no policy owner, receipt, or desired state; later policy commands read OpenShell directly. This verification does not establish that APF injected the policy.
+
+With one [registered external component](../deployment/register-external-component#select-interceptor-supplied-policy), the component supplies policy through the existing OpenShell interceptor contract.
+Required providers must resolve through existing OpenShell mechanisms before activation.
+NemoClaw activates the component only after verifying immutable sandbox identity and effective policy, then verifies them again after the response.
+Missing or invalid policy does not trigger a fallback to NemoClaw policy or ordinary onboarding.
+Registration alone does not select this option.
 
 ```bash
 $$nemoclaw onboard --fresh --apf-interceptor --name my-apf-sandbox

--- a/src/lib/onboard/external-component/onboarding.test.ts
+++ b/src/lib/onboard/external-component/onboarding.test.ts
@@ -218,18 +218,14 @@ describe("external component onboarding lifecycle", () => {
     }
   });
 
-  it("rejects APF onboarding when a component is registered (#11340)", () => {
-    mocks.loadExternalComponentDeclaration.mockReturnValue({} as never);
-
-    expect(() =>
-      prepareExternalComponent({
-        externalComponentActivation: null,
-        apfInterceptorRequested: true,
-      }),
-    ).toThrowError(
-      expect.objectContaining<Partial<ExternalComponentContractError>>({
-        code: "lifecycle_unsupported",
-      }),
-    );
-  });
+  it.each([true, false])(
+    "preserves registration with providerless selection %s (#11486)",
+    (apfInterceptorRequested) => {
+      const component = {} as PreparedExternalComponent;
+      mocks.loadExternalComponentDeclaration.mockReturnValue(component);
+      expect(prepareExternalComponent({ apfInterceptorRequested })).toBe(component);
+      mocks.loadExternalComponentDeclaration.mockReturnValue(null);
+      expect(prepareExternalComponent({ apfInterceptorRequested })).toBeNull();
+    },
+  );
 });

--- a/src/lib/onboard/external-component/onboarding.ts
+++ b/src/lib/onboard/external-component/onboarding.ts
@@ -20,11 +20,7 @@ export function prepareExternalComponent(
   } | null,
 ): PreparedExternalComponent | null {
   assertNoIncompleteExternalComponentActivation(session);
-  const externalComponent = loadExternalComponentDeclaration();
-  if (externalComponent && session?.apfInterceptorRequested === true) {
-    throw new ExternalComponentContractError("lifecycle_unsupported");
-  }
-  return externalComponent;
+  return loadExternalComponentDeclaration();
 }
 
 export function assertNoIncompleteExternalComponentActivation(

--- a/src/lib/onboard/external-component/proof.test.ts
+++ b/src/lib/onboard/external-component/proof.test.ts
@@ -52,24 +52,49 @@ function fixture() {
 }
 
 describe("external component activation proof", () => {
-  it("binds the durable OpenShell identity to the effective policy (#11340)", () => {
-    const { deps } = fixture();
+  it.each([policyHash, policyHash.slice("sha256:".length)])(
+    "binds the durable OpenShell identity to policy digest %s (#11486)",
+    (hash) => {
+      const { deps, inspection } = fixture();
+      inspection.policyIdentity.hash = hash;
 
+      const proof = createExternalComponentActivationProof("assistant", "nemoclaw", deps);
+
+      expect(proof).toMatchObject({
+        gatewayName: "nemoclaw",
+        sandboxId,
+        sandboxIdentityFingerprint: `sha256:${fingerprintOpenShellSandboxId(sandboxId)}`,
+        lifecycleGeneration: "generation-1",
+        policySource: "sandbox",
+        policyHash,
+        policyActiveVersion: 3,
+      });
+      expect(deps.inspectPolicy).toHaveBeenCalledWith(
+        "assistant",
+        "verify external component activation policy",
+        "nemoclaw",
+      );
+    },
+  );
+
+  it("rejects a changed OpenShell digest after activation (#11486)", () => {
+    const { deps, inspection } = fixture();
+    inspection.policyIdentity.hash = "a".repeat(64);
     const proof = createExternalComponentActivationProof("assistant", "nemoclaw", deps);
+    inspection.policyIdentity.hash = "b".repeat(64);
+    expect(() => proof.revalidate("after_activation")).toThrow(ExternalComponentProofError);
+  });
 
-    expect(proof).toMatchObject({
-      gatewayName: "nemoclaw",
-      sandboxId,
-      sandboxIdentityFingerprint: `sha256:${fingerprintOpenShellSandboxId(sandboxId)}`,
-      lifecycleGeneration: "generation-1",
-      policySource: "sandbox",
-      policyHash,
-      policyActiveVersion: 3,
-    });
-    expect(deps.inspectPolicy).toHaveBeenCalledWith(
-      "assistant",
-      "verify external component activation policy",
-      "nemoclaw",
+  it.each([
+    "a".repeat(63),
+    "a".repeat(65),
+    `sha256:sha256:${"a".repeat(64)}`,
+    `sha512:${"a".repeat(64)}`,
+  ])("rejects malformed policy digest %s (#11486)", (hash) => {
+    const { deps, inspection } = fixture();
+    inspection.policyIdentity.hash = hash;
+    expect(() => createExternalComponentActivationProof("assistant", "nemoclaw", deps)).toThrow(
+      ExternalComponentProofError,
     );
   });
 

--- a/src/lib/onboard/external-component/proof.ts
+++ b/src/lib/onboard/external-component/proof.ts
@@ -81,11 +81,12 @@ function captureProofSnapshotUnchecked(
     "verify external component activation policy",
     expectedGatewayName,
   );
+  const policyDigest = policy.inspection.policyIdentity.hash.replace(/^sha256:/u, "");
   if (
     policy.gatewayName !== expectedGatewayName ||
     policy.inspection.policySource !== "sandbox" ||
     row.current_policy_version !== policy.inspection.policyIdentity.activeVersion ||
-    !/^sha256:[0-9a-f]{64}$/u.test(policy.inspection.policyIdentity.hash)
+    !/^[0-9a-f]{64}$/u.test(policyDigest)
   ) {
     throw new ExternalComponentProofError();
   }
@@ -101,7 +102,7 @@ function captureProofSnapshotUnchecked(
     gatewayName: expectedGatewayName,
     lifecycleGeneration: entry.lifecycleGeneration,
     policyActiveVersion: policy.inspection.policyIdentity.activeVersion,
-    policyHash: policy.inspection.policyIdentity.hash,
+    policyHash: `sha256:${policyDigest}`,
     policySource: policy.inspection.policySource,
     sandboxId: row.id,
     sandboxIdentityFingerprint: `sha256:${fingerprint}`,

--- a/src/lib/onboard/machine/core-flow-phases.test.ts
+++ b/src/lib/onboard/machine/core-flow-phases.test.ts
@@ -833,112 +833,129 @@ describe("core onboard flow phases", () => {
     expect(reserveSandboxInferenceRoute).not.toHaveBeenCalled();
   });
 
-  it("completes providerless APF after the verified sandbox-create boundary", async () => {
-    const setupNim = vi.fn();
-    const setupInference = vi.fn(async () => ({ ok: true as const }));
-    let providerlessReservation: {
-      name: string;
-      gatewayName: string;
-      pendingRouteReservation: true;
-      reservationSessionId?: string;
-      provider: string | null;
-      model: string | null;
-      endpointUrl: string | null;
-      endpointSource: InferenceEndpointSource | null;
-      credentialEnv: string | null;
-      preferredInferenceApi: string | null;
-    } | null = null;
-    const reserveRoute = vi.fn(
-      (
-        name: string,
-        route: Parameters<ProviderOptions["deps"]["reserveSandboxInferenceRoute"]>[1],
-      ) => {
-        providerlessReservation = {
-          name,
-          pendingRouteReservation: true,
-          ...route,
-        };
-        return true;
-      },
-    );
-    const updateSandboxRegistry = vi.fn();
-    const recordStepComplete = vi.fn(async (_stepName: string, updates: SessionUpdates = {}) => {
-      Object.assign(session, updates);
-      return session;
-    });
-    const createSandbox = vi.fn(async (...args: unknown[]) => {
-      expect(args[1]).toBe("");
-      expect(args[2]).toBe("");
-      expect(args[15]).toMatchObject({
-        apfInterceptorRequested: true,
-        deferSandboxEffectsUntilIdentityVerification: true,
+  it.each([false, true])(
+    "routes verified providerless creation with component %s (#11486)",
+    async (registered) => {
+      const setupNim = vi.fn();
+      const setupInference = vi.fn(async () => ({ ok: true as const }));
+      let providerlessReservation: {
+        name: string;
+        gatewayName: string;
+        pendingRouteReservation: true;
+        reservationSessionId?: string;
+        provider: string | null;
+        model: string | null;
+        endpointUrl: string | null;
+        endpointSource: InferenceEndpointSource | null;
+        credentialEnv: string | null;
+        preferredInferenceApi: string | null;
+      } | null = null;
+      const reserveRoute = vi.fn(
+        (
+          name: string,
+          route: Parameters<ProviderOptions["deps"]["reserveSandboxInferenceRoute"]>[1],
+        ) => {
+          providerlessReservation = {
+            name,
+            pendingRouteReservation: true,
+            ...route,
+          };
+          return true;
+        },
+      );
+      const updateSandboxRegistry = vi.fn();
+      const recordStepComplete = vi.fn(async (_stepName: string, updates: SessionUpdates = {}) => {
+        Object.assign(session, updates);
+        return session;
       });
-      return "created-sandbox";
-    });
-    const session = createSession({ apfInterceptorRequested: true });
-    const { providerInference: providerPhase, sandbox: sandboxPhase } = createPhases({
-      providerEnv: { NEMOCLAW_WEB_SEARCH_PROVIDER: "none" },
-      providerDeps: {
-        reserveSandboxInferenceRoute: reserveRoute,
-        setupInference,
-        setupNim,
-      },
-      sandboxOptions: { apfInterceptorRequested: true },
-      sandboxDeps: {
-        createSandbox,
-        getSandboxRegistryEntry: () => providerlessReservation,
-        recordStepComplete,
-        setupMessagingChannels: vi.fn(async () => []),
-        updateSandboxRegistry,
-      },
-    });
-    const initial = context({
-      fresh: true,
-      session,
-      model: null,
-      provider: null,
-      selectedMessagingChannels: [],
-    });
-
-    const providerResult = await providerPhase.run(initial);
-    expect(providerResult.result).toEqual([
-      advanceTo("inference", {
-        metadata: { state: "provider_selection", providerlessApf: true },
-      }),
-      advanceTo("sandbox", {
-        metadata: { state: "inference", providerlessApf: true },
-      }),
-    ]);
-    expect(reserveRoute).toHaveBeenCalledWith(
-      "my-sandbox",
-      expect.objectContaining({
-        provider: null,
+      const createSandbox = vi.fn(async (...args: unknown[]) => {
+        expect(args[1]).toBe("");
+        expect(args[2]).toBe("");
+        expect(args[15]).toMatchObject({
+          apfInterceptorRequested: true,
+          deferSandboxEffectsUntilIdentityVerification: true,
+        });
+        return "created-sandbox";
+      });
+      const session = createSession({ apfInterceptorRequested: true });
+      const { providerInference: providerPhase, sandbox: sandboxPhase } = createPhases({
+        providerEnv: { NEMOCLAW_WEB_SEARCH_PROVIDER: "none" },
+        providerDeps: {
+          reserveSandboxInferenceRoute: reserveRoute,
+          setupInference,
+          setupNim,
+        },
+        sandboxOptions: { apfInterceptorRequested: true },
+        sandboxDeps: {
+          createSandbox,
+          getSandboxRegistryEntry: () => providerlessReservation,
+          recordStepComplete,
+          setupMessagingChannels: vi.fn(async () => []),
+          updateSandboxRegistry,
+        },
+      });
+      const initial = context({
+        fresh: true,
+        session,
         model: null,
-        gatewayName: "nemoclaw",
-        reservationSessionId: session.sessionId,
-      }),
-      { requireAbsent: true },
-    );
-    const sandboxResult = await sandboxPhase.run(providerResult.context);
+        provider: null,
+        selectedMessagingChannels: [],
+        externalComponent: registered
+          ? {
+              declaration: {
+                schemaVersion: 1,
+                componentId: "policy-governance",
+                interceptorSocketPath: "/run/component/interceptor.sock",
+                activationSocketPath: "/run/component/activation.sock",
+              },
+              revalidateBeforeGateway: vi.fn(),
+              revalidateBeforeActivation: vi.fn(),
+            }
+          : null,
+      });
 
-    expect(sandboxResult.result).toMatchObject({ type: "complete" });
-    expect(
-      isCoreFlowCompleteBeforeFinalization({
-        context: sandboxResult.context,
-        session: { machine: { state: "complete" } },
-      }),
-    ).toBe(true);
-    expect(setupNim).not.toHaveBeenCalled();
-    expect(setupInference).not.toHaveBeenCalled();
-    expect(createSandbox).toHaveBeenCalledOnce();
-    expect(updateSandboxRegistry).toHaveBeenCalledWith(
-      "created-sandbox",
-      expect.not.objectContaining({ model: expect.anything(), provider: expect.anything() }),
-    );
-    const sandboxCompletion = recordStepComplete.mock.calls.find(([step]) => step === "sandbox");
-    expect(sandboxCompletion?.[1]).not.toHaveProperty("model");
-    expect(sandboxCompletion?.[1]).not.toHaveProperty("provider");
-  });
+      const providerResult = await providerPhase.run(initial);
+      expect(providerResult.result).toEqual([
+        advanceTo("inference", {
+          metadata: { state: "provider_selection", providerlessApf: true },
+        }),
+        advanceTo("sandbox", {
+          metadata: { state: "inference", providerlessApf: true },
+        }),
+      ]);
+      expect(reserveRoute).toHaveBeenCalledWith(
+        "my-sandbox",
+        expect.objectContaining({
+          provider: null,
+          model: null,
+          gatewayName: "nemoclaw",
+          reservationSessionId: session.sessionId,
+        }),
+        { requireAbsent: true },
+      );
+      const sandboxResult = await sandboxPhase.run(providerResult.context);
+
+      expect(sandboxResult.result).toMatchObject(
+        registered ? { type: "transition", next: "agent_setup" } : { type: "complete" },
+      );
+      expect(
+        isCoreFlowCompleteBeforeFinalization({
+          context: sandboxResult.context,
+          session: { machine: { state: "complete" } },
+        }),
+      ).toBe(!registered);
+      expect(setupNim).not.toHaveBeenCalled();
+      expect(setupInference).not.toHaveBeenCalled();
+      expect(createSandbox).toHaveBeenCalledOnce();
+      expect(updateSandboxRegistry).toHaveBeenCalledWith(
+        "created-sandbox",
+        expect.not.objectContaining({ model: expect.anything(), provider: expect.anything() }),
+      );
+      const sandboxCompletion = recordStepComplete.mock.calls.find(([step]) => step === "sandbox");
+      expect(sandboxCompletion?.[1]).not.toHaveProperty("model");
+      expect(sandboxCompletion?.[1]).not.toHaveProperty("provider");
+    },
+  );
 
   it.each([
     ["registered", true, false],

--- a/src/lib/onboard/machine/core-flow-phases.ts
+++ b/src/lib/onboard/machine/core-flow-phases.ts
@@ -110,11 +110,15 @@ interface EndpointProvenance {
 }
 
 export function isCoreFlowCompleteBeforeFinalization(result: {
-  readonly context: Pick<OnboardFlowContext, "providerlessApf" | "sandboxName">;
+  readonly context: Pick<
+    OnboardFlowContext,
+    "providerlessApf" | "sandboxName" | "externalComponent"
+  >;
   readonly session: { readonly machine: { readonly state: string } };
 }): boolean {
   return (
     result.context.providerlessApf === true &&
+    !result.context.externalComponent &&
     result.session.machine.state === "complete" &&
     Boolean(result.context.sandboxName)
   );

--- a/src/lib/onboard/machine/final-flow-phases.test.ts
+++ b/src/lib/onboard/machine/final-flow-phases.test.ts
@@ -6,8 +6,6 @@ import {
   context,
   createPhases,
   createProviderlessComponentFlow,
-  createRuntimeHarness,
-  sessionAt,
 } from "../../../../test/helpers/onboard-final-flow-phases";
 import { createSession } from "../../state/onboard-session";
 import { runFinalOnboardFlowSlice } from "./final-flow-phases";

--- a/src/lib/onboard/machine/final-flow-phases.test.ts
+++ b/src/lib/onboard/machine/final-flow-phases.test.ts
@@ -2,12 +2,99 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it, vi } from "vitest";
-import { context, createPhases } from "../../../../test/helpers/onboard-final-flow-phases";
+import {
+  context,
+  createPhases,
+  createProviderlessComponentFlow,
+  createRuntimeHarness,
+  sessionAt,
+} from "../../../../test/helpers/onboard-final-flow-phases";
 import { createSession } from "../../state/onboard-session";
 import { runFinalOnboardFlowSlice } from "./final-flow-phases";
 import { advanceTo } from "./result";
 
 describe("final onboard flow phases", () => {
+  it("completes providerless onboarding only after verified component activation (#11486)", async () => {
+    const flow = createProviderlessComponentFlow();
+    const result = await flow.run();
+    expect(result.session.machine.state).toBe("complete");
+    expect(flow.transport).toHaveBeenCalledOnce();
+    expect(flow.revalidate).toHaveBeenCalledTimes(2);
+    expect(flow.evidence).toHaveBeenLastCalledWith(null);
+    expect(flow.order).toEqual(["verify-proof", "activate"]);
+    await expect(createPhases("openclaw")[3].run(flow.initial)).rejects.toThrow(
+      "Providerless component activation has not completed in this onboarding run.",
+    );
+  });
+
+  it("preserves failed providerless activation evidence after rejection (#11486)", async () => {
+    const flow = createProviderlessComponentFlow();
+    flow.response.result = "rejected";
+    const result = await flow.run();
+    expect(result.session.machine.state).toBe("finalizing");
+    expect(result.session.externalComponentActivation).toMatchObject({
+      sandboxIdentityFingerprint: flow.proof.sandboxIdentityFingerprint,
+      lifecycleGeneration: flow.proof.lifecycleGeneration,
+      resultClass: "failed",
+    });
+    expect(flow.transport).toHaveBeenCalledOnce();
+    expect(flow.order).toEqual(["verify-proof", "activate"]);
+  });
+
+  it.each([
+    {
+      outcome: "malformed response",
+      arrange: (flow: ReturnType<typeof createProviderlessComponentFlow>) =>
+        flow.transport.mockResolvedValue("{}"),
+      requests: 1,
+      order: ["verify-proof", "activate"],
+    },
+    {
+      outcome: "changed endpoint",
+      arrange: (flow: ReturnType<typeof createProviderlessComponentFlow>) =>
+        flow.revalidateEndpoint.mockImplementation(() => {
+          throw new Error("changed endpoint");
+        }),
+      requests: 0,
+      order: ["verify-proof"],
+    },
+    {
+      outcome: "changed identity or policy proof",
+      arrange: (flow: ReturnType<typeof createProviderlessComponentFlow>) =>
+        flow.revalidate
+          .mockImplementationOnce(() => undefined)
+          .mockImplementationOnce(() => {
+            throw new Error("drift");
+          }),
+      requests: 1,
+      order: ["verify-proof", "activate"],
+    },
+  ])(
+    "preserves ambiguous providerless activation evidence for $outcome (#11486)",
+    async ({ arrange, requests, order }) => {
+      const flow = createProviderlessComponentFlow();
+      arrange(flow);
+      const result = await flow.run();
+      expect(result.session.machine.state).toBe("finalizing");
+      expect(result.session.externalComponentActivation).toMatchObject({
+        sandboxIdentityFingerprint: flow.proof.sandboxIdentityFingerprint,
+        lifecycleGeneration: flow.proof.lifecycleGeneration,
+        resultClass: "ambiguous",
+      });
+      expect(flow.transport).toHaveBeenCalledTimes(requests);
+      expect(flow.order).toEqual(order);
+    },
+  );
+
+  it("refuses providerless activation when policy proof is unavailable (#11486)", async () => {
+    const flow = createProviderlessComponentFlow();
+    flow.createProof.mockImplementation(() => {
+      throw new Error("policy unavailable");
+    });
+    await expect(flow.run()).rejects.toThrow("policy unavailable");
+    expect(flow.transport).not.toHaveBeenCalled();
+  });
+
   it("selects the requested branch setup state", () => {
     expect(createPhases("openclaw")[0].state).toBe("openclaw");
     expect(createPhases("agent_setup")[0].state).toBe("agent_setup");

--- a/src/lib/onboard/machine/final-flow-phases.ts
+++ b/src/lib/onboard/machine/final-flow-phases.ts
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { WebSearchConfig, WebSearchProvider } from "../../inference/web-search";
-import { assertSandboxCreatedContext, type OnboardFlowContext } from "./flow-context";
+import {
+  assertSandboxCreatedContext,
+  isProviderlessComponentOnboarding,
+  type OnboardFlowContext,
+} from "./flow-context";
 import {
   createAgentSetupPhase,
   createFinalizationPhase,
@@ -20,7 +24,7 @@ import {
 } from "./handlers/finalization";
 import { handlePoliciesState, type PoliciesStateOptions } from "./handlers/policies";
 import { createPhaseProgressReporter } from "./phase-progress";
-import type { OnboardStateResult } from "./result";
+import { advanceTo, completeOnboardMachine, type OnboardStateResult } from "./result";
 import type { OnboardMachineRunnerRuntime, OnboardStateHandlerResult } from "./runner";
 import type { OnboardSequencePhase } from "./sequence-runner";
 import type { OnboardMachineEventType, OnboardMachineState } from "./types";
@@ -60,10 +64,14 @@ export function createFinalOnboardFlowPhases<
   OnboardSequencePhase<Context>,
 ] {
   const finalizationDeps = options.finalizationDeps;
+  let activatedProviderlessSandbox: string | null = null;
   const createBranchPhase =
     options.branchState === "agent_setup" ? createAgentSetupPhase : createOpenclawSetupPhase;
   const branchSetupPhase = createBranchPhase<Context>(async (context) => {
     assertSandboxCreatedContext(context, "agent setup");
+    if (isProviderlessComponentOnboarding(context)) {
+      return { result: advanceTo("policies", { metadata: { state: options.branchState } }) };
+    }
     const agentSetupResult = await handleAgentSetupState({
       agent: context.agent,
       sandboxName: context.sandboxName,
@@ -84,6 +92,10 @@ export function createFinalOnboardFlowPhases<
 
   const policiesPhase = createPoliciesPhase<Context>(async (context) => {
     assertSandboxCreatedContext(context, "policies");
+    if (isProviderlessComponentOnboarding(context)) {
+      // OpenShell already verified the interceptor-supplied policy during creation.
+      return { result: advanceTo("finalizing", { metadata: { state: "policies" } }) };
+    }
     const policiesResult = await handlePoliciesState({
       resume: context.resume,
       preserveRebuildLivePolicy: options.preserveRebuildLivePolicy,
@@ -133,13 +145,28 @@ export function createFinalOnboardFlowPhases<
       portableProfileSelected: context.session?.checkpoint?.profile.value === "portable",
       recreateJournalHandoff: context.recreateJournalHandoff,
       externalComponent: context.externalComponent,
+      providerless: isProviderlessComponentOnboarding(context),
       deps: finalizationDeps,
     });
+    if (
+      isProviderlessComponentOnboarding(context) &&
+      finalizationResult.stateResult.type === "transition"
+    ) {
+      activatedProviderlessSandbox = context.sandboxName;
+    }
     return { result: finalizationResult.stateResult };
   });
 
   const postVerifyPhase = createPostVerifyPhase<Context>(async (context) => {
     assertSandboxCreatedContext(context, "post verification");
+    if (isProviderlessComponentOnboarding(context)) {
+      if (activatedProviderlessSandbox !== context.sandboxName) {
+        throw new Error(
+          "Providerless component activation has not completed in this onboarding run.",
+        );
+      }
+      return { result: completeOnboardMachine({}, { state: "post_verify" }) };
+    }
     const webSearchEnabled = options.finalization.webSearchEnabled(context.webSearchConfig);
     const postVerifyResult = await handlePostVerifyState({
       sandboxName: context.sandboxName,

--- a/src/lib/onboard/machine/flow-context.ts
+++ b/src/lib/onboard/machine/flow-context.ts
@@ -124,11 +124,20 @@ export function assertProviderSelectedContext<Context extends OnboardFlowContext
   }
 }
 
+export function isProviderlessComponentOnboarding(
+  context: Pick<OnboardFlowContext, "providerlessApf" | "externalComponent">,
+): boolean {
+  return context.providerlessApf === true && Boolean(context.externalComponent);
+}
+
 export function assertSandboxCreatedContext<Context extends OnboardFlowContext>(
   context: Context,
   stepName: string,
 ): asserts context is SandboxCreatedOnboardFlowContext<Context> {
-  if (!context.sandboxName || !context.model || !context.provider) {
+  const inferenceReady = isProviderlessComponentOnboarding(context)
+    ? context.model === "" && context.provider === ""
+    : Boolean(context.model && context.provider);
+  if (!context.sandboxName || !inferenceReady) {
     throw new Error(`Onboarding state is incomplete before ${stepName}.`);
   }
 }

--- a/src/lib/onboard/machine/flow-handoff.test.ts
+++ b/src/lib/onboard/machine/flow-handoff.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { createSession, MACHINE_SNAPSHOT_VERSION, type Session } from "../../state/onboard-session";
 import type { OnboardFlowContext } from "./flow-context";
+import type { PreparedExternalComponent } from "../external-component";
 import { prepareCoreOnboardFlowContext, prepareFinalOnboardFlowContext } from "./flow-handoff";
 import type { OnboardMachineState } from "./types";
 
@@ -99,6 +100,70 @@ function context(): OnboardFlowContext & {
 }
 
 describe("onboard flow handoffs", () => {
+  const component = (): PreparedExternalComponent => ({
+    declaration: {
+      schemaVersion: 1,
+      componentId: "policy-governance",
+      interceptorSocketPath: "/run/component/interceptor.sock",
+      activationSocketPath: "/run/component/activation.sock",
+    },
+    revalidateBeforeGateway: vi.fn(),
+    revalidateBeforeActivation: vi.fn(),
+  });
+
+  it("accepts a providerless final handoff with explicit selection and registration (#11486)", () => {
+    expect(
+      prepareFinalOnboardFlowContext({
+        context: {
+          ...context(),
+          sandboxName: "ready",
+          providerlessApf: true,
+          externalComponent: component(),
+        },
+        session: createSession(),
+      }),
+    ).toMatchObject({ model: "", provider: "" });
+  });
+
+  it.each([
+    [false, false],
+    [false, true],
+    [true, false],
+  ])(
+    "rejects a providerless final handoff with selection=%s and registration=%s (#11486)",
+    (selected, registered) => {
+      expect(() =>
+        prepareFinalOnboardFlowContext({
+          context: {
+            ...context(),
+            sandboxName: "ready",
+            providerlessApf: selected ? true : undefined,
+            externalComponent: registered ? component() : null,
+          },
+          session: createSession(),
+        }),
+      ).toThrow("incomplete after sandbox setup");
+    },
+  );
+
+  it.each(["provider", "model"])(
+    "rejects conflicting %s state in a providerless final handoff (#11486)",
+    (field) => {
+      expect(() =>
+        prepareFinalOnboardFlowContext({
+          context: {
+            ...context(),
+            sandboxName: "ready",
+            providerlessApf: true,
+            externalComponent: component(),
+            [field]: "unexpected",
+          },
+          session: createSession(),
+        }),
+      ).toThrow("incomplete after sandbox setup");
+    },
+  );
+
   it("constructs core context from the initial result and requested name", () => {
     const initialContext = context();
     const persisted = createSession();

--- a/src/lib/onboard/machine/flow-handoff.ts
+++ b/src/lib/onboard/machine/flow-handoff.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { OnboardFlowContext } from "./flow-context";
+import { isProviderlessComponentOnboarding, type OnboardFlowContext } from "./flow-context";
 import type { OnboardMachineRunnerResult } from "./runner";
 
 type InitialHandoffContext<Gpu, SandboxGpuConfig> = OnboardFlowContext & {
@@ -47,14 +47,18 @@ export function prepareFinalOnboardFlowContext<Context extends OnboardFlowContex
   core: OnboardMachineRunnerResult<Context>,
 ): Context & { sandboxName: string; model: string; provider: string } {
   const context = core.context;
-  if (!context.sandboxName || !context.model || !context.provider) {
+  const providerless = isProviderlessComponentOnboarding(context);
+  if (
+    !context.sandboxName ||
+    (providerless ? context.model || context.provider : !context.model || !context.provider)
+  ) {
     throw new Error("Onboarding state is incomplete after sandbox setup.");
   }
   return {
     ...context,
     session: core.session,
     sandboxName: context.sandboxName,
-    model: context.model,
-    provider: context.provider,
+    model: context.model ?? "",
+    provider: context.provider ?? "",
   };
 }

--- a/src/lib/onboard/machine/handlers/finalization.test.ts
+++ b/src/lib/onboard/machine/handlers/finalization.test.ts
@@ -150,6 +150,26 @@ async function runFinalizationHandlers(
 }
 
 describe("finalization handlers", () => {
+  it("completes providerless component activation without ordinary setup (#11486)", async () => {
+    const { deps, calls } = createDeps();
+    const result = await handleFinalizationPhase({
+      ...baseOptions(deps),
+      externalComponent,
+      providerless: true,
+      provider: "",
+      model: "",
+    });
+    expect(result.stateResult).toMatchObject({ type: "transition", next: "post_verify" });
+    expect(calls.activateExternalComponent).toHaveBeenCalledOnce();
+    expect(calls.setExternalComponentActivationEvidence).toHaveBeenLastCalledWith(null);
+    expect(calls.setDefaultSandbox).not.toHaveBeenCalled();
+    expect(calls.removeLegacy).not.toHaveBeenCalled();
+    expect(calls.cleanupHost).not.toHaveBeenCalled();
+    expect(calls.recoverProcesses).not.toHaveBeenCalled();
+    expect(calls.verify).not.toHaveBeenCalled();
+    expect(calls.dashboard).not.toHaveBeenCalled();
+  });
+
   it("activates the registered component before declaring the sandbox ready (#11340)", async () => {
     const { deps, calls } = createDeps();
 
@@ -182,11 +202,13 @@ describe("finalization handlers", () => {
   });
 
   it.each([
-    ["rejected", "failed"],
-    ["ambiguous", "ambiguous"],
+    ["rejected", "failed", false],
+    ["ambiguous", "ambiguous", false],
+    ["rejected", "failed", true],
+    ["ambiguous", "ambiguous", true],
   ] as const)(
     "preserves identity-bound incomplete state for %s activation (#11340)",
-    async (kind, resultClass) => {
+    async (kind, resultClass, providerless) => {
       const activationId = "4b5a8e18-f967-4e27-a3b2-f2cc315abe21";
       const activate = vi.fn(async () =>
         kind === "rejected"
@@ -198,6 +220,7 @@ describe("finalization handlers", () => {
       const result = await handleFinalizationPhase({
         ...baseOptions(deps),
         externalComponent,
+        providerless,
       });
 
       expect(result.stateResult).toEqual({

--- a/src/lib/onboard/machine/handlers/finalization.ts
+++ b/src/lib/onboard/machine/handlers/finalization.ts
@@ -36,6 +36,7 @@ export interface FinalizationStateOptions<Agent, VerifyChain, VerificationResult
   portableProfileSelected?: boolean;
   recreateJournalHandoff?: boolean;
   externalComponent?: PreparedExternalComponent | null;
+  providerless?: boolean;
   deps: {
     /**
      * Mark this sandbox as the default. Called here (not at sandbox creation) so
@@ -198,6 +199,7 @@ export async function handleFinalizationState<Agent, VerifyChain, VerificationRe
   stagedLegacyKeys,
   migratedLegacyKeys,
   externalComponent = null,
+  providerless = false,
   deps,
 }: FinalizationStateOptions<
   Agent,
@@ -205,6 +207,9 @@ export async function handleFinalizationState<Agent, VerifyChain, VerificationRe
   VerificationResult
 >): Promise<FinalizationStateResult> {
   const manageDashboard = shouldManageDashboardForAgent(agent as DashboardRuntimeAgent);
+  if (providerless && !externalComponent) {
+    throw new Error("Providerless finalization requires a registered external component.");
+  }
   if (externalComponent) {
     if (
       !deps.createExternalComponentActivationProof ||
@@ -244,6 +249,12 @@ export async function handleFinalizationState<Agent, VerifyChain, VerificationRe
       };
     }
     deps.setExternalComponentActivationEvidence(null);
+  }
+  if (providerless) {
+    return {
+      stateResult: advanceTo("post_verify", { metadata: { state: "finalizing" } }),
+      unmigratedLegacyKeys: stagedLegacyKeys.filter((key) => !migratedLegacyKeys.has(key)),
+    };
   }
   // Reaching finalization means the policy-preset step was confirmed, so it is
   // now safe to register this sandbox as the default (#4614).

--- a/src/lib/onboard/machine/handlers/sandbox-apf.test.ts
+++ b/src/lib/onboard/machine/handlers/sandbox-apf.test.ts
@@ -21,58 +21,62 @@ describe("APF sandbox create selection", () => {
     expect(apfCreateFingerprintFields(true)).toEqual(["apf-interceptor"]);
   });
 
-  it("defers providerless creation effects behind the verified APF callback (#9833)", async () => {
-    const session = createSession({ apfInterceptorRequested: true });
-    const { deps, calls } = createDeps(
-      {
-        getSandboxRegistryEntry: (name) => ({
-          name,
-          gatewayName: "nemoclaw",
-          pendingRouteReservation: true,
-          reservationSessionId: session.sessionId,
-          webSearchEnabled: false,
-          toolDisclosure: "progressive",
-          fromDockerfile: null,
-          hermesAuthMethod: null,
-        }),
-        getSandboxRecreateObservation: () => ({
-          state: "missing" as const,
-          liveIdentityFingerprint: null,
-        }),
-      },
-      session,
-    );
+  it.each([false, true])(
+    "defers providerless creation effects behind verification with registration=%s (#11486)",
+    async (externalComponentRegistered) => {
+      const session = createSession({ apfInterceptorRequested: true });
+      const { deps, calls } = createDeps(
+        {
+          getSandboxRegistryEntry: (name) => ({
+            name,
+            gatewayName: "nemoclaw",
+            pendingRouteReservation: true,
+            reservationSessionId: session.sessionId,
+            webSearchEnabled: false,
+            toolDisclosure: "progressive",
+            fromDockerfile: null,
+            hermesAuthMethod: null,
+          }),
+          getSandboxRecreateObservation: () => ({
+            state: "missing" as const,
+            liveIdentityFingerprint: null,
+          }),
+        },
+        session,
+      );
 
-    await handleSandboxState({
-      ...baseOptions(deps, session),
-      fresh: true,
-      apfInterceptorRequested: true,
-      model: "",
-      provider: "",
-      preferredInferenceApi: null,
-    });
+      await handleSandboxState({
+        ...baseOptions(deps, session),
+        fresh: true,
+        apfInterceptorRequested: true,
+        externalComponentRegistered,
+        model: "",
+        provider: "",
+        preferredInferenceApi: null,
+      });
 
-    expect(calls.stageCredentialProviders).not.toHaveBeenCalled();
-    expect(calls.configureWebSearch).not.toHaveBeenCalled();
-    expect(calls.validateBrave).not.toHaveBeenCalled();
-    expect(calls.setupMessaging).not.toHaveBeenCalled();
-    expect(calls.createSandbox).toHaveBeenCalledOnce();
-    const createCall = calls.createSandbox.mock.calls[0] ?? [];
-    expect(createCall.at(-2)).toMatchObject({
-      apfInterceptorRequested: true,
-      deferSandboxEffectsUntilIdentityVerification: true,
-    });
-    const activateVerifiedEffects = createCall.at(-1);
-    expect(activateVerifiedEffects).toEqual(expect.any(Function));
+      expect(calls.stageCredentialProviders).not.toHaveBeenCalled();
+      expect(calls.configureWebSearch).not.toHaveBeenCalled();
+      expect(calls.validateBrave).not.toHaveBeenCalled();
+      expect(calls.setupMessaging).not.toHaveBeenCalled();
+      expect(calls.createSandbox).toHaveBeenCalledOnce();
+      const createCall = calls.createSandbox.mock.calls[0] ?? [];
+      expect(createCall.at(-2)).toMatchObject({
+        apfInterceptorRequested: true,
+        deferSandboxEffectsUntilIdentityVerification: true,
+      });
+      const activateVerifiedEffects = createCall.at(-1);
+      expect(activateVerifiedEffects).toEqual(expect.any(Function));
 
-    const sessionUpdatesBeforeVerifiedEffects = calls.updateSession.mock.calls.length;
-    await (activateVerifiedEffects as unknown as (context: unknown) => Promise<void>)({
-      revalidateSandboxIdentity: () => undefined,
-    });
-    expect(calls.updateSession.mock.calls.length).toBeGreaterThan(
-      sessionUpdatesBeforeVerifiedEffects,
-    );
-  });
+      const sessionUpdatesBeforeVerifiedEffects = calls.updateSession.mock.calls.length;
+      await (activateVerifiedEffects as unknown as (context: unknown) => Promise<void>)({
+        revalidateSandboxIdentity: () => undefined,
+      });
+      expect(calls.updateSession.mock.calls.length).toBeGreaterThan(
+        sessionUpdatesBeforeVerifiedEffects,
+      );
+    },
+  );
 
   it.each([
     [
@@ -103,43 +107,47 @@ describe("APF sandbox create selection", () => {
     expect(calls.createSandbox).not.toHaveBeenCalled();
   });
 
-  it("rejects a resolved APF provider plan before sandbox or provider effects (#9833)", async () => {
-    const session = createSession({ apfInterceptorRequested: true });
-    const { deps, calls } = createDeps(
-      {
-        getSandboxRegistryEntry: (name) => ({
-          name,
-          gatewayName: "nemoclaw",
-          pendingRouteReservation: true,
-          reservationSessionId: session.sessionId,
-        }),
-        getSandboxRecreateObservation: () => ({
-          state: "missing" as const,
-          liveIdentityFingerprint: null,
-        }),
-        planRegisteredExtraProviders: () => ({
-          extraProviders: [],
-          staleExtraProviders: ["stale-provider"],
-        }),
-      },
-      session,
-    );
+  it.each([false, true])(
+    "rejects a provider plan before effects with registration=%s (#11486)",
+    async (externalComponentRegistered) => {
+      const session = createSession({ apfInterceptorRequested: true });
+      const { deps, calls } = createDeps(
+        {
+          getSandboxRegistryEntry: (name) => ({
+            name,
+            gatewayName: "nemoclaw",
+            pendingRouteReservation: true,
+            reservationSessionId: session.sessionId,
+          }),
+          getSandboxRecreateObservation: () => ({
+            state: "missing" as const,
+            liveIdentityFingerprint: null,
+          }),
+          planRegisteredExtraProviders: () => ({
+            extraProviders: [],
+            staleExtraProviders: ["stale-provider"],
+          }),
+        },
+        session,
+      );
 
-    await expect(
-      handleSandboxState({
-        ...baseOptions(deps, session),
-        fresh: true,
-        apfInterceptorRequested: true,
-        model: "",
-        provider: "",
-        preferredInferenceApi: null,
-      }),
-    ).rejects.toThrow(/supports providerless sandbox creation only/u);
+      await expect(
+        handleSandboxState({
+          ...baseOptions(deps, session),
+          fresh: true,
+          apfInterceptorRequested: true,
+          externalComponentRegistered,
+          model: "",
+          provider: "",
+          preferredInferenceApi: null,
+        }),
+      ).rejects.toThrow(/supports providerless sandbox creation only/u);
 
-    expect(calls.resolveCreateIntent).not.toHaveBeenCalled();
-    expect(calls.stageCredentialProviders).not.toHaveBeenCalled();
-    expect(calls.createSandbox).not.toHaveBeenCalled();
-  });
+      expect(calls.resolveCreateIntent).not.toHaveBeenCalled();
+      expect(calls.stageCredentialProviders).not.toHaveBeenCalled();
+      expect(calls.createSandbox).not.toHaveBeenCalled();
+    },
+  );
 
   it("rejects registered sandbox adoption before credential staging (#9833)", async () => {
     const session = createSession({ apfInterceptorRequested: true });

--- a/src/lib/onboard/machine/handlers/sandbox.ts
+++ b/src/lib/onboard/machine/handlers/sandbox.ts
@@ -2538,7 +2538,7 @@ class SandboxStateFlow<
       webSearchSupported: state.webSearchSupported,
       session: state.session,
       stateResult:
-        this.options.apfInterceptorRequested === true
+        this.options.apfInterceptorRequested === true && !this.options.externalComponentRegistered
           ? completeOnboardMachine({}, metadata)
           : branchTo(this.options.agent ? "agent_setup" : "openclaw", { metadata }),
     };

--- a/test/helpers/onboard-final-flow-phases.ts
+++ b/test/helpers/onboard-final-flow-phases.ts
@@ -2,11 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { vi } from "vitest";
+import type { PreparedExternalComponent } from "../../src/lib/onboard/external-component";
+import {
+  activateExternalComponent,
+  type ExternalComponentActivationProof,
+} from "../../src/lib/onboard/external-component/activation";
+import { prepareFinalOnboardFlowContext } from "../../src/lib/onboard/machine/flow-handoff";
 import type { DashboardDeliveryChain } from "../../src/lib/dashboard/contract";
 import type { OnboardMachineEvent } from "../../src/lib/onboard/machine/events";
-import { createFinalOnboardFlowPhases } from "../../src/lib/onboard/machine/final-flow-phases";
+import {
+  createFinalOnboardFlowPhases,
+  runFinalOnboardFlowSlice,
+} from "../../src/lib/onboard/machine/final-flow-phases";
 import type { OnboardFlowContext } from "../../src/lib/onboard/machine/flow-context";
 import type { PoliciesStateOptions } from "../../src/lib/onboard/machine/handlers/policies";
+import type { FinalizationStateOptions } from "../../src/lib/onboard/machine/handlers/finalization";
 import { OnboardRuntime, type OnboardRuntimeDeps } from "../../src/lib/onboard/machine/runtime";
 import type { OnboardMachineState } from "../../src/lib/onboard/machine/types";
 import { OnboardRuntimeBoundary } from "../../src/lib/onboard/runtime-boundary";
@@ -24,6 +34,9 @@ export type Agent = { name: string };
 type WebSearchConfig = NonNullable<OnboardFlowContext["webSearchConfig"]>;
 
 export type RecorderOverrides = {
+  finalizationDeps?: Partial<
+    FinalizationStateOptions<Agent | null, DashboardDeliveryChain, VerifyDeploymentResult>["deps"]
+  >;
   loadSession?: () => Session | null;
   updateSession?: (mutator: (session: Session) => Session | void) => Session;
   recordStepSkipped?: (stepName: string) => Promise<Session>;
@@ -312,6 +325,93 @@ export function createPhases(
       printDashboard: recorders.printDashboard ?? vi.fn(),
       error: vi.fn(),
       log: vi.fn(),
+      ...recorders.finalizationDeps,
     },
   });
+}
+
+export function createProviderlessComponentFlow() {
+  const order: string[] = [];
+  const harness = createRuntimeHarness(sessionAt("openclaw"));
+  const revalidate = vi.fn();
+  const revalidateEndpoint = vi.fn();
+  const proof: ExternalComponentActivationProof = {
+    gatewayName: "nemoclaw",
+    sandboxId: "sandbox-123",
+    sandboxIdentityFingerprint: `sha256:${"b".repeat(64)}`,
+    lifecycleGeneration: "generation-1",
+    policySource: "sandbox",
+    policyHash: `sha256:${"a".repeat(64)}`,
+    policyActiveVersion: 1,
+    revalidate,
+  };
+  const component: PreparedExternalComponent = {
+    declaration: {
+      schemaVersion: 1,
+      componentId: "policy-governance",
+      interceptorSocketPath: "/run/component/interceptor.sock",
+      activationSocketPath: "/run/component/activation.sock",
+    },
+    revalidateBeforeGateway: vi.fn(),
+    revalidateBeforeActivation: revalidateEndpoint,
+  };
+  const activationId = "4b5a8e18-f967-4e27-a3b2-f2cc315abe21";
+  const response = {
+    schemaVersion: 1,
+    activationId,
+    componentId: component.declaration.componentId,
+    sandboxId: proof.sandboxId,
+    policyHash: proof.policyHash,
+    result: "activated",
+  };
+  const transport = vi.fn(async (_socket: string, _body: string) => JSON.stringify(response));
+  const evidence = vi.fn();
+  const createProof = vi.fn(() => {
+    order.push("verify-proof");
+    return proof;
+  });
+  const phases = createPhases("openclaw", order, {
+    finalizationDeps: {
+      createExternalComponentActivationProof: createProof,
+      createExternalComponentActivationId: () => activationId,
+      activateExternalComponent: (registered, verified, id) =>
+        activateExternalComponent(
+          registered,
+          verified,
+          (socket, body) => {
+            order.push("activate");
+            return transport(socket, body);
+          },
+          id,
+        ),
+      setExternalComponentActivationEvidence: evidence,
+    },
+  });
+  const initial = prepareFinalOnboardFlowContext({
+    context: context({
+      providerlessApf: true,
+      externalComponent: component,
+      model: null,
+      provider: null,
+    }),
+    session: harness.getSession(),
+  });
+  return {
+    order,
+    proof,
+    response,
+    transport,
+    evidence,
+    createProof,
+    revalidate,
+    revalidateEndpoint,
+    initial,
+    run: () =>
+      runFinalOnboardFlowSlice({
+        context: initial,
+        runtime: harness.boundary.getRuntime(),
+        phases,
+        recordRepairEvent: vi.fn(),
+      }),
+  };
 }

--- a/test/onboarding/onboard-fsm-live-slices.test.ts
+++ b/test/onboarding/onboard-fsm-live-slices.test.ts
@@ -244,7 +244,11 @@ const staleAdmissionExit = new Error("stale recovery admission refused");
 if (scenario.mode === "providerless-external-component") {
   require(${externalComponentPath}).loadExternalComponentDeclaration = () => {
     called.push("component-validated");
-    return {};
+    return {
+      declaration: { schemaVersion: 1, componentId: "policy-governance", interceptorSocketPath: "/run/component/interceptor.sock", activationSocketPath: "/run/component/activation.sock" },
+      revalidateBeforeGateway() {},
+      revalidateBeforeActivation() {},
+    };
   };
 }
 
@@ -387,6 +391,7 @@ preflightHandlers.handlePreflightState = async (options) => {
 gatewayHandlers.handleGatewayState = async (options) => {
   if (scenario.mode === "providerless-external-component") {
     called.push("gateway-effect");
+    return { gatewayReuseState: "healthy", session: options.session, stateResult: advanceTo("provider_selection", { metadata: { state: "gateway" } }) };
   }
   if (!scenario.mode.includes("core-gateway")) {
     throw new Error("unexpected gateway compatibility handler");
@@ -594,9 +599,7 @@ const { onboard } = require(${onboardPath});
       (scenario.mode === "endpoint-override" &&
         error?.name === "OpenShellGatewayEndpointOverrideError") ||
       (scenario.mode === "providerless-staged-messaging" &&
-        /supports providerless sandbox creation only/.test(String(error?.message))) ||
-      (scenario.mode === "providerless-external-component" &&
-        error?.code === "lifecycle_unsupported")
+        /supports providerless sandbox creation only/.test(String(error?.message)))
     ) {
       const payload = "__RESULT__" + JSON.stringify({ called });
       if (scenario.mode === "dashboard-port-composition") {
@@ -687,11 +690,16 @@ describe("live onboard FSM slice boundaries", () => {
     );
   });
 
-  it("rejects a registered component with providerless APF before effects (#11340)", () => {
-    assert.deepEqual(runSliceProbe({ slice: "initial", mode: "providerless-external-component" }), [
-      "component-validated",
-    ]);
-  });
+  it(
+    "validates the registered component before providerless onboarding effects (#11486)",
+    () => {
+      assert.deepEqual(
+        runSliceProbe({ slice: "initial", mode: "providerless-external-component" }),
+        ["component-validated", "preflight-effect", "gateway-effect", "sandbox-effect"],
+      );
+    },
+    probeTimeoutMs,
+  );
 
   it("rechecks retained sandbox admission after acquiring the onboarding lock (#9833)", () => {
     assert.deepEqual(runSliceProbe({ slice: "initial", mode: "stale-recovery-admission" }), []);


### PR DESCRIPTION
## Outcome

Fresh onboarding with one registered external component and explicit providerless selection reaches the existing activation lifecycle instead of failing with `lifecycle_unsupported`. Completion requires verified immutable sandbox identity and effective policy, successful bounded activation, and post-response reverification. Ordinary onboarding, ordinary component onboarding, and providerless onboarding without registration retain their existing selection paths.

## Reason

Removing the combination guard alone would let the providerless core flow complete before activation. The final flow also assumed a provider/model selection and ordinary agent and policy setup. Live qualification exposed an additional mismatch: OpenShell returns a bare SHA-256 policy digest, while the activation proof expected its `sha256:` representation.

### Related issues

Fixes #11486. Extends #11366 under #11340 and follows the [accepted scope decision](https://github.com/NVIDIA/NemoClaw/issues/11486#issuecomment-5627319265).

## Changes

- Route the explicitly selected combination through the existing state machine and finalizer. Skip ordinary provider, agent, and policy setup for this combination only; registration alone does not select it.
- Retain declaration validation before gateway effects, NemoClaw's gateway ownership, and OpenShell's authority over identity, policy, and provider resolution. NemoClaw supplies no initial policy, creates no providers, and handles no component credentials in this flow.
- Preserve existing activation deadlines, fail-closed behavior, post-response verification, and identity-bound incomplete-state evidence. Normalize a valid OpenShell SHA-256 digest without changing the activation message format or accepting malformed digests.
- Extend existing fixtures with explicit success and failure cases, and update the owning component-registration and command documentation. Keep #11375 documentation-only and #11453's declarative onboarding separate. No new provider APIs, hooks, service management, retry, recovery, or lifecycle interface.

## Verification

- Implementation validation covered component registration, activation, proof, flow handoffs, sandbox identity, providerless plans, and gateway configuration: 270 tests passed across 15 files. After the digest repair, `npx vitest run --project cli src/lib/onboard/external-component src/lib/onboard/machine/final-flow-phases.test.ts src/lib/onboard/machine/handlers/finalization.test.ts --coverage=false` passed all 110 affected tests. The subsequent test-only repair is verified below.
- `npx vitest run --project cli src/lib/onboard/machine/final-flow-phases.test.ts src/lib/onboard/machine/flow-handoff.test.ts --coverage=false` — 34 tests passed after splitting conditional assertions into explicit cases.
- `npx vitest run --project integration test/onboarding/onboard-fsm-live-slices.test.ts --testTimeout=60000 --coverage=false` — 18 passed. The default-timeout run timed out in two unchanged subprocess cases; the changed case passed.
- `NODE_OPTIONS=--max-old-space-size=8192 npm run typecheck:cli`, `npm run build:cli`, changed-file Oxlint, `npm run checks:repository`, and `git diff --check` — passed during implementation.
- `npm run docs` — zero errors, five Fern warnings. The combined-flow procedure is present only in the OpenClaw variant; the other generated variants were checked.
- Real OpenShell 0.0.106 boundary test in disposable Linux: a generic component supplied sandbox policy through the existing interceptor contract, the sandbox reached Ready, and one real activation completed after three identity/policy observations. No caller policy or providers were supplied. OpenShell rejected a separate unresolved-provider request. This test used a registry fixture bound to the real sandbox ID; it was not full NemoClaw onboarding. All disposable containers and sandboxes were removed.
- Full combined NemoClaw onboarding remains unvalidated: the managed gateway started, but the sandbox image build exhausted disposable Docker disk space before activation. No image or security check was bypassed.
- `NODE_OPTIONS=--max-old-space-size=8192 npm run validate:pr` — passed for candidate `aa79ad4a8fe4a1e059dac81f3d4ec77bdcab14da` against canonical base `1279b2f1b35790b767ff8252d9fa6e969d5f7d0f`; validation sources and resolved executables were checked against the canonical checkout and a fresh locked dependency install.
- Normal pre-commit and commit-message checks passed. The guarded push also passed CLI, plugin, and checked-JavaScript TypeScript hooks. GitHub reports the single published commit as Verified.
- The reviewed diff contains no secrets, API keys, or credentials.

## Review notes

Draft for independent review and completion of full combined onboarding validation. No approval or CI waiver is claimed.

The implementation and publication self-review inspected NVIDIA/NemoClaw candidate `aa79ad4a8fe4a1e059dac81f3d4ec77bdcab14da`, including the sensitive paths under `src/lib/onboard/**`, against the accepted scope and failure-state requirements. The review found no additional scope change after the test repair. No independent pre-publication review has been performed; these sensitive paths await independent review.

Open #11483 also changes the existing proof/activation owners and needs integration coordination. Its code was not imported here.

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added providerless onboarding for registered external components through the existing interceptor contract.
  - Added validation of component identity, policy proofs, and activation state before and after sandbox activation.
  - Providerless onboarding skips provider, model, credential, and standard policy setup.

- **Bug Fixes**
  - Improved policy digest validation for prefixed and unprefixed SHA-256 values.
  - Added fail-closed handling for missing, malformed, changed, or unavailable activation proofs.

- **Documentation**
  - Updated onboarding and command references with providerless component requirements and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->