### PR TITLE
fix(test): remove duplicate host fence imports

### DIFF
--- a/src/lib/onboard/runtime-provider/podman.test.ts
+++ b/src/lib/onboard/runtime-provider/podman.test.ts
@@ -16,7 +16,6 @@ import {
   type PodmanSocketAuthority,
 } from "../../adapters/podman";
 import type { SandboxEntry, SandboxWorkloadReceipt } from "../../state/registry/types";
-import { withCurrentPortableHostFence } from "../../state/portable-uninstall-retirement";
 import { CURRENT_RUNTIME_PROVIDER_BUNDLES } from "./current";
 import { createPodmanRuntimeProviderBundle } from "./podman";
 import {

--- a/src/lib/onboard/runtime-provider/runtime-provider-contract.test.ts
+++ b/src/lib/onboard/runtime-provider/runtime-provider-contract.test.ts
@@ -24,7 +24,6 @@ import { stopSandbox } from "../../actions/sandbox/stop";
 import { withCurrentPortableHostFence } from "../../state/portable-uninstall-retirement";
 import { loadAgent } from "../../agent/defs";
 import type { SandboxEntry, SandboxWorkloadReceipt } from "../../state/registry/types";
-import { withCurrentPortableHostFence } from "../../state/portable-uninstall-retirement";
 import { cloneSandboxWorkloadReceipt } from "../../state/registry/workload";
 import { createDockerManagedBootstrapSurface } from "../managed-bootstrap/docker-runtime";
 import { MANAGED_IMAGE_REPOSITORIES } from "../managed-image/contract";


### PR DESCRIPTION
## Outcome

Restore CLI typechecking on `main` by removing two duplicate test-helper imports. Runtime behavior is unchanged.

## Reason

#11480 re-added imports that were already introduced by #11506, causing deterministic duplicate-identifier failures in both runtime-provider test files.

### Related issues

Refs #11480
Refs #11506

## Changes

- Remove the duplicate `withCurrentPortableHostFence` import from the Podman test.
- Remove the duplicate `withCurrentPortableHostFence` import from the runtime-provider contract test.

## Verification

- Affected runtime-provider and lifecycle-lock suites — 102/102 passed.
- `NODE_OPTIONS=--max-old-space-size=8192 npm run typecheck:cli` — passed.
- `NODE_OPTIONS=--max-old-space-size=8192 npm run validate:pr` — passed.
- Diff reviewed — no secrets, API keys, credentials, or production-code changes.

## Review notes

This is an isolated two-line test correction based on current `main`; independent review and normal required CI remain required.

---
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused test imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->