### PR TITLE
fix(ci): use supported protected audit verifier flag

### DIFF
--- a/scripts/checks/build-protected-managed-images.sh
+++ b/scripts/checks/build-protected-managed-images.sh
@@ -242,7 +242,7 @@ validate_audit_evidence() {
     --audit-config "$trusted_audit_config" \
     --registry https://registry.yarnpkg.com \
     --threshold high \
-    --legacy-npmjs true \
+    --legacy-audit true \
     --result "$audit_policy_result"
   [[ -f "$audit_policy_result" && -s "$audit_policy_result" && ! -L "$audit_policy_result" ]] || {
     echo "ERROR: protected managed-image reviewed audit policy result is missing or unsafe" >&2


### PR DESCRIPTION
## Outcome

Protected managed-image builds can verify supplied mcporter audit evidence before the offline rebuild.

## Reason

The trusted controller passes `--legacy-npmjs`, but the verifier accepts only `--legacy-audit`. It rejects valid evidence with `verifier arguments has unexpected or missing keys` before Docker starts. Manual PR E2E uses this controller from `main`, so repairing the candidate copy cannot unblock GPU qualification.

### Related issues

Refs #11088. Prerequisite for #11156, following #11370.

## Changes

Replace the obsolete verifier flag with the supported name. One line changes; no new mechanism or test scenario.

## Verification

- Executed the controller's evidence-validation function with a valid receipt and the real verifier: main exited 1; the one-line fix exited 0 and produced a clean policy result.
- Existing controller and receipt tests: 46 passed.
- `npm run validate:pr`: passed on `615eb8afdc9906d22d8eb360b33380122780aad4` against canonical main `189043e740fdab61c8c3fdf6fe9407f438e4d955`.
- No secrets, API keys, or credentials are in the diff.

## Review notes

Self-review covered `scripts/checks/build-protected-managed-images.sh` at `615eb8afdc` in NVIDIA/NemoClaw. Validation used an unprivileged Node 22.23.2 Linux container without host mounts, credentials, or a Docker socket. Independent review is pending. The GPU target remains owned by #11156.

---
Signed-off-by: San Dang <sdang@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated audit receipt verification to use the correct legacy audit option, improving compatibility with protected managed image checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->