### PR TITLE
test(installer): make ACP shim race deterministic

### DIFF
--- a/test/install/install-npm-resolution.test.ts
+++ b/test/install/install-npm-resolution.test.ts
@@ -612,9 +612,11 @@ exec ${JSON.stringify(process.execPath)} "$@"
       const shimPath = path.join(tmp, ".local", "bin", "nemoclaw-acp");
       const packagedCli = path.join(prefixBin, "nemoclaw-acp");
       const targetPath = path.join(tmp, "user-command");
+      const swapLink = path.join(tmp, "replacement-link");
       const foreignContents = Buffer.from("#!/usr/bin/env bash\nprintf 'user-owned\\n'\n");
       fs.mkdirSync(path.dirname(shimPath), { recursive: true });
       fs.writeFileSync(targetPath, foreignContents, { mode: 0o755 });
+      fs.symlinkSync(targetPath, swapLink);
       writeExecutable(
         shimPath,
         [
@@ -627,7 +629,7 @@ exec ${JSON.stringify(process.execPath)} "$@"
 
       const result = runInstallerFunction(
         `shim_path=${JSON.stringify(shimPath)}
-swap_target=${JSON.stringify(targetPath)}
+swap_link=${JSON.stringify(swapLink)}
 identity_calls=${JSON.stringify(path.join(tmp, "identity-calls"))}
 eval "$(declare -f cli_shim_entry_identity | sed '1s/cli_shim_entry_identity/original_cli_shim_entry_identity/')"
 cli_shim_entry_identity() {
@@ -636,8 +638,7 @@ cli_shim_entry_identity() {
   count=$((count + 1))
   printf '%s\\n' "$count" >"$identity_calls"
   if [[ "$count" -eq 3 ]]; then
-    rm -f "$shim_path"
-    ln -s "$swap_target" "$shim_path"
+    mv -f "$swap_link" "$shim_path"
   fi
   original_cli_shim_entry_identity "$@"
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

The ACP shim replacement-race test now deterministically exercises the intended identity-change path instead of occasionally observing a reused inode and accepting a different safe failure path.

## Reason

PR #11458's Linux CLI shard failed because the test removed the original shim before creating its replacement. The filesystem could reuse the deleted inode, causing the installer to report that the shim was no longer managed instead of reporting an identity change. Both outcomes fail closed, but the fixture asserted only the identity-change diagnostic.

### Related issues

Part of #11458.

## Changes

- Create the replacement symlink before the installer reaches the injected race.
- Atomically move that prebuilt symlink over the managed shim so the replacement has a provably distinct identity.
- Preserve the existing assertions that the installer fails, leaves the replacement target untouched, removes temporary files, and emits the intended identity-change diagnostic.

## Verification

- `npx vitest run --project integration test/install/install-npm-resolution.test.ts --coverage=false` — 29/29 tests passed.
- `npx oxfmt --check test/install/install-npm-resolution.test.ts` — passed.
- `npx oxlint test/install/install-npm-resolution.test.ts` — passed.
- Normal pre-commit hooks — passed.
- `node --max-old-space-size=8192 node_modules/typescript/bin/tsc -p tsconfig.cli.json --incremental` — passed after building the repository's CLI and plugin artifacts.
- GitHub commit verification — commit is Verified.
- Diff inspection — no secrets, API keys, or credentials.

## Review notes

This PR intentionally targets `codex/10947-acp-review-repairs`, the source branch of #11458, and contains only the test-fixture correction for its failing CLI shard. No production or user-facing behavior changes, so no documentation update is needed.

---
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>
