### PR TITLE
feat(onboard): configure authenticated external component connections

### DIFF
--- a/src/lib/onboard/docker-driver-gateway-config.ts
+++ b/src/lib/onboard/docker-driver-gateway-config.ts
@@ -19,7 +19,17 @@ import {
   ensureDockerDriverGatewayJwtBundle,
 } from "./docker-driver-gateway-jwt-bundle";
 import { parseDockerDriverGatewayRuntimeMarker } from "./docker-driver-gateway-runtime-marker";
-import type { ExternalComponentDeclaration } from "./external-component";
+import {
+  ExternalComponentContractError,
+  type ExternalComponentGatewayConfiguration,
+} from "./external-component";
+import {
+  externalComponentGatewayNetwork,
+  parseExternalComponentConnections,
+  renderExternalComponentConnections,
+  validateExternalComponentGatewaySettings,
+} from "./external-component/gateway-config";
+import type { ExternalComponentGatewayPreparation } from "./external-component/activation";
 import type { RuntimeProviderGatewayHostRuntime } from "./runtime-provider/contract";
 import {
   resolveConfiguredRuntimeProvider,
@@ -125,16 +135,19 @@ type DockerDriverGatewayIdentity =
       sandboxNamespace: string;
     };
 
-export type ExternalComponentGatewayConfiguration = Pick<
-  ExternalComponentDeclaration,
-  "componentId" | "interceptorSocketPath"
->;
+export type { ExternalComponentGatewayConfiguration } from "./external-component";
 
 function externalComponentGatewayIdentity(
   component: ExternalComponentGatewayConfiguration,
 ): string {
   return createHash("sha256")
-    .update(JSON.stringify([component.componentId, component.interceptorSocketPath]))
+    .update(
+      JSON.stringify(
+        "interceptor" in component
+          ? validateExternalComponentGatewaySettings(component)
+          : [component.componentId, component.interceptorSocketPath],
+      ),
+    )
     .digest("hex");
 }
 
@@ -617,7 +630,12 @@ function existingGatewayIdentityFromConfig(
     const driverConfig = asTomlTable(drivers?.[driver]);
     let externalComponent: ExternalComponentGatewayConfiguration | null;
     try {
-      externalComponent = parseExternalComponentGatewayConfiguration(gateway?.interceptors);
+      const interceptors = gateway?.interceptors;
+      const first = Array.isArray(interceptors) ? asTomlTable(interceptors[0]) : null;
+      externalComponent =
+        typeof first?.grpc_endpoint === "string" && first.grpc_endpoint.startsWith("https://")
+          ? parseExternalComponentConnections(openshell!)
+          : parseExternalComponentGatewayConfiguration(interceptors);
     } catch {
       throw ambiguousGatewayConfig(configPath, "the interceptor configuration is invalid");
     }
@@ -861,6 +879,16 @@ function buildDockerDriverGatewayConfigTomlForIdentity(
     "disable_tls = false",
     "",
   ];
+  if (
+    externalComponent &&
+    "interceptor" in externalComponent &&
+    externalComponent.providerProfileSource
+  ) {
+    sections.push(
+      `provider_profile_sources = [{ type = "interceptor", name = ${tomlString(externalComponent.providerProfileSource)} }]`,
+      "",
+    );
+  }
 
   if (jwtBundle) {
     const tlsDir = localTlsDir ?? gatewayLocalTlsDir(gatewayEnv);
@@ -887,7 +915,12 @@ function buildDockerDriverGatewayConfigTomlForIdentity(
     );
   }
 
-  if (externalComponent) {
+  if (externalComponent && "interceptor" in externalComponent) {
+    if (!jwtBundle) throw new ExternalComponentContractError("declaration_invalid");
+    const settings = validateExternalComponentGatewaySettings(externalComponent);
+    const network = externalComponentGatewayNetwork(gatewayEnv, runtime, settings);
+    sections.push(...renderExternalComponentConnections(settings, network.gatewayIp));
+  } else if (externalComponent) {
     sections.push(
       "[[openshell.gateway.interceptors]]",
       `name = ${tomlString(externalComponent.componentId)}`,
@@ -1020,6 +1053,68 @@ export function writeDockerDriverGatewayConfig(
   );
 }
 
+export function readExternalComponentGatewayPreparation(
+  gatewayEnv: Record<string, string>,
+  component: ExternalComponentGatewayConfiguration,
+  projectedRuntime?: RuntimeProviderGatewayHostRuntime,
+): ExternalComponentGatewayPreparation {
+  if (!("interceptor" in component) || !gatewayEnv.OPENSHELL_GATEWAY_CONFIG) {
+    throw new ExternalComponentContractError("preparation_failed");
+  }
+  const env = { ...gatewayEnv };
+  const stateDir = path.dirname(env.OPENSHELL_GATEWAY_CONFIG!);
+  const runtime = resolveGatewayRuntimeProjection(env, projectedRuntime);
+  const snapshot = () => {
+    const identity = resolveDockerDriverGatewayIdentity(stateDir, env, runtime);
+    let keys: LegacyJwtBundleProof | undefined;
+    try {
+      if (
+        !identity.configProof ||
+        !identity.externalComponent ||
+        externalComponentGatewayIdentity(identity.externalComponent) !==
+          externalComponentGatewayIdentity(component)
+      ) {
+        throw new Error("component configuration changed");
+      }
+      keys = openOwnedLegacyJwtBundle(stateDir, identity.configProof.stateDirIdentity.uid);
+      const read = (filePath: string) =>
+        keys!.files.find((file) => file.path === filePath)!.bytes.toString("utf-8");
+      return {
+        gateway: {
+          id: identity.gatewayId,
+          issuer: `openshell-gateway:${identity.gatewayId}`,
+          publicKeyPem: read(keys.bundle.publicKeyPath),
+          kid: read(keys.bundle.kidPath).trim(),
+          extensionTokenTtlSecs: 900 as const,
+        },
+        network: externalComponentGatewayNetwork(env, runtime, component),
+        config: identity.configProof.bytes.toString("utf-8"),
+      };
+    } finally {
+      if (keys) closeLegacyJwtBundleProof(keys);
+      if (identity.configProof) closeRegularFileProof(identity.configProof);
+      if (identity.kind === "legacy") closeLegacyJwtBundleProof(identity.jwtProof);
+    }
+  };
+  try {
+    const expected = snapshot();
+    return {
+      gateway: expected.gateway,
+      network: expected.network,
+      revalidate() {
+        try {
+          if (!isDeepStrictEqual(snapshot(), expected))
+            throw new Error("gateway preparation changed");
+        } catch {
+          throw new ExternalComponentContractError("preparation_failed");
+        }
+      },
+    };
+  } catch {
+    throw new ExternalComponentContractError("preparation_failed");
+  }
+}
+
 export function prepareDockerDriverGatewayConfigEnv(
   gatewayEnv: Record<string, string>,
   stateDir: string,
@@ -1053,6 +1148,22 @@ export function prepareDockerDriverGatewayConfigEnv(
     options.externalComponent === undefined
       ? identity.externalComponent
       : options.externalComponent;
+  const observedComponentIdentity = externalComponent
+    ? externalComponentGatewayIdentity(externalComponent)
+    : NO_EXTERNAL_COMPONENT_GATEWAY_IDENTITY;
+  const expectedComponentIdentity = gatewayEnv[NEMOCLAW_EXTERNAL_COMPONENT_GATEWAY_IDENTITY_ENV];
+  if (
+    options.externalComponent === undefined &&
+    expectedComponentIdentity !== undefined &&
+    expectedComponentIdentity !== observedComponentIdentity
+  ) {
+    if (identity.configProof) closeRegularFileProof(identity.configProof);
+    if (identity.kind === "legacy") closeLegacyJwtBundleProof(identity.jwtProof);
+    throw ambiguousGatewayConfig(
+      path.join(stateDir, DOCKER_DRIVER_GATEWAY_CONFIG_NAME),
+      "the external component configuration changed",
+    );
+  }
   gatewayEnv.OPENSHELL_GATEWAY_CONFIG = writeDockerDriverGatewayConfigWithIdentity(
     stateDir,
     gatewayEnv,
@@ -1062,9 +1173,7 @@ export function prepareDockerDriverGatewayConfigEnv(
     externalComponent,
   );
   // An explicit absence lets the existing runtime comparison detect removal.
-  gatewayEnv[NEMOCLAW_EXTERNAL_COMPONENT_GATEWAY_IDENTITY_ENV] = externalComponent
-    ? externalComponentGatewayIdentity(externalComponent)
-    : NO_EXTERNAL_COMPONENT_GATEWAY_IDENTITY;
+  gatewayEnv[NEMOCLAW_EXTERNAL_COMPONENT_GATEWAY_IDENTITY_ENV] = observedComponentIdentity;
   if (runtime.gatewayConfig.sandboxNamespace === "omitted") {
     delete gatewayEnv[NEMOCLAW_OPENSHELL_SANDBOX_NAMESPACE_ENV];
   } else {

--- a/src/lib/onboard/docker-driver-gateway-env.ts
+++ b/src/lib/onboard/docker-driver-gateway-env.ts
@@ -24,8 +24,10 @@ import {
   NEMOCLAW_EXTERNAL_COMPONENT_GATEWAY_IDENTITY_ENV,
   NEMOCLAW_OPENSHELL_SANDBOX_NAMESPACE_ENV,
   prepareDockerDriverGatewayConfigEnv,
+  readExternalComponentGatewayPreparation,
   type ExternalComponentGatewayConfiguration,
 } from "./docker-driver-gateway-config";
+import type { ExternalComponentGatewayPreparation } from "./external-component/activation";
 import { buildDockerDriverGatewayLocalTlsEnv } from "./docker-driver-gateway-local-tls";
 import {
   getOpenShellGatewayManagedServiceLogCommand,
@@ -97,7 +99,7 @@ export interface BuildDockerDriverGatewayEnvOptions {
 export function configureDockerDriverGatewayExternalComponent(
   gatewayEnv: Record<string, string>,
   externalComponent: ExternalComponentGatewayConfiguration | null,
-): void {
+): ExternalComponentGatewayPreparation | void {
   const configPath = gatewayEnv.OPENSHELL_GATEWAY_CONFIG;
   if (!configPath) {
     throw new Error("OpenShell Docker-driver gateway requires OPENSHELL_GATEWAY_CONFIG");
@@ -110,6 +112,9 @@ export function configureDockerDriverGatewayExternalComponent(
       externalComponent,
     },
   );
+  if (externalComponent && "interceptor" in externalComponent) {
+    return readExternalComponentGatewayPreparation(gatewayEnv, externalComponent);
+  }
 }
 
 function preparePortableGatewayHostRuntime(

--- a/src/lib/onboard/external-component/README.md
+++ b/src/lib/onboard/external-component/README.md
@@ -11,11 +11,11 @@ The component supplies policy. OpenShell validates effective policy and enforces
 ## Runtime dependency
 
 This v2 implementation requires authenticated interceptor and middleware APIs,
-interceptor-backed provider profiles, and exact authorization for disjoint RPC phases.
+and interceptor-backed provider profiles.
 The current shared runtime pin does not contain all required behavior.
-The local OpenShell candidate is validation evidence, not a qualified release.
+Qualify the accepted behavior against a released runtime before claiming integration support.
 Keep runtime qualification and shared version pins in their existing owner.
-Do not add an insecure transport or dynamic-binding fallback.
+Dynamic registration is the accepted v2 contract. Do not add an insecure transport fallback.
 
 ## Declaration
 
@@ -31,17 +31,7 @@ V2 contains these fields only:
   "interceptor": {
     "endpoint": "https://127.0.0.1:9443",
     "caCertificatePath": "/run/user/1000/component/ca.pem",
-    "audience": "urn:generic:admission",
-    "bindings": [
-      {
-        "rpc": "openshell.v1.OpenShell/CreateSandbox",
-        "phases": ["modify_operation", "validate"]
-      },
-      {
-        "rpc": "openshell.v1.OpenShell/CreateSandbox",
-        "phases": ["post_commit"]
-      }
-    ]
+    "audience": "urn:generic:admission"
   },
   "middleware": {
     "name": "generic/middleware",
@@ -58,12 +48,12 @@ The middleware endpoint must use the fixed `host.openshell.internal` selector wi
 NemoClaw resolves this selector to the inspected Docker bridge address and writes an IP endpoint.
 It does not perform a DNS lookup or accept arbitrary host addresses.
 
-Bindings authorize RPC and phase pairs exactly. Admission failures close the operation.
-A post-commit phase must occupy its own group and uses `fail_open`, because the operation has already committed.
-Duplicate or overlapping phases are invalid. `CreateSandbox` and `UpdateConfig` support all three phases.
-The other accepted RPCs support validation only: `CreateProvider`, `UpdateProvider`, `ImportProviderProfiles`,
-`UpdateProviderProfiles`, `DeleteProviderProfile`, `SubmitPolicyAnalysis`, `ApproveDraftChunk`, and `ApproveAllDraftChunks`.
-OpenShell remains responsible for manifest compatibility and middleware binding validation.
+The authenticated component's manifest owns callback selection and callback failure behavior.
+NemoClaw configures `binding_policy = "dynamic"` with no binding or failure-policy overrides.
+New supported callbacks are trusted. Missing callbacks do not trigger a strict-registration failure.
+A callback's explicit failure policy can override the manifest's service default, including a `fail_closed` default.
+Tests must verify the component's required checks and their allowed and denied outcomes.
+OpenShell validates supported RPCs, phases, manifests, and middleware bindings, and retains enforcement authority.
 
 `providerProfileSource` is optional. When present, it must name this interceptor.
 It selects the interceptor as the sole profile source; unresolved profiles cannot fall back to built-in or user profiles.
@@ -82,14 +72,14 @@ The JSON request has `schemaVersion: 2`, a random `preparationId`, `componentId`
 
 - `gateway`: `name`, `id`, `issuer`, `publicKeyPem`, `kid`, and `extensionTokenTtlSecs: 900`.
 - `network`: the inspected `gatewayIp` and `subnet`.
-- `interceptor` and `middleware`: the validated declaration settings, including ports, CA paths, audiences, and bindings.
+- `interceptor` and `middleware`: the validated declaration settings, including ports, CA paths and audiences.
 - `providerProfileSource`: included only when declared.
 
 The component uses the public key to verify OpenShell's EdDSA extension credentials.
 It must check the issuer, audience, key ID, token type, expiration, and caller identity.
 The gateway signing key stays in NemoClaw's protected state directory. It is never sent to the component.
 OpenShell mints and refreshes extension credentials; they expire after 900 seconds with the existing gateway settings.
-Removing component registration removes future delivery. Existing credentials remain valid until their expiration.
+Restarting the gateway without component registration removes future delivery. Existing credentials remain valid until their expiration.
 
 The component replies with HTTP 200 and exactly four JSON fields:
 `schemaVersion: 2`, the matching `preparationId`, the matching `componentId`, and `result: "prepared"`.

--- a/src/lib/onboard/external-component/README.md
+++ b/src/lib/onboard/external-component/README.md
@@ -1,0 +1,115 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# External component connections
+
+Issue #11507 extends the existing component contract for fresh Linux onboarding.
+The v1 declaration and `/v1/activate` protocol retain their existing behavior.
+NemoClaw writes the generated OpenShell configuration and owns the gateway lifecycle.
+The component supplies policy. OpenShell validates effective policy and enforces it.
+
+## Runtime dependency
+
+This v2 implementation requires authenticated interceptor and middleware APIs,
+interceptor-backed provider profiles, and exact authorization for disjoint RPC phases.
+The current shared runtime pin does not contain all required behavior.
+The local OpenShell candidate is validation evidence, not a qualified release.
+Keep runtime qualification and shared version pins in their existing owner.
+Do not add an insecure transport or dynamic-binding fallback.
+
+## Declaration
+
+The operator installs the existing `external-component.json` file with mode `0600`.
+Existing declaration ownership, parent-directory, and activation-socket checks apply.
+V2 contains these fields only:
+
+```json
+{
+  "schemaVersion": 2,
+  "componentId": "generic/policy",
+  "activationSocketPath": "/run/user/1000/component/activation.sock",
+  "interceptor": {
+    "endpoint": "https://127.0.0.1:9443",
+    "caCertificatePath": "/run/user/1000/component/ca.pem",
+    "audience": "urn:generic:admission",
+    "bindings": [
+      {
+        "rpc": "openshell.v1.OpenShell/CreateSandbox",
+        "phases": ["modify_operation", "validate"]
+      },
+      {
+        "rpc": "openshell.v1.OpenShell/CreateSandbox",
+        "phases": ["post_commit"]
+      }
+    ]
+  },
+  "middleware": {
+    "name": "generic/middleware",
+    "endpoint": "https://host.openshell.internal:9444",
+    "caCertificatePath": "/run/user/1000/component/ca.pem",
+    "audience": "urn:generic:middleware"
+  },
+  "providerProfileSource": "generic/policy"
+}
+```
+
+`componentId` is also the interceptor registration name. Names cannot use the reserved `openshell/` prefix.
+The middleware endpoint must use the fixed `host.openshell.internal` selector with an explicit port.
+NemoClaw resolves this selector to the inspected Docker bridge address and writes an IP endpoint.
+It does not perform a DNS lookup or accept arbitrary host addresses.
+
+Bindings authorize RPC and phase pairs exactly. Admission failures close the operation.
+A post-commit phase must occupy its own group and uses `fail_open`, because the operation has already committed.
+Duplicate or overlapping phases are invalid. `CreateSandbox` and `UpdateConfig` support all three phases.
+The other accepted RPCs support validation only: `CreateProvider`, `UpdateProvider`, `ImportProviderProfiles`,
+`UpdateProviderProfiles`, `DeleteProviderProfile`, `SubmitPolicyAnalysis`, `ApproveDraftChunk`, and `ApproveAllDraftChunks`.
+OpenShell remains responsible for manifest compatibility and middleware binding validation.
+
+`providerProfileSource` is optional. When present, it must name this interceptor.
+It selects the interceptor as the sole profile source; unresolved profiles cannot fall back to built-in or user profiles.
+NemoClaw does not distribute profiles or evaluate profile content.
+
+## Preparation
+
+The component must create its CA files and protected activation socket before onboarding.
+CA files must contain currently valid CA certificates only, with protected parents and no symlinks or hardlinks.
+Root or the current user must own the files. Group and other users must not have write access.
+NemoClaw checks file identity and content again before startup and activation.
+The component may create its listener certificates after receiving the bridge address; it must retain the pinned CA files.
+
+After writing configuration and generating gateway keys, NemoClaw sends `POST /v2/prepare` on the activation socket.
+The JSON request has `schemaVersion: 2`, a random `preparationId`, `componentId`, and these objects:
+
+- `gateway`: `name`, `id`, `issuer`, `publicKeyPem`, `kid`, and `extensionTokenTtlSecs: 900`.
+- `network`: the inspected `gatewayIp` and `subnet`.
+- `interceptor` and `middleware`: the validated declaration settings, including ports, CA paths, audiences, and bindings.
+- `providerProfileSource`: included only when declared.
+
+The component uses the public key to verify OpenShell's EdDSA extension credentials.
+It must check the issuer, audience, key ID, token type, expiration, and caller identity.
+The gateway signing key stays in NemoClaw's protected state directory. It is never sent to the component.
+OpenShell mints and refreshes extension credentials; they expire after 900 seconds with the existing gateway settings.
+Removing component registration removes future delivery. Existing credentials remain valid until their expiration.
+
+The component replies with HTTP 200 and exactly four JSON fields:
+`schemaVersion: 2`, the matching `preparationId`, the matching `componentId`, and `result: "prepared"`.
+It may return `result: "rejected"` to refuse preparation.
+The existing transport requires a bounded `Content-Length`, rejects ambiguous framing, and closes after each request.
+The response limit is 1 MiB, with a 16 KiB header limit and a 30-second total deadline. NemoClaw does not retry.
+Any preparation error prevents gateway startup. Preparation errors contain no service diagnostics.
+
+The listener must retain the same protected socket inode through preparation and activation.
+The component associates the later activation with the prepared `componentId` and `gateway.name`.
+It verifies the sandbox against the prepared gateway identity before acknowledging activation.
+The existing activation UUID, effective-policy proof, failure classification, and incomplete-activation state remain unchanged.
+
+NemoClaw revalidates declaration, socket, CA files, generated configuration, gateway keys, and bridge addressing.
+OpenShell performs authenticated registration after successful preparation and rejects missing or incompatible services.
+NemoClaw does not install or supervise those services.
+
+## Validation
+
+`connections.test.ts` covers declaration restrictions, trust files, generated configuration, drift, and preparation.
+Existing activation and gateway-handler tests cover bounded transport, incomplete activation, and unchanged v1 behavior.
+Real OpenShell registration, policy and profile delivery, sandbox identity, and middleware outcomes require live evidence.
+Record NemoClaw, OpenShell, and combined #11486 revisions separately. Mocked results do not qualify the integration.

--- a/src/lib/onboard/external-component/activation.ts
+++ b/src/lib/onboard/external-component/activation.ts
@@ -8,6 +8,7 @@ import {
   EXTERNAL_COMPONENT_ACTIVATION_TIMEOUT_MS,
   EXTERNAL_COMPONENT_MAX_RESPONSE_BYTES,
   EXTERNAL_COMPONENT_SCHEMA_VERSION,
+  ExternalComponentContractError,
   parseStrictExternalComponentJson,
   type PreparedExternalComponent,
 } from "./index";
@@ -136,7 +137,11 @@ export function parseExternalComponentHttpResponse(raw: Buffer): string {
   return raw.subarray(bodyStart).toString("utf-8");
 }
 
-export function sendExternalComponentActivation(socketPath: string, body: string): Promise<string> {
+export function sendExternalComponentActivation(
+  socketPath: string,
+  body: string,
+  route: "/v1/activate" | "/v2/prepare" = "/v1/activate",
+): Promise<string> {
   return new Promise((resolve, reject) => {
     const request = Buffer.from(body, "utf-8");
     const socket = net.createConnection({ path: socketPath });
@@ -159,7 +164,7 @@ export function sendExternalComponentActivation(socketPath: string, body: string
     deadline.unref();
     socket.once("connect", () => {
       socket.write(
-        `POST /v1/activate HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nAccept: application/json\r\nContent-Length: ${String(request.length)}\r\nConnection: close\r\n\r\n${body}`,
+        `POST ${route} HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nAccept: application/json\r\nContent-Length: ${String(request.length)}\r\nConnection: close\r\n\r\n${body}`,
       );
     });
     socket.on("data", (chunk: Buffer) => {
@@ -190,6 +195,61 @@ export function sendExternalComponentActivation(socketPath: string, body: string
     });
     socket.once("error", () => finish(new Error("connection")));
   });
+}
+
+export interface ExternalComponentGatewayPreparation {
+  readonly gateway: {
+    readonly id: string;
+    readonly issuer: string;
+    readonly publicKeyPem: string;
+    readonly kid: string;
+    readonly extensionTokenTtlSecs: 900;
+  };
+  readonly network: { readonly gatewayIp: string; readonly subnet: string };
+  revalidate(): void;
+}
+
+export async function prepareExternalComponentGateway(
+  component: PreparedExternalComponent,
+  gatewayName: string,
+  preparation: ExternalComponentGatewayPreparation | void,
+  transport: typeof sendExternalComponentActivation = sendExternalComponentActivation,
+): Promise<void> {
+  if (component.declaration.schemaVersion !== 2) return;
+  try {
+    if (!preparation || !component.setGatewayRevalidation) throw new Error("missing gateway proof");
+    component.setGatewayRevalidation(() => preparation.revalidate());
+    component.revalidateBeforeGateway();
+    const declaration = component.declaration;
+    const preparationId = randomUUID();
+    const body = JSON.stringify({
+      schemaVersion: 2,
+      preparationId,
+      componentId: declaration.componentId,
+      gateway: { name: gatewayName, ...preparation.gateway },
+      network: preparation.network,
+      interceptor: declaration.interceptor,
+      middleware: declaration.middleware,
+      ...(declaration.providerProfileSource
+        ? { providerProfileSource: declaration.providerProfileSource }
+        : {}),
+    });
+    const raw = await transport(declaration.activationSocketPath, body, "/v2/prepare");
+    const response = parseStrictExternalComponentJson(raw);
+    if (
+      !isRecord(response) ||
+      Object.keys(response).sort().join(",") !== "componentId,preparationId,result,schemaVersion" ||
+      response.schemaVersion !== 2 ||
+      response.preparationId !== preparationId ||
+      response.componentId !== declaration.componentId ||
+      response.result !== "prepared"
+    ) {
+      throw new Error("preparation rejected");
+    }
+    component.revalidateBeforeGateway();
+  } catch {
+    throw new ExternalComponentContractError("preparation_failed");
+  }
 }
 
 export async function activateExternalComponent(

--- a/src/lib/onboard/external-component/connections.test.ts
+++ b/src/lib/onboard/external-component/connections.test.ts
@@ -1,0 +1,417 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import http from "node:http";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { parse as parseToml } from "smol-toml";
+import { PEM, LEAF_PEM, PRIVATE_KEY } from "../__test-helpers__/corporate-ca-fixtures";
+import { baseGatewayEnv } from "../../../../test/support/openshell-gateway-config-helpers";
+import { resolveRegisteredRuntimeProvider } from "../runtime-provider/selection";
+import {
+  prepareDockerDriverGatewayConfigEnv,
+  readExternalComponentGatewayPreparation,
+} from "../docker-driver-gateway-config";
+import {
+  captureExternalComponentTrust,
+  gatewayConfigurationForExternalComponent,
+  loadExternalComponentDeclaration,
+  parseExternalComponentDeclaration,
+  type ExternalComponentDeclarationV2,
+} from "./index";
+import { prepareExternalComponentGateway, sendExternalComponentActivation } from "./activation";
+
+const roots: string[] = [];
+const servers: http.Server[] = [];
+afterEach(async () => {
+  await Promise.all(
+    servers
+      .splice(0)
+      .map((server) => new Promise<void>((resolve) => server.close(() => resolve()))),
+  );
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+function declaration(caCertificatePath = "/run/component/ca.pem"): ExternalComponentDeclarationV2 {
+  return {
+    schemaVersion: 2,
+    componentId: "generic/policy",
+    activationSocketPath: "/run/component/activate.sock",
+    interceptor: {
+      endpoint: "https://127.0.0.1:9443",
+      caCertificatePath,
+      audience: "urn:generic:admission",
+      bindings: [
+        { rpc: "openshell.v1.OpenShell/CreateSandbox", phases: ["modify_operation", "validate"] },
+        { rpc: "openshell.v1.OpenShell/UpdateConfig", phases: ["modify_operation", "validate"] },
+        { rpc: "openshell.v1.OpenShell/CreateSandbox", phases: ["post_commit"] },
+        { rpc: "openshell.v1.OpenShell/UpdateConfig", phases: ["post_commit"] },
+      ],
+    },
+    middleware: {
+      name: "generic/middleware",
+      endpoint: "https://host.openshell.internal:9444",
+      caCertificatePath,
+      audience: "urn:generic:middleware",
+    },
+    providerProfileSource: "generic/policy",
+  };
+}
+
+function fixture() {
+  const root = fs.mkdtempSync(path.join(path.dirname(process.cwd()), "nc-connections-"));
+  roots.push(root);
+  const ca = path.join(root, "ca.pem");
+  fs.writeFileSync(ca, PEM, { mode: 0o600 });
+  const state = path.join(root, "gateway");
+  fs.mkdirSync(state, { mode: 0o700 });
+  const env = baseGatewayEnv(state);
+  const component = declaration(ca);
+  const provider = resolveRegisteredRuntimeProvider("docker")!;
+  const gateway = provider.gateway as Extract<typeof provider.gateway, { supported: true }>;
+  const observed = gateway.observeHostRuntime({ environment: env, platform: "linux" });
+  const inspect = vi.fn(() => ({ gatewayIp: "172.30.115.1", subnet: "172.30.115.0/24" }));
+  const runtime = { ...observed, network: { ...observed.network, inspect } };
+  const settings = gatewayConfigurationForExternalComponent(component);
+  const write = () =>
+    prepareDockerDriverGatewayConfigEnv(env, state, "/usr/bin/openshell-sandbox", {
+      gatewayRuntime: runtime,
+      externalComponent: settings,
+    });
+  return { root, ca, state, env, component, settings, runtime, inspect, write };
+}
+
+describe("external component connection declaration", () => {
+  it("accepts protected connection references and separate admission and observation phases (#11507)", () => {
+    const parsed = parseExternalComponentDeclaration(JSON.stringify(declaration()));
+    expect(parsed).toEqual(declaration());
+    expect(Object.isFrozen(parsed)).toBe(true);
+  });
+
+  it.each([
+    ["HTTP", "http://127.0.0.1:9443"],
+    ["remote hosts", "https://example.com:9443"],
+    ["alternate loopback addresses", "https://127.1:9443"],
+    ["credentials", "https://user:pass@127.0.0.1:9443"],
+    ["paths", "https://127.0.0.1:9443/rpc"],
+    ["queries", "https://127.0.0.1:9443?key=value"],
+    ["fragments", "https://127.0.0.1:9443#fragment"],
+    ["missing ports", "https://127.0.0.1"],
+    ["wildcards", "https://0.0.0.0:9443"],
+    ["invalid ports", "https://127.0.0.1:65536"],
+  ])("rejects interceptor endpoints with %s (#11507)", (_title, endpoint) => {
+    const value = declaration();
+    expect(() =>
+      parseExternalComponentDeclaration(
+        JSON.stringify({ ...value, interceptor: { ...value.interceptor, endpoint } }),
+      ),
+    ).toThrow(/endpoint_restricted/);
+  });
+
+  it.each(["https://127.0.0.1:9444", "https://172.30.115.1:9444", "https://example.com:9444"])(
+    "requires the managed bridge selector for middleware endpoint %s (#11507)",
+    (endpoint) => {
+      const value = declaration();
+      expect(() =>
+        parseExternalComponentDeclaration(
+          JSON.stringify({ ...value, middleware: { ...value.middleware, endpoint } }),
+        ),
+      ).toThrow(/endpoint_restricted/);
+    },
+  );
+
+  it.each([
+    ["unrecognized RPC", [{ rpc: "openshell.v1.OpenShell/DeleteSandbox", phases: ["validate"] }]],
+    ["wildcard RPC", [{ rpc: "openshell.v1.OpenShell/*", phases: ["validate"] }]],
+    ["unknown phase", [{ rpc: "openshell.v1.OpenShell/CreateSandbox", phases: ["before"] }]],
+    [
+      "overlapping phases",
+      [{ rpc: "openshell.v1.OpenShell/CreateSandbox", phases: ["validate", "validate"] }],
+    ],
+    [
+      "mixed failure behavior",
+      [{ rpc: "openshell.v1.OpenShell/CreateSandbox", phases: ["validate", "post_commit"] }],
+    ],
+    [
+      "unauthorized provider mutation",
+      [{ rpc: "openshell.v1.OpenShell/CreateProvider", phases: ["modify_operation"] }],
+    ],
+    ["empty bindings", []],
+  ])("rejects %s (#11507)", (_title, bindings) => {
+    const value = declaration();
+    expect(() =>
+      parseExternalComponentDeclaration(
+        JSON.stringify({ ...value, interceptor: { ...value.interceptor, bindings } }),
+      ),
+    ).toThrow(/binding_unauthorized/);
+  });
+
+  it("rejects overlapping phase groups and unknown nested settings (#11507)", () => {
+    const value = declaration();
+    expect(() =>
+      parseExternalComponentDeclaration(
+        JSON.stringify({
+          ...value,
+          interceptor: {
+            ...value.interceptor,
+            bindings: [...value.interceptor.bindings, value.interceptor.bindings[0]],
+          },
+        }),
+      ),
+    ).toThrow(/binding_unauthorized/);
+    expect(() =>
+      parseExternalComponentDeclaration(
+        JSON.stringify({
+          ...value,
+          interceptor: { ...value.interceptor, allowInsecureTransport: true },
+        }),
+      ),
+    ).toThrow(/declaration_unknown_field/);
+    expect(() =>
+      parseExternalComponentDeclaration(
+        JSON.stringify({ ...value, providerProfileSource: "unregistered" }),
+      ),
+    ).toThrow(/declaration_invalid/);
+  });
+});
+
+describe("external component trust", () => {
+  it.each(["", "invalid PEM", LEAF_PEM, PEM + PRIVATE_KEY, PEM + "unrecognized text"])(
+    "rejects invalid certificate content %# (#11507)",
+    (content) => {
+      const f = fixture();
+      fs.writeFileSync(f.ca, content);
+      expect(() => captureExternalComponentTrust(f.ca)).toThrow(/trust_invalid/);
+    },
+  );
+
+  it("rejects expired and not-yet-valid trust (#11507)", () => {
+    const f = fixture();
+    vi.spyOn(Date, "now").mockReturnValue(Date.parse("2040-01-01"));
+    expect(() => captureExternalComponentTrust(f.ca)).toThrow(/trust_invalid/);
+    vi.spyOn(Date, "now").mockReturnValue(Date.parse("2020-01-01"));
+    expect(() => captureExternalComponentTrust(f.ca)).toThrow(/trust_invalid/);
+  });
+
+  it.each(["symlink", "hardlink", "writable file", "writable parent", "directory", "oversized"])(
+    "rejects a trust path with %s (#11507)",
+    (kind) => {
+      const f = fixture();
+      const mutations: Record<string, () => string> = {
+        symlink: () => {
+          const target = path.join(f.root, "link.pem");
+          fs.symlinkSync(f.ca, target);
+          return target;
+        },
+        hardlink: () => {
+          fs.linkSync(f.ca, path.join(f.root, "other.pem"));
+          return f.ca;
+        },
+        "writable file": () => {
+          fs.chmodSync(f.ca, 0o666);
+          return f.ca;
+        },
+        "writable parent": () => {
+          fs.chmodSync(f.root, 0o777);
+          return f.ca;
+        },
+        directory: () => f.root,
+        oversized: () => {
+          fs.writeFileSync(f.ca, "x".repeat(65537));
+          return f.ca;
+        },
+      };
+      const target = mutations[kind]!();
+      expect(() => captureExternalComponentTrust(target)).toThrow(/trust_invalid/);
+    },
+  );
+
+  it("detects replacement and content drift after pinning public trust (#11507)", () => {
+    const f = fixture();
+    const proof = captureExternalComponentTrust(f.ca);
+    proof.revalidate();
+    fs.appendFileSync(f.ca, "\n");
+    expect(() => proof.revalidate()).toThrow(/trust_changed/);
+    fs.writeFileSync(f.ca, PEM);
+    fs.renameSync(f.ca, `${f.ca}.old`);
+    fs.writeFileSync(f.ca, PEM, { mode: 0o600 });
+    expect(() => proof.revalidate()).toThrow(/trust_changed/);
+  });
+});
+
+describe("managed gateway connection configuration", () => {
+  it("writes authenticated connections, authoritative profiles, and distinct failure policies (#11507)", () => {
+    const f = fixture();
+    f.write();
+    const config = fs.readFileSync(f.env.OPENSHELL_GATEWAY_CONFIG!, "utf-8");
+    const parsed = parseToml(config) as any;
+    const gateway = parsed.openshell.gateway;
+    expect(gateway.provider_profile_sources).toEqual([
+      { type: "interceptor", name: f.component.componentId },
+    ]);
+    expect(gateway.interceptors[0]).toMatchObject({
+      binding_policy: "exact",
+      failure_policy: "fail_closed",
+      allow_insecure_transport: false,
+      audience: f.component.interceptor.audience,
+    });
+    expect(gateway.interceptors[0].bindings.map((binding: any) => binding.failure_policy)).toEqual([
+      "fail_closed",
+      "fail_closed",
+      "fail_open",
+      "fail_open",
+    ]);
+    expect(parsed.openshell.supervisor.middleware[0]).toMatchObject({
+      grpc_endpoint: "https://172.30.115.1:9444",
+      allow_insecure_transport: false,
+    });
+    expect(() => f.write()).not.toThrow();
+    expect(fs.readFileSync(f.env.OPENSHELL_GATEWAY_CONFIG!, "utf-8")).toBe(config);
+    const preparation = readExternalComponentGatewayPreparation(f.env, f.settings, f.runtime);
+    expect(preparation.gateway.publicKeyPem).toContain("BEGIN PUBLIC KEY");
+    expect(preparation.gateway.extensionTokenTtlSecs).toBe(900);
+    expect(preparation.network).toEqual({ gatewayIp: "172.30.115.1", subnet: "172.30.115.0/24" });
+    expect(JSON.stringify(preparation)).not.toContain("PRIVATE");
+    preparation.revalidate();
+  });
+
+  it.each([
+    'binding_policy = "exact"',
+    "allow_insecure_transport = false",
+    "172.30.115.1",
+    "ca-sha256",
+  ])("refuses to replace changed configuration at %s (#11507)", (setting) => {
+    const f = fixture();
+    f.write();
+    const file = f.env.OPENSHELL_GATEWAY_CONFIG!;
+    const changed = fs.readFileSync(file, "utf-8").replace(setting, `${setting}-changed`);
+    fs.writeFileSync(file, changed);
+    expect(() => f.write()).toThrow();
+    expect(fs.readFileSync(file, "utf-8")).toBe(changed);
+  });
+
+  it("rejects network and CA drift after configuration and public handoff (#11507)", () => {
+    const f = fixture();
+    f.write();
+    const preparation = readExternalComponentGatewayPreparation(f.env, f.settings, f.runtime);
+    f.inspect.mockReturnValue({ gatewayIp: "172.30.116.1", subnet: "172.30.116.0/24" });
+    expect(() => preparation.revalidate()).toThrow(/preparation_failed/);
+    expect(() => f.write()).toThrow();
+    f.inspect.mockReturnValue({ gatewayIp: "172.30.115.1", subnet: "172.30.115.0/24" });
+    fs.appendFileSync(f.ca, "\n");
+    expect(() => preparation.revalidate()).toThrow(/preparation_failed/);
+    expect(() => f.write()).toThrow();
+  });
+
+  it("rejects a missing managed bridge before writing component configuration (#11507)", () => {
+    const f = fixture();
+    f.inspect.mockReturnValue({ gatewayIp: "", subnet: "" });
+    expect(() => f.write()).toThrow(/endpoint_restricted/);
+    expect(fs.existsSync(f.env.OPENSHELL_GATEWAY_CONFIG ?? "")).toBe(false);
+  });
+
+  it("detects removal of the component before launch rewrites configuration (#11507)", () => {
+    const f = fixture();
+    f.write();
+    const expectedEnv = { ...f.env };
+    prepareDockerDriverGatewayConfigEnv(f.env, f.state, "/usr/bin/openshell-sandbox", {
+      gatewayRuntime: f.runtime,
+      externalComponent: null,
+    });
+    const removed = fs.readFileSync(f.env.OPENSHELL_GATEWAY_CONFIG!, "utf-8");
+    expect(() =>
+      prepareDockerDriverGatewayConfigEnv(expectedEnv, f.state, "/usr/bin/openshell-sandbox", {
+        gatewayRuntime: f.runtime,
+      }),
+    ).toThrow(/external component configuration changed/);
+    expect(fs.readFileSync(f.env.OPENSHELL_GATEWAY_CONFIG!, "utf-8")).toBe(removed);
+  });
+});
+
+async function preparedFixture(response: (request: Record<string, any>) => unknown) {
+  const f = fixture();
+  f.write();
+  const socket = path.join(f.root, "activate.sock");
+  const server = http.createServer((request, reply) => {
+    let body = "";
+    request.on("data", (chunk) => {
+      body += String(chunk);
+    });
+    request.on("end", () => {
+      expect(request.url).toBe("/v2/prepare");
+      const result = JSON.stringify(response(JSON.parse(body)));
+      reply.writeHead(200, { "content-length": Buffer.byteLength(result), connection: "close" });
+      reply.end(result);
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(socket, resolve));
+  servers.push(server);
+  fs.chmodSync(socket, 0o600);
+  const declarationPath = path.join(f.root, "external-component.json");
+  fs.writeFileSync(
+    declarationPath,
+    JSON.stringify({ ...f.component, activationSocketPath: socket }),
+    { mode: 0o600 },
+  );
+  const component = loadExternalComponentDeclaration({
+    declarationPath,
+    homeDirectory: f.root,
+    platform: "linux",
+  })!;
+  const preparation = readExternalComponentGatewayPreparation(f.env, f.settings, f.runtime);
+  return { ...f, component, preparation, socket };
+}
+
+describe("component preparation", () => {
+  it("delivers public identity and resolves service preparation on the existing socket (#11507)", async () => {
+    const requests: Record<string, any>[] = [];
+    const f = await preparedFixture((request) => {
+      requests.push(request);
+      return {
+        schemaVersion: 2,
+        preparationId: request.preparationId,
+        componentId: request.componentId,
+        result: "prepared",
+      };
+    });
+    await prepareExternalComponentGateway(f.component, "generic-gateway", f.preparation);
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.gateway).toMatchObject({
+      name: "generic-gateway",
+      extensionTokenTtlSecs: 900,
+    });
+    expect(requests[0]?.network.gatewayIp).toBe("172.30.115.1");
+    expect(JSON.stringify(requests)).not.toContain("PRIVATE");
+    f.component.revalidateBeforeActivation();
+    fs.appendFileSync(f.ca, "\n");
+    expect(() => f.component.revalidateBeforeActivation()).toThrow(/trust_changed/);
+  });
+
+  it.each(["rejected", "wrong identity", "unknown field"])(
+    "fails closed when preparation returns %s (#11507)",
+    async (kind) => {
+      const f = await preparedFixture((request) => ({
+        schemaVersion: 2,
+        preparationId: kind === "wrong identity" ? "wrong" : request.preparationId,
+        componentId: request.componentId,
+        result: kind === "rejected" ? "rejected" : "prepared",
+        ...(kind === "unknown field" ? { command: "ignored" } : {}),
+      }));
+      await expect(
+        prepareExternalComponentGateway(f.component, "generic-gateway", f.preparation),
+      ).rejects.toThrow(/preparation_failed/);
+    },
+  );
+
+  it("does not retry failed preparation or expose transport diagnostics (#11507)", async () => {
+    const f = await preparedFixture(() => ({}));
+    const transport = vi
+      .fn<typeof sendExternalComponentActivation>()
+      .mockRejectedValue(new Error("private transport detail"));
+    await expect(
+      prepareExternalComponentGateway(f.component, "generic-gateway", f.preparation, transport),
+    ).rejects.toThrow(/preparation_failed/);
+    expect(transport).toHaveBeenCalledOnce();
+  });
+});

--- a/src/lib/onboard/external-component/connections.test.ts
+++ b/src/lib/onboard/external-component/connections.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import fs from "node:fs";
+import assert from "node:assert/strict";
 import http from "node:http";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -9,6 +10,8 @@ import { parse as parseToml } from "smol-toml";
 import { PEM, LEAF_PEM, PRIVATE_KEY } from "../__test-helpers__/corporate-ca-fixtures";
 import { baseGatewayEnv } from "../../../../test/support/openshell-gateway-config-helpers";
 import { resolveRegisteredRuntimeProvider } from "../runtime-provider/selection";
+import * as runtimeSelection from "../runtime-provider/selection";
+import { configureDockerDriverGatewayExternalComponent } from "../docker-driver-gateway-env";
 import {
   prepareDockerDriverGatewayConfigEnv,
   readExternalComponentGatewayPreparation,
@@ -73,7 +76,7 @@ function fixture() {
       gatewayRuntime: runtime,
       externalComponent: settings,
     });
-  return { root, ca, state, env, component, settings, runtime, inspect, write };
+  return { root, ca, state, env, component, settings, runtime, provider, gateway, inspect, write };
 }
 
 describe("external component connection declaration", () => {
@@ -223,7 +226,12 @@ describe("managed gateway connection configuration", () => {
     });
     expect(() => f.write()).not.toThrow();
     expect(fs.readFileSync(f.env.OPENSHELL_GATEWAY_CONFIG!, "utf-8")).toBe(config);
-    const preparation = readExternalComponentGatewayPreparation(f.env, f.settings, f.runtime);
+    vi.spyOn(runtimeSelection, "resolveConfiguredRuntimeProvider").mockReturnValue({
+      ...f.provider,
+      gateway: { ...f.gateway, observeHostRuntime: () => f.runtime },
+    });
+    const preparation = configureDockerDriverGatewayExternalComponent(f.env, f.settings);
+    assert.ok(preparation, "configuration must return the component preparation");
     expect(preparation.gateway.publicKeyPem).toContain("BEGIN PUBLIC KEY");
     expect(preparation.gateway.extensionTokenTtlSecs).toBe(900);
     expect(preparation.network).toEqual({ gatewayIp: "172.30.115.1", subnet: "172.30.115.0/24" });

--- a/src/lib/onboard/external-component/connections.test.ts
+++ b/src/lib/onboard/external-component/connections.test.ts
@@ -42,12 +42,6 @@ function declaration(caCertificatePath = "/run/component/ca.pem"): ExternalCompo
       endpoint: "https://127.0.0.1:9443",
       caCertificatePath,
       audience: "urn:generic:admission",
-      bindings: [
-        { rpc: "openshell.v1.OpenShell/CreateSandbox", phases: ["modify_operation", "validate"] },
-        { rpc: "openshell.v1.OpenShell/UpdateConfig", phases: ["modify_operation", "validate"] },
-        { rpc: "openshell.v1.OpenShell/CreateSandbox", phases: ["post_commit"] },
-        { rpc: "openshell.v1.OpenShell/UpdateConfig", phases: ["post_commit"] },
-      ],
     },
     middleware: {
       name: "generic/middleware",
@@ -83,7 +77,7 @@ function fixture() {
 }
 
 describe("external component connection declaration", () => {
-  it("accepts protected connection references and separate admission and observation phases (#11507)", () => {
+  it("accepts protected connection references for a component-owned manifest (#11507)", () => {
     const parsed = parseExternalComponentDeclaration(JSON.stringify(declaration()));
     expect(parsed).toEqual(declaration());
     expect(Object.isFrozen(parsed)).toBe(true);
@@ -121,56 +115,22 @@ describe("external component connection declaration", () => {
     },
   );
 
-  it.each([
-    ["unrecognized RPC", [{ rpc: "openshell.v1.OpenShell/DeleteSandbox", phases: ["validate"] }]],
-    ["wildcard RPC", [{ rpc: "openshell.v1.OpenShell/*", phases: ["validate"] }]],
-    ["unknown phase", [{ rpc: "openshell.v1.OpenShell/CreateSandbox", phases: ["before"] }]],
-    [
-      "overlapping phases",
-      [{ rpc: "openshell.v1.OpenShell/CreateSandbox", phases: ["validate", "validate"] }],
-    ],
-    [
-      "mixed failure behavior",
-      [{ rpc: "openshell.v1.OpenShell/CreateSandbox", phases: ["validate", "post_commit"] }],
-    ],
-    [
-      "unauthorized provider mutation",
-      [{ rpc: "openshell.v1.OpenShell/CreateProvider", phases: ["modify_operation"] }],
-    ],
-    ["empty bindings", []],
-  ])("rejects %s (#11507)", (_title, bindings) => {
-    const value = declaration();
-    expect(() =>
-      parseExternalComponentDeclaration(
-        JSON.stringify({ ...value, interceptor: { ...value.interceptor, bindings } }),
-      ),
-    ).toThrow(/binding_unauthorized/);
-  });
+  it.each(["bindings", "failurePolicy", "bindingPolicy", "allowInsecureTransport"])(
+    "rejects declaration overrides of %s (#11507)",
+    (field) => {
+      const value = declaration();
+      expect(() =>
+        parseExternalComponentDeclaration(
+          JSON.stringify({ ...value, interceptor: { ...value.interceptor, [field]: [] } }),
+        ),
+      ).toThrow(/declaration_unknown_field/);
+    },
+  );
 
-  it("rejects overlapping phase groups and unknown nested settings (#11507)", () => {
-    const value = declaration();
+  it("rejects an unregistered provider-profile source (#11507)", () => {
     expect(() =>
       parseExternalComponentDeclaration(
-        JSON.stringify({
-          ...value,
-          interceptor: {
-            ...value.interceptor,
-            bindings: [...value.interceptor.bindings, value.interceptor.bindings[0]],
-          },
-        }),
-      ),
-    ).toThrow(/binding_unauthorized/);
-    expect(() =>
-      parseExternalComponentDeclaration(
-        JSON.stringify({
-          ...value,
-          interceptor: { ...value.interceptor, allowInsecureTransport: true },
-        }),
-      ),
-    ).toThrow(/declaration_unknown_field/);
-    expect(() =>
-      parseExternalComponentDeclaration(
-        JSON.stringify({ ...value, providerProfileSource: "unregistered" }),
+        JSON.stringify({ ...declaration(), providerProfileSource: "unregistered" }),
       ),
     ).toThrow(/declaration_invalid/);
   });
@@ -241,7 +201,7 @@ describe("external component trust", () => {
 });
 
 describe("managed gateway connection configuration", () => {
-  it("writes authenticated connections, authoritative profiles, and distinct failure policies (#11507)", () => {
+  it("writes authenticated connections and delegates callback selection to the component (#11507)", () => {
     const f = fixture();
     f.write();
     const config = fs.readFileSync(f.env.OPENSHELL_GATEWAY_CONFIG!, "utf-8");
@@ -251,17 +211,12 @@ describe("managed gateway connection configuration", () => {
       { type: "interceptor", name: f.component.componentId },
     ]);
     expect(gateway.interceptors[0]).toMatchObject({
-      binding_policy: "exact",
-      failure_policy: "fail_closed",
+      binding_policy: "dynamic",
       allow_insecure_transport: false,
       audience: f.component.interceptor.audience,
     });
-    expect(gateway.interceptors[0].bindings.map((binding: any) => binding.failure_policy)).toEqual([
-      "fail_closed",
-      "fail_closed",
-      "fail_open",
-      "fail_open",
-    ]);
+    expect(gateway.interceptors[0]).not.toHaveProperty("bindings");
+    expect(gateway.interceptors[0]).not.toHaveProperty("failure_policy");
     expect(parsed.openshell.supervisor.middleware[0]).toMatchObject({
       grpc_endpoint: "https://172.30.115.1:9444",
       allow_insecure_transport: false,
@@ -277,7 +232,7 @@ describe("managed gateway connection configuration", () => {
   });
 
   it.each([
-    'binding_policy = "exact"',
+    'binding_policy = "dynamic"',
     "allow_insecure_transport = false",
     "172.30.115.1",
     "ca-sha256",

--- a/src/lib/onboard/external-component/gateway-config.ts
+++ b/src/lib/onboard/external-component/gateway-config.ts
@@ -64,21 +64,12 @@ export function renderExternalComponentConnections(
     `audience = ${quote(interceptor.audience)}`,
     "allow_insecure_transport = false",
     "order = 10",
-    'failure_policy = "fail_closed"',
-    'binding_policy = "exact"',
+    'binding_policy = "dynamic"',
     'timeout = "500ms"',
     "max_response_bytes = 1048576",
     "max_patches = 32",
     "",
   );
-  for (const binding of interceptor.bindings)
-    lines.push(
-      "[[openshell.gateway.interceptors.bindings]]",
-      `rpc = ${quote(binding.rpc)}`,
-      `phases = [${binding.phases.map((phase) => quote(phase)).join(", ")}]`,
-      `failure_policy = "${binding.phases[0] === "post_commit" ? "fail_open" : "fail_closed"}"`,
-      "",
-    );
   lines.push(
     "[[openshell.supervisor.middleware]]",
     `name = ${quote(middleware.name)}`,
@@ -116,13 +107,7 @@ export function parseExternalComponentConnections(openshell: Record<string, unkn
   return validateExternalComponentGatewaySettings({
     schemaVersion: 2,
     componentId: interceptor.name,
-    interceptor: {
-      ...connection(interceptor),
-      bindings: (interceptor.bindings as Record<string, unknown>[]).map((binding) => ({
-        rpc: binding.rpc,
-        phases: binding.phases,
-      })),
-    },
+    interceptor: connection(interceptor),
     middleware: {
       ...connection(middleware),
       endpoint:

--- a/src/lib/onboard/external-component/gateway-config.ts
+++ b/src/lib/onboard/external-component/gateway-config.ts
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  captureExternalComponentTrust,
+  ExternalComponentContractError,
+  parseExternalComponentDeclaration,
+  type ExternalComponentDeclarationV2,
+} from "./index";
+import type { RuntimeProviderGatewayHostRuntime } from "../runtime-provider/contract";
+import { isIPv4 } from "node:net";
+
+type Settings = Omit<ExternalComponentDeclarationV2, "activationSocketPath">;
+const quote = JSON.stringify;
+
+export function validateExternalComponentGatewaySettings(value: unknown): Settings {
+  const declaration = parseExternalComponentDeclaration(
+    JSON.stringify({
+      ...(value as Settings),
+      activationSocketPath: "/unused",
+    }),
+  );
+  if (declaration.schemaVersion !== 2)
+    throw new ExternalComponentContractError("declaration_invalid");
+  const { activationSocketPath: _socket, ...settings } = declaration;
+  return settings;
+}
+
+export function externalComponentGatewayNetwork(
+  env: Record<string, string>,
+  runtime: RuntimeProviderGatewayHostRuntime,
+  settings: Settings,
+): { gatewayIp: string; subnet: string } {
+  const name = env.OPENSHELL_DOCKER_NETWORK_NAME;
+  const network = name ? runtime.network.inspect(name) : undefined;
+  if (
+    runtime.openShellDriver !== "docker" ||
+    !network?.gatewayIp ||
+    !network.subnet ||
+    !isIPv4(network.gatewayIp) ||
+    !/^(?:10\.|192\.168\.|172\.(?:1[6-9]|2\d|3[01])\.)/u.test(network.gatewayIp) ||
+    new URL(settings.middleware.endpoint).hostname !== "host.openshell.internal"
+  ) {
+    throw new ExternalComponentContractError("endpoint_restricted");
+  }
+  return { gatewayIp: network.gatewayIp, subnet: network.subnet };
+}
+
+export function renderExternalComponentConnections(
+  settings: Settings,
+  gatewayIp: string,
+): string[] {
+  const interceptor = settings.interceptor;
+  const middleware = settings.middleware;
+  const interceptorTrust = captureExternalComponentTrust(interceptor.caCertificatePath);
+  const middlewareTrust = captureExternalComponentTrust(middleware.caCertificatePath);
+  const lines: string[] = [];
+  lines.push(
+    "[[openshell.gateway.interceptors]]",
+    `name = ${quote(settings.componentId)}`,
+    `grpc_endpoint = ${quote(interceptor.endpoint)}`,
+    `tls_ca_cert_path = ${quote(interceptor.caCertificatePath)}`,
+    `# ca-sha256 = ${interceptorTrust.sha256}`,
+    `audience = ${quote(interceptor.audience)}`,
+    "allow_insecure_transport = false",
+    "order = 10",
+    'failure_policy = "fail_closed"',
+    'binding_policy = "exact"',
+    'timeout = "500ms"',
+    "max_response_bytes = 1048576",
+    "max_patches = 32",
+    "",
+  );
+  for (const binding of interceptor.bindings)
+    lines.push(
+      "[[openshell.gateway.interceptors.bindings]]",
+      `rpc = ${quote(binding.rpc)}`,
+      `phases = [${binding.phases.map((phase) => quote(phase)).join(", ")}]`,
+      `failure_policy = "${binding.phases[0] === "post_commit" ? "fail_open" : "fail_closed"}"`,
+      "",
+    );
+  lines.push(
+    "[[openshell.supervisor.middleware]]",
+    `name = ${quote(middleware.name)}`,
+    `grpc_endpoint = ${quote(middleware.endpoint.replace("host.openshell.internal", gatewayIp))}`,
+    `tls_ca_cert_path = ${quote(middleware.caCertificatePath)}`,
+    `# ca-sha256 = ${middlewareTrust.sha256}`,
+    `audience = ${quote(middleware.audience)}`,
+    "allow_insecure_transport = false",
+    "max_payload_bytes = 262144",
+    'timeout = "500ms"',
+    "",
+  );
+  return lines;
+}
+
+export function parseExternalComponentConnections(openshell: Record<string, unknown>): Settings {
+  const gateway = openshell.gateway as Record<string, unknown>;
+  const interceptors = gateway.interceptors as Record<string, unknown>[];
+  const supervisor = openshell.supervisor as Record<string, unknown>;
+  const services = supervisor?.middleware as Record<string, unknown>[];
+  if (interceptors?.length !== 1 || services?.length !== 1) {
+    throw new ExternalComponentContractError("declaration_invalid");
+  }
+  const interceptor = interceptors[0]!;
+  const middleware = services[0]!;
+  const sources = gateway.provider_profile_sources as Record<string, unknown>[] | undefined;
+  if (sources && (sources.length !== 1 || sources[0]?.type !== "interceptor")) {
+    throw new ExternalComponentContractError("declaration_invalid");
+  }
+  const connection = (service: Record<string, unknown>) => ({
+    endpoint: service.grpc_endpoint,
+    caCertificatePath: service.tls_ca_cert_path,
+    audience: service.audience,
+  });
+  return validateExternalComponentGatewaySettings({
+    schemaVersion: 2,
+    componentId: interceptor.name,
+    interceptor: {
+      ...connection(interceptor),
+      bindings: (interceptor.bindings as Record<string, unknown>[]).map((binding) => ({
+        rpc: binding.rpc,
+        phases: binding.phases,
+      })),
+    },
+    middleware: {
+      ...connection(middleware),
+      endpoint:
+        typeof middleware.grpc_endpoint === "string"
+          ? middleware.grpc_endpoint.replace(
+              /^https:\/\/[^:]+:/u,
+              "https://host.openshell.internal:",
+            )
+          : null,
+      name: middleware.name,
+    },
+    ...(sources ? { providerProfileSource: sources[0]?.name } : {}),
+  });
+}

--- a/src/lib/onboard/external-component/index.test.ts
+++ b/src/lib/onboard/external-component/index.test.ts
@@ -125,7 +125,7 @@ describe("external component declaration", () => {
       "declaration_duplicate_key",
     ],
     ["unknown fields", validJson({ command: "run" }), "declaration_unknown_field"],
-    ["unsupported schemas", validJson({ schemaVersion: 2 }), "schema_unsupported"],
+    ["unsupported schemas", validJson({ schemaVersion: 3 }), "schema_unsupported"],
     [
       "missing fields",
       JSON.stringify({ schemaVersion: 1, componentId: "component" }),

--- a/src/lib/onboard/external-component/index.ts
+++ b/src/lib/onboard/external-component/index.ts
@@ -41,7 +41,6 @@ export type ExternalComponentContractErrorCode =
   | "lifecycle_unsupported"
   | "platform_unsupported"
   | "schema_unsupported"
-  | "binding_unauthorized"
   | "endpoint_restricted"
   | "trust_invalid"
   | "trust_changed"
@@ -75,18 +74,11 @@ export interface ExternalComponentConnection {
   readonly audience: string;
 }
 
-export interface ExternalComponentBinding {
-  readonly rpc: string;
-  readonly phases: readonly ("modify_operation" | "validate" | "post_commit")[];
-}
-
 export interface ExternalComponentDeclarationV2 {
   readonly schemaVersion: 2;
   readonly componentId: string;
   readonly activationSocketPath: string;
-  readonly interceptor: ExternalComponentConnection & {
-    readonly bindings: readonly ExternalComponentBinding[];
-  };
+  readonly interceptor: ExternalComponentConnection;
   readonly middleware: ExternalComponentConnection & { readonly name: string };
   readonly providerProfileSource?: string;
 }
@@ -639,71 +631,13 @@ function connection(
   });
 }
 
-function bindings(value: unknown): readonly ExternalComponentBinding[] {
-  if (!Array.isArray(value) || value.length === 0 || value.length > 32) {
-    throw new ExternalComponentContractError("binding_unauthorized");
-  }
-  const seen = new Set<string>();
-  return Object.freeze(
-    value.map((entry) => {
-      const record = fields(entry, ["rpc", "phases"]);
-      const method =
-        typeof record.rpc === "string"
-          ? record.rpc.replace(/^openshell\.v1\.OpenShell\//u, "")
-          : "";
-      const policyMutation = method === "CreateSandbox" || method === "UpdateConfig";
-      const supported = [
-        "CreateProvider",
-        "UpdateProvider",
-        "ImportProviderProfiles",
-        "UpdateProviderProfiles",
-        "DeleteProviderProfile",
-        "SubmitPolicyAnalysis",
-        "ApproveDraftChunk",
-        "ApproveAllDraftChunks",
-      ];
-      if (
-        record.rpc !== `openshell.v1.OpenShell/${method}` ||
-        (!policyMutation && !supported.includes(method)) ||
-        !Array.isArray(record.phases) ||
-        record.phases.length === 0 ||
-        record.phases.length > 2
-      ) {
-        throw new ExternalComponentContractError("binding_unauthorized");
-      }
-      for (const phase of record.phases) {
-        const key = `${String(record.rpc)}:${String(phase)}`;
-        if (
-          !(
-            policyMutation ? ["modify_operation", "validate", "post_commit"] : ["validate"]
-          ).includes(phase) ||
-          (phase === "post_commit" && record.phases.length !== 1) ||
-          seen.has(key)
-        ) {
-          throw new ExternalComponentContractError("binding_unauthorized");
-        }
-        seen.add(key);
-      }
-      return Object.freeze({
-        rpc: record.rpc as string,
-        phases: Object.freeze([...record.phases]) as ExternalComponentBinding["phases"],
-      });
-    }),
-  );
-}
-
 function parseConnectionDeclaration(value: unknown): ExternalComponentDeclarationV2 {
   const record = fields(
     value,
     ["schemaVersion", "componentId", "activationSocketPath", "interceptor", "middleware"],
     ["providerProfileSource"],
   );
-  const interceptor = fields(record.interceptor, [
-    "endpoint",
-    "caCertificatePath",
-    "audience",
-    "bindings",
-  ]);
+  const interceptor = fields(record.interceptor, ["endpoint", "caCertificatePath", "audience"]);
   const middleware = fields(record.middleware, [
     "name",
     "endpoint",
@@ -718,10 +652,7 @@ function parseConnectionDeclaration(value: unknown): ExternalComponentDeclaratio
     schemaVersion: 2,
     componentId,
     activationSocketPath: validatedSocketPath(record.activationSocketPath),
-    interceptor: Object.freeze({
-      ...connection(interceptor, true),
-      bindings: bindings(interceptor.bindings),
-    }),
+    interceptor: connection(interceptor, true),
     middleware: Object.freeze({
       ...connection(middleware, false),
       name: serviceName(middleware.name),

--- a/src/lib/onboard/external-component/index.ts
+++ b/src/lib/onboard/external-component/index.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import fs from "node:fs";
+import { createHash, X509Certificate } from "node:crypto";
 import os from "node:os";
 import path from "node:path";
 import { TextDecoder } from "node:util";
@@ -40,6 +41,11 @@ export type ExternalComponentContractErrorCode =
   | "lifecycle_unsupported"
   | "platform_unsupported"
   | "schema_unsupported"
+  | "binding_unauthorized"
+  | "endpoint_restricted"
+  | "trust_invalid"
+  | "trust_changed"
+  | "preparation_failed"
   | "socket_ambiguous"
   | "socket_mode"
   | "socket_owner"
@@ -56,11 +62,53 @@ export class ExternalComponentContractError extends Error {
   }
 }
 
-export interface ExternalComponentDeclaration {
+export interface ExternalComponentDeclarationV1 {
   readonly schemaVersion: typeof EXTERNAL_COMPONENT_SCHEMA_VERSION;
   readonly componentId: string;
   readonly interceptorSocketPath: string;
   readonly activationSocketPath: string;
+}
+
+export interface ExternalComponentConnection {
+  readonly endpoint: string;
+  readonly caCertificatePath: string;
+  readonly audience: string;
+}
+
+export interface ExternalComponentBinding {
+  readonly rpc: string;
+  readonly phases: readonly ("modify_operation" | "validate" | "post_commit")[];
+}
+
+export interface ExternalComponentDeclarationV2 {
+  readonly schemaVersion: 2;
+  readonly componentId: string;
+  readonly activationSocketPath: string;
+  readonly interceptor: ExternalComponentConnection & {
+    readonly bindings: readonly ExternalComponentBinding[];
+  };
+  readonly middleware: ExternalComponentConnection & { readonly name: string };
+  readonly providerProfileSource?: string;
+}
+
+export type ExternalComponentDeclaration =
+  | ExternalComponentDeclarationV1
+  | ExternalComponentDeclarationV2;
+
+export type ExternalComponentGatewayConfiguration =
+  | Pick<ExternalComponentDeclarationV1, "componentId" | "interceptorSocketPath">
+  | Omit<ExternalComponentDeclarationV2, "activationSocketPath">;
+
+export function gatewayConfigurationForExternalComponent(
+  declaration: ExternalComponentDeclaration,
+): ExternalComponentGatewayConfiguration {
+  if (declaration.schemaVersion === 1)
+    return {
+      componentId: declaration.componentId,
+      interceptorSocketPath: declaration.interceptorSocketPath,
+    };
+  const { activationSocketPath: _socket, ...configuration } = declaration;
+  return configuration;
 }
 
 interface FileIdentity {
@@ -87,6 +135,7 @@ interface EndpointProof extends PathProof {
 
 export interface PreparedExternalComponent {
   readonly declaration: ExternalComponentDeclaration;
+  setGatewayRevalidation?(revalidate: () => void): void;
   revalidateBeforeGateway(): void;
   revalidateBeforeActivation(): void;
 }
@@ -448,6 +497,7 @@ export function parseExternalComponentDeclaration(source: string): ExternalCompo
     throw new ExternalComponentContractError("declaration_invalid");
   }
   const record = parsed as Record<string, unknown>;
+  if (record.schemaVersion === 2) return parseConnectionDeclaration(record);
   if (Object.keys(record).some((field) => !DECLARATION_FIELDS.has(field))) {
     throw new ExternalComponentContractError("declaration_unknown_field");
   }
@@ -501,16 +551,245 @@ export function loadExternalComponentDeclaration(
     throw new ExternalComponentContractError("declaration_invalid");
   }
   const declaration = parseExternalComponentDeclaration(source);
-  const interceptorProof = captureEndpoint(declaration.interceptorSocketPath, uid);
+  const interceptorProof =
+    declaration.schemaVersion === 1
+      ? captureEndpoint(declaration.interceptorSocketPath, uid)
+      : null;
+  const trustProofs =
+    declaration.schemaVersion === 2
+      ? [declaration.interceptor, declaration.middleware].map((connection) =>
+          captureExternalComponentTrust(connection.caCertificatePath, uid),
+        )
+      : [];
   const activationProof = captureEndpoint(declaration.activationSocketPath, uid);
+  let revalidateGateway: (() => void) | undefined;
   const revalidate = (): void => {
     revalidateDeclaration(declarationProof);
-    revalidateEndpoint(interceptorProof);
+    if (interceptorProof) revalidateEndpoint(interceptorProof);
+    for (const proof of trustProofs) proof.revalidate();
     revalidateEndpoint(activationProof);
+    revalidateGateway?.();
   };
   return {
     declaration,
+    setGatewayRevalidation(revalidateGatewayProof) {
+      if (revalidateGateway) throw new ExternalComponentContractError("preparation_failed");
+      revalidateGateway = revalidateGatewayProof;
+    },
     revalidateBeforeGateway: revalidate,
     revalidateBeforeActivation: revalidate,
   };
+}
+
+function fields(
+  value: unknown,
+  required: readonly string[],
+  optional: readonly string[] = [],
+): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new ExternalComponentContractError("declaration_invalid");
+  }
+  const record = value as Record<string, unknown>;
+  if (Object.keys(record).some((key) => !required.includes(key) && !optional.includes(key))) {
+    throw new ExternalComponentContractError("declaration_unknown_field");
+  }
+  if (required.some((key) => !Object.hasOwn(record, key))) {
+    throw new ExternalComponentContractError("declaration_invalid");
+  }
+  return record;
+}
+
+function serviceName(value: unknown): string {
+  if (
+    typeof value !== "string" ||
+    !/^[A-Za-z0-9][A-Za-z0-9._/-]{0,127}$/u.test(value) ||
+    value.startsWith("openshell/")
+  )
+    throw new ExternalComponentContractError("declaration_invalid");
+  return value;
+}
+
+function connection(
+  record: Record<string, unknown>,
+  interceptor: boolean,
+): ExternalComponentConnection {
+  const endpoint = record.endpoint;
+  const match =
+    typeof endpoint === "string"
+      ? /^https:\/\/(127\.0\.0\.1|host\.openshell\.internal):([1-9]\d{0,4})$/u.exec(endpoint)
+      : null;
+  const host = match?.[1] ?? "";
+  if (
+    !match ||
+    Number(match[2]) > 65535 ||
+    host !== (interceptor ? "127.0.0.1" : "host.openshell.internal")
+  ) {
+    throw new ExternalComponentContractError("endpoint_restricted");
+  }
+  if (
+    typeof record.audience !== "string" ||
+    record.audience.length > 256 ||
+    !/^[\x21-\x7e]+$/u.test(record.audience)
+  )
+    throw new ExternalComponentContractError("declaration_invalid");
+  return Object.freeze({
+    endpoint: endpoint as string,
+    caCertificatePath: validatedSocketPath(record.caCertificatePath),
+    audience: record.audience,
+  });
+}
+
+function bindings(value: unknown): readonly ExternalComponentBinding[] {
+  if (!Array.isArray(value) || value.length === 0 || value.length > 32) {
+    throw new ExternalComponentContractError("binding_unauthorized");
+  }
+  const seen = new Set<string>();
+  return Object.freeze(
+    value.map((entry) => {
+      const record = fields(entry, ["rpc", "phases"]);
+      const method =
+        typeof record.rpc === "string"
+          ? record.rpc.replace(/^openshell\.v1\.OpenShell\//u, "")
+          : "";
+      const policyMutation = method === "CreateSandbox" || method === "UpdateConfig";
+      const supported = [
+        "CreateProvider",
+        "UpdateProvider",
+        "ImportProviderProfiles",
+        "UpdateProviderProfiles",
+        "DeleteProviderProfile",
+        "SubmitPolicyAnalysis",
+        "ApproveDraftChunk",
+        "ApproveAllDraftChunks",
+      ];
+      if (
+        record.rpc !== `openshell.v1.OpenShell/${method}` ||
+        (!policyMutation && !supported.includes(method)) ||
+        !Array.isArray(record.phases) ||
+        record.phases.length === 0 ||
+        record.phases.length > 2
+      ) {
+        throw new ExternalComponentContractError("binding_unauthorized");
+      }
+      for (const phase of record.phases) {
+        const key = `${String(record.rpc)}:${String(phase)}`;
+        if (
+          !(
+            policyMutation ? ["modify_operation", "validate", "post_commit"] : ["validate"]
+          ).includes(phase) ||
+          (phase === "post_commit" && record.phases.length !== 1) ||
+          seen.has(key)
+        ) {
+          throw new ExternalComponentContractError("binding_unauthorized");
+        }
+        seen.add(key);
+      }
+      return Object.freeze({
+        rpc: record.rpc as string,
+        phases: Object.freeze([...record.phases]) as ExternalComponentBinding["phases"],
+      });
+    }),
+  );
+}
+
+function parseConnectionDeclaration(value: unknown): ExternalComponentDeclarationV2 {
+  const record = fields(
+    value,
+    ["schemaVersion", "componentId", "activationSocketPath", "interceptor", "middleware"],
+    ["providerProfileSource"],
+  );
+  const interceptor = fields(record.interceptor, [
+    "endpoint",
+    "caCertificatePath",
+    "audience",
+    "bindings",
+  ]);
+  const middleware = fields(record.middleware, [
+    "name",
+    "endpoint",
+    "caCertificatePath",
+    "audience",
+  ]);
+  const componentId = serviceName(record.componentId);
+  if (record.providerProfileSource !== undefined && record.providerProfileSource !== componentId) {
+    throw new ExternalComponentContractError("declaration_invalid");
+  }
+  return Object.freeze({
+    schemaVersion: 2,
+    componentId,
+    activationSocketPath: validatedSocketPath(record.activationSocketPath),
+    interceptor: Object.freeze({
+      ...connection(interceptor, true),
+      bindings: bindings(interceptor.bindings),
+    }),
+    middleware: Object.freeze({
+      ...connection(middleware, false),
+      name: serviceName(middleware.name),
+    }),
+    ...(record.providerProfileSource === undefined ? {} : { providerProfileSource: componentId }),
+  });
+}
+
+/** Certificate bytes stay public; private keys must never enter a supervisor's trust bundle. */
+export function captureExternalComponentTrust(
+  certificatePath: string,
+  uid = process.geteuid?.(),
+): {
+  readonly sha256: string;
+  revalidate(): void;
+} {
+  if (uid === undefined) throw new ExternalComponentContractError("trust_invalid");
+  try {
+    validatedSocketPath(certificatePath);
+    const parents = captureSafeParents(endpointParents(certificatePath), uid, false);
+    const stat = fs.lstatSync(certificatePath);
+    const expected = identity(stat, "file");
+    if ((stat.uid !== uid && stat.uid !== 0) || (stat.mode & 0o022) !== 0 || stat.nlink !== 1) {
+      throw new Error("unsafe certificate file");
+    }
+    const file = openRegularFileNoFollow(certificatePath);
+    let bytes: Buffer;
+    try {
+      if (!sameIdentity(expected, identity(file.stat(), "file")))
+        throw new Error("changed certificate");
+      bytes = file.readBytes(64 * 1024);
+    } finally {
+      file.close();
+    }
+    const pem = UTF8_DECODER.decode(bytes);
+    const certificates =
+      pem.match(/-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----/gu) ?? [];
+    if (
+      !certificates.length ||
+      pem.replace(/-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----/gu, "").trim()
+    ) {
+      throw new Error("certificate-only PEM required");
+    }
+    for (const certificate of certificates) {
+      const parsed = new X509Certificate(certificate);
+      if (
+        !parsed.ca ||
+        Date.parse(parsed.validFrom) > Date.now() ||
+        Date.parse(parsed.validTo) <= Date.now()
+      ) {
+        throw new Error("valid CA certificate required");
+      }
+    }
+    const sha256 = createHash("sha256").update(bytes).digest("hex");
+    return {
+      sha256,
+      revalidate() {
+        try {
+          for (const parent of parents) assertPathProof(parent, "trust_changed");
+          assertPathProof({ path: certificatePath, identity: expected }, "trust_changed");
+          if (captureExternalComponentTrust(certificatePath, uid).sha256 !== sha256)
+            throw new Error("changed trust");
+        } catch {
+          throw new ExternalComponentContractError("trust_changed");
+        }
+      },
+    };
+  } catch {
+    throw new ExternalComponentContractError("trust_invalid");
+  }
 }

--- a/src/lib/onboard/external-component/onboarding.ts
+++ b/src/lib/onboard/external-component/onboarding.ts
@@ -9,6 +9,7 @@ import {
   ExternalComponentContractError,
   loadExternalComponentDeclaration,
   type PreparedExternalComponent,
+  type ExternalComponentGatewayConfiguration,
 } from "./index";
 import { activateExternalComponent, createExternalComponentActivationId } from "./activation";
 import { createExternalComponentActivationProof } from "./proof";
@@ -54,10 +55,7 @@ export function flowDeps(
     assertExternalComponentFreshSandbox: (requestedSandboxName: string | null) =>
       assertExternalComponentFreshSandbox(requestedSandboxName, inspectSandboxForCreate),
     configureExternalComponentGateway: (
-      externalComponent: {
-        readonly componentId: string;
-        readonly interceptorSocketPath: string;
-      } | null,
+      externalComponent: ExternalComponentGatewayConfiguration | null,
     ) =>
       configureDockerDriverGatewayExternalComponent(getDockerDriverGatewayEnv(), externalComponent),
     prepareExternalComponent,

--- a/src/lib/onboard/machine/handlers/gateway.test.ts
+++ b/src/lib/onboard/machine/handlers/gateway.test.ts
@@ -10,6 +10,7 @@ import { createSession, type Session } from "../../../state/onboard-session";
 import { flushTrace, resetTraceForTests, TRACE_FILE_ENV, type TraceArtifact } from "../../../trace";
 import type { GatewayContainerState } from "../../gateway-container-running";
 import type { PreparedExternalComponent } from "../../external-component";
+import * as componentActivation from "../../external-component/activation";
 import {
   type GatewayAttachmentProbe,
   type GatewayOwner,
@@ -50,6 +51,29 @@ function preparedExternalComponent(revalidateBeforeGateway = vi.fn()): PreparedE
     },
     revalidateBeforeGateway,
     revalidateBeforeActivation: vi.fn(),
+  };
+}
+
+function preparedConnectionComponent(): PreparedExternalComponent {
+  return {
+    ...preparedExternalComponent(),
+    declaration: {
+      schemaVersion: 2,
+      componentId: "generic-policy",
+      activationSocketPath: "/run/component/activate.sock",
+      interceptor: {
+        endpoint: "https://127.0.0.1:9443",
+        caCertificatePath: "/run/component/ca.pem",
+        audience: "urn:generic:admission",
+        bindings: [{ rpc: "openshell.v1.OpenShell/CreateSandbox", phases: ["validate"] }],
+      },
+      middleware: {
+        name: "generic-middleware",
+        endpoint: "https://host.openshell.internal:9444",
+        caCertificatePath: "/run/component/ca.pem",
+        audience: "urn:generic:middleware",
+      },
+    },
   };
 }
 
@@ -255,6 +279,39 @@ describe("handleGatewayState", () => {
     expect(calls.configureExternalComponentGateway.mock.invocationCallOrder[0]).toBeLessThan(
       calls.refresh.mock.invocationCallOrder[0],
     );
+  });
+
+  it("starts the gateway after component preparation succeeds (#11507)", async () => {
+    const prepare = vi
+      .spyOn(componentActivation, "prepareExternalComponentGateway")
+      .mockResolvedValue();
+    const component = preparedConnectionComponent();
+    const { deps, calls } = createDeps({ isLinuxDockerDriverGatewayEnabled: vi.fn(() => true) });
+    await handleGatewayState({ ...baseOptions(deps, "missing"), externalComponent: component });
+    expect(prepare).toHaveBeenCalledOnce();
+    expect(calls.configureExternalComponentGateway).toHaveBeenCalledWith(
+      expect.objectContaining({ schemaVersion: 2 }),
+    );
+    expect(prepare.mock.invocationCallOrder[0]).toBeLessThan(
+      calls.startGateway.mock.invocationCallOrder[0]!,
+    );
+    expect(component.revalidateBeforeGateway).toHaveBeenCalledTimes(2);
+  });
+
+  it("preserves gateway state when component preparation fails (#11507)", async () => {
+    vi.spyOn(componentActivation, "prepareExternalComponentGateway").mockRejectedValue(
+      new Error("preparation_failed"),
+    );
+    const { deps, calls } = createDeps({ isLinuxDockerDriverGatewayEnabled: vi.fn(() => true) });
+    await expect(
+      handleGatewayState({
+        ...baseOptions(deps, "missing"),
+        externalComponent: preparedConnectionComponent(),
+      }),
+    ).rejects.toThrow("preparation_failed");
+    expect(calls.refresh).not.toHaveBeenCalled();
+    expect(calls.startGateway).not.toHaveBeenCalled();
+    expect(calls.complete).not.toHaveBeenCalled();
   });
 
   it("removes a prior component before evaluating managed gateway reuse (#11340)", async () => {

--- a/src/lib/onboard/machine/handlers/gateway.test.ts
+++ b/src/lib/onboard/machine/handlers/gateway.test.ts
@@ -65,7 +65,6 @@ function preparedConnectionComponent(): PreparedExternalComponent {
         endpoint: "https://127.0.0.1:9443",
         caCertificatePath: "/run/component/ca.pem",
         audience: "urn:generic:admission",
-        bindings: [{ rpc: "openshell.v1.OpenShell/CreateSandbox", phases: ["validate"] }],
       },
       middleware: {
         name: "generic-middleware",

--- a/src/lib/onboard/machine/handlers/gateway.test.ts
+++ b/src/lib/onboard/machine/handlers/gateway.test.ts
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import fs from "node:fs";
+import http from "node:http";
+import { generateKeyPairSync } from "node:crypto";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
@@ -54,13 +56,21 @@ function preparedExternalComponent(revalidateBeforeGateway = vi.fn()): PreparedE
   };
 }
 
-function preparedConnectionComponent(): PreparedExternalComponent {
+function preparedConnectionComponent(
+  activationSocketPath = "/run/component/activate.sock",
+): PreparedExternalComponent {
+  let revalidateGateway = () => {};
   return {
     ...preparedExternalComponent(),
+    setGatewayRevalidation: vi.fn((revalidate: () => void) => {
+      revalidateGateway = revalidate;
+    }),
+    revalidateBeforeGateway: vi.fn(() => revalidateGateway()),
+    revalidateBeforeActivation: vi.fn(() => revalidateGateway()),
     declaration: {
       schemaVersion: 2,
       componentId: "generic-policy",
-      activationSocketPath: "/run/component/activate.sock",
+      activationSocketPath,
       interceptor: {
         endpoint: "https://127.0.0.1:9443",
         caCertificatePath: "/run/component/ca.pem",
@@ -281,20 +291,81 @@ describe("handleGatewayState", () => {
   });
 
   it("starts the gateway after component preparation succeeds (#11507)", async () => {
-    const prepare = vi
-      .spyOn(componentActivation, "prepareExternalComponentGateway")
-      .mockResolvedValue();
-    const component = preparedConnectionComponent();
+    const directory = fs.mkdtempSync(path.join(path.dirname(process.cwd()), "nc-prepare-"));
+    const socketPath = path.join(directory, "activate.sock");
+    const component = preparedConnectionComponent(socketPath);
+    const preparation: componentActivation.ExternalComponentGatewayPreparation = {
+      gateway: {
+        id: "generic-gateway",
+        issuer: "openshell-gateway:generic-gateway",
+        publicKeyPem: generateKeyPairSync("ed25519")
+          .publicKey.export({ type: "spki", format: "pem" })
+          .toString(),
+        kid: "generic-key",
+        extensionTokenTtlSecs: 900,
+      },
+      network: { gatewayIp: "172.30.115.1", subnet: "172.30.115.0/24" },
+      revalidate: vi.fn(),
+    };
     const { deps, calls } = createDeps({ isLinuxDockerDriverGatewayEnabled: vi.fn(() => true) });
-    await handleGatewayState({ ...baseOptions(deps, "missing"), externalComponent: component });
-    expect(prepare).toHaveBeenCalledOnce();
-    expect(calls.configureExternalComponentGateway).toHaveBeenCalledWith(
-      expect.objectContaining({ schemaVersion: 2 }),
-    );
-    expect(prepare.mock.invocationCallOrder[0]).toBeLessThan(
-      calls.startGateway.mock.invocationCallOrder[0]!,
-    );
-    expect(component.revalidateBeforeGateway).toHaveBeenCalledTimes(2);
+    calls.configureExternalComponentGateway.mockReturnValue(preparation);
+    const acknowledge = vi.fn((request: { preparationId: string; componentId: string }) => ({
+      schemaVersion: 2,
+      preparationId: request.preparationId,
+      componentId: request.componentId,
+      result: "prepared",
+    }));
+    const received: unknown[] = [];
+    const server = http.createServer((request, reply) => {
+      let body = "";
+      request.on("data", (chunk) => {
+        body += String(chunk);
+      });
+      request.on("end", () => {
+        const payload = JSON.parse(body);
+        received.push({ method: request.method, url: request.url, body: payload });
+        const response = JSON.stringify(acknowledge(payload));
+        reply.writeHead(200, {
+          "content-length": Buffer.byteLength(response),
+          connection: "close",
+        });
+        reply.end(response);
+      });
+    });
+    try {
+      await new Promise<void>((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(socketPath, resolve);
+      });
+      await handleGatewayState({ ...baseOptions(deps, "missing"), externalComponent: component });
+      expect(received).toEqual([
+        {
+          method: "POST",
+          url: "/v2/prepare",
+          body: expect.objectContaining({
+            schemaVersion: 2,
+            componentId: component.declaration.componentId,
+            gateway: { name: "nemoclaw", ...preparation.gateway },
+            network: preparation.network,
+          }),
+        },
+      ]);
+      expect(component.setGatewayRevalidation).toHaveBeenCalledOnce();
+      expect(preparation.revalidate).toHaveBeenCalled();
+      expect(calls.configureExternalComponentGateway).toHaveBeenCalledWith(
+        expect.objectContaining({ schemaVersion: 2 }),
+      );
+      expect(calls.configureExternalComponentGateway.mock.invocationCallOrder[0]).toBeLessThan(
+        acknowledge.mock.invocationCallOrder[0]!,
+      );
+      expect(acknowledge.mock.invocationCallOrder[0]).toBeLessThan(
+        calls.startGateway.mock.invocationCallOrder[0]!,
+      );
+      expect(calls.startGateway).toHaveBeenCalledOnce();
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
   });
 
   it("preserves gateway state when component preparation fails (#11507)", async () => {

--- a/src/lib/onboard/machine/handlers/gateway.ts
+++ b/src/lib/onboard/machine/handlers/gateway.ts
@@ -5,7 +5,15 @@ import type { NvidiaPlatform } from "../../../inference/nim";
 import type { GatewayReuseState } from "../../../state/gateway";
 import type { Session } from "../../../state/onboard-session";
 import type { GatewayContainerState } from "../../gateway-container-running";
-import type { PreparedExternalComponent } from "../../external-component";
+import {
+  gatewayConfigurationForExternalComponent,
+  type PreparedExternalComponent,
+  type ExternalComponentGatewayConfiguration,
+} from "../../external-component";
+import {
+  prepareExternalComponentGateway,
+  type ExternalComponentGatewayPreparation,
+} from "../../external-component/activation";
 import {
   describeGatewayOwner,
   evaluateGatewayAttachment,
@@ -40,11 +48,8 @@ export interface GatewayStateOptions<Gpu> {
     attachGateway(owner: GatewayOwner, expectedProbe: GatewayAttachmentProbe): Promise<void>;
     assertExternalComponentFreshSandbox(requestedSandboxName: string | null): void;
     configureExternalComponentGateway(
-      component: {
-        readonly componentId: string;
-        readonly interceptorSocketPath: string;
-      } | null,
-    ): void;
+      component: ExternalComponentGatewayConfiguration | null,
+    ): ExternalComponentGatewayPreparation | void;
     refreshDockerDriverGatewayReuseState(state: GatewayReuseState): Promise<GatewayReuseState>;
     gatewayCliSupportsLifecycleCommands(): boolean;
     verifyGatewayContainerRunning(gatewayName: string): GatewayContainerState;
@@ -155,14 +160,14 @@ async function handleGatewayStatePhase<Gpu>({
   }
   externalComponent?.revalidateBeforeGateway();
   if (deps.isLinuxDockerDriverGatewayEnabled()) {
-    deps.configureExternalComponentGateway(
+    const preparation = deps.configureExternalComponentGateway(
       externalComponent
-        ? {
-            componentId: externalComponent.declaration.componentId,
-            interceptorSocketPath: externalComponent.declaration.interceptorSocketPath,
-          }
+        ? gatewayConfigurationForExternalComponent(externalComponent.declaration)
         : null,
     );
+    if (externalComponent?.declaration.schemaVersion === 2) {
+      await prepareExternalComponentGateway(externalComponent, gatewayName, preparation);
+    }
   }
 
   let gatewayReuseState = await deps.refreshDockerDriverGatewayReuseState(initialGatewayReuseState);
@@ -305,6 +310,8 @@ async function handleGatewayStatePhase<Gpu>({
     } else if (gatewayReuseState === "foreign-active") {
       gatewayReuseState = "missing";
     }
+    if (externalComponent?.declaration.schemaVersion === 2)
+      externalComponent.revalidateBeforeGateway();
     await deps.startGateway(gpu, { gpuPassthrough });
     session = await deps.recordStepComplete("gateway");
   }


### PR DESCRIPTION
## Outcome

One operator-registered external component can supply validated connection settings before a NemoClaw-managed OpenShell gateway starts. NemoClaw retains generated-configuration and gateway lifecycle ownership; the component supplies policy, and OpenShell validates and enforces effective sandbox policy.

## Reason

The existing component declaration cannot configure authenticated interceptor and supervisor middleware connections. Extending its existing validation, configuration writer, and activation transport lets fresh Linux Docker-driver onboarding prepare those connections before startup.

### Related issues

Fixes #11507.

Consumes #11486, merged through #11508. Shared-file ownership was coordinated before editing; the change to `external-component/onboarding.ts` only widens the configuration callback type.

## Changes

- Extend the declaration with a strict v2 schema for one interceptor, one middleware service, CA references, audiences, and an optional provider-profile source. Interceptor endpoints must use HTTPS on literal loopback. Middleware uses the fixed managed-bridge selector, resolved from Docker inspection. `connections.test.ts` protects field and endpoint restrictions.
- Extend the existing configuration writer with the OpenShell connection settings and drift checks. CA files must contain valid CA certificates, have protected ownership and permissions, and contain no links or private keys. Revalidation covers declaration, socket, trust, generated configuration, gateway keys, and bridge addressing. The connection tests cover invalid trust and drift.
- Use the authenticated component manifest for callback selection and per-callback failure behavior. V2 explicitly selects `binding_policy = "dynamic"` and rejects declaration overrides. Missing callbacks are accepted; an explicit callback `fail_open` can override a service `fail_closed` default. This is the implementation decision, superseding the issue's initial strict-binding proposal. OpenShell still validates supported RPCs, phases, and middleware bindings. Deterministic configuration tests and live registration cases cover this contract.
- Add `/v2/prepare` to the existing bounded socket transport. It sends public gateway identity and inspected network data before startup, then requires a matching acknowledgement. Private signing keys remain in NemoClaw state. Preparation and gateway-handler tests cover ordering, refusal, identity mismatch, and failure without retries.
- Allow `providerProfileSource` to reference only the same authenticated interceptor. This selects OpenShell's existing profile delivery mechanism when the component supplies required profiles. There is no new profile transport or policy evaluator; live tests verify delivery and unavailable-profile failure without fallback.

Ordinary onboarding and v1 behavior retain their existing paths. #11486 retains ownership of providerless onboarding guards, finalization, and incomplete-activation state. Service installation, shared runtime upgrades, recovery changes, and export/apply remain outside this PR.

## Verification

Publication candidate: `f39217e9c05a477955b8242a9ccd9fe818244164`. Its implementation base is `e0273c244c0e96ab35bd1d3c962c3802633d67e7`; repair publication validation uses canonical main `f75f722bb4a1ec9642c8df36c8924e24500d78f0`.

- Repair tests at `f39217e9c05a477955b8242a9ccd9fe818244164`: **197 passed in eight files**. `NODE_OPTIONS=--max-old-space-size=5120 npx vitest run --project cli src/lib/onboard/external-component src/lib/onboard/machine/handlers/gateway.test.ts src/lib/onboard/docker-driver-gateway-runtime.test.ts src/lib/onboard/gateway-reuse.test.ts` passed. Two temporary mutation checks confirmed that dropping the configuration result or the handler handoff makes the corresponding test fail; production source was restored byte-for-byte.
- The repaired handler test uses the real preparation helper over a controlled Unix socket. The connection test also exercises the configuration facade's returned preparation. Existing failure and default paths remain covered.

- Initial publication tests at `1b6e94431559234e5971952c531735506589e307`: **273 passed in 11 files**, across the two selections below. These cover accepted settings, invalid declarations, endpoint restrictions, trust files, configuration drift, preparation, existing activation, and onboarding flow behavior.

  ```sh
  NODE_OPTIONS=--max-old-space-size=5120 npx vitest run --project cli src/lib/onboard/external-component src/lib/onboard/machine/handlers/gateway.test.ts src/lib/onboard/machine/handlers/finalization.test.ts src/lib/onboard/machine/handlers/sandbox.test.ts src/lib/onboard/flow-context src/lib/onboard/initial-flow-phases
  NODE_OPTIONS=--max-old-space-size=5120 npx vitest run --project cli src/lib/onboard/machine/flow-context.test.ts src/lib/onboard/machine/flow-handoff.test.ts src/lib/onboard/machine/initial-flow-phases.test.ts
  ```

- `NODE_OPTIONS=--max-old-space-size=5120 npm run validate:pr` — passed for `f39217e9c05a477955b8242a9ccd9fe818244164` against canonical main `f75f722bb4a1ec9642c8df36c8924e24500d78f0`, including formatting, lint, repository checks, secret scanning, commit-message validation, and applicable pre-push checks. Validator source, configuration, dependency bytes, and resolved executables were checked before execution.
- Earlier implementation checks at `35bcbe640b4086a0452e37c93ece63aa9c1850c5`: 1,391 gateway/component/machine regression tests passed; CLI typecheck and build passed; `npm run test:projects:check` passed; `npm run docs` passed with zero errors and five existing warnings.
- Focused live qualification: **10 generic cases passed using real released OpenShell 0.0.116 gateway, supervisor, and CLI processes**, on Linux ARM64. OpenShell source: `d1155aa70042d3e2ee49dbfa15346b108b7c1d92`; release archive checksums were verified. Evidence covers TLS registration, caller identity and audience checks, policy/profile delivery, admission denial, middleware allow/deny and unavailable-service denial, incompatible bindings, missing services, authentication rejection, and unresolved profiles.
- Standalone live revision: `35bcbe640b4086a0452e37c93ece63aa9c1850c5`. Combined live revision: `4a58ea8932ae4abaef086af44d84ce45dab08194`, including #11486 candidate `c52408724bdb4c660e5e97cd461f2f993048ddee`. The combined cases used production activation-proof and finalization code with a real sandbox identity. Activation succeeded in 176 ms; a 30,106 ms timeout preserved the sandbox and incomplete-activation evidence without retrying. The fixture supplied the registry entry; this was not a full onboarding run. The changed implementation files are unchanged by the publication rebase.
- The diff contains no secrets, API keys, or credentials. Examples use generic component names. Disposable live-test keys and task resources were removed.

## Review notes

All 11 changed files match the canonical sensitive-path policy under `src/lib/onboard/**`. Self-review covered the complete NVIDIA/NemoClaw diff and the two-file test repair at `f39217e9c05a477955b8242a9ccd9fe818244164`. CodeRabbit and all nine [Advisor specialists](https://github.com/NVIDIA/NemoClaw/actions/runs/34572310804) completed review of `1b6e94431559234e5971952c531735506589e307`; its CI passed. Their shared preparation-handoff test finding is repaired. Evaluation of the repair revision remains required.

[The maintainer acceptance record](https://github.com/NVIDIA/NemoClaw/issues/11507#issuecomment-5630870109) names the accountable owner and records the approved scope, dynamic manifest authority, and validation limits. It does not waive qualification or CI. The reported managed-gateway reuse concern is handled by the existing component-identity drift comparison in `docker-driver-gateway-runtime.ts` and `gateway-reuse.ts`; the focused regression selection passes those owners' tests. Published `docs/**` changes remain with Docs / Post-Merge Catch-Up under the explicit AGENTS.md policy; the owning source README is included here.

The shared OpenShell pin remains 0.0.106. #11229 / #11251 owns its upgrade; this change does not add a component-specific version pin. Full fresh application onboarding, inference, and MCP qualification remain pending. The generic live fixture and deterministic tests do not establish full integration or release qualification. No OpenShell issue or PR is part of this change.

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added version 2 external-component onboarding for Linux.
  - Added provider profiles, middleware connections, HTTPS metadata, and Docker network configuration.
  - Added gateway preparation and validation before activation and startup.
  - Added certificate trust verification and detection of configuration, network, or identity changes.

- **Bug Fixes**
  - Improved handling of invalid endpoints, certificates, network settings, and preparation failures.
  - Preserved compatibility with version 1 and Unix-socket configurations.

- **Documentation**
  - Documented the version 2 external-component onboarding contract and operational requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->