### PR TITLE
fix(inference): probe the published managed vLLM port

### DIFF
--- a/src/lib/inference/local-vllm-published-port.test.ts
+++ b/src/lib/inference/local-vllm-published-port.test.ts
@@ -4,6 +4,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 const PUBLISHED_HOST_PORT = 46_145;
+const AMBIENT_CONTEXT = "remote-builder";
 
 vi.mock("../adapters/docker/container", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../adapters/docker/container")>()),
@@ -39,13 +40,16 @@ describe("managed vLLM status probe port resolution", () => {
     const endpoint = probedArgv.find((arg) => arg.includes("/v1/models")) ?? "";
     expect(endpoint).toContain(`:${PUBLISHED_HOST_PORT}`);
   });
-  it("finds the container when only a non-default Docker context publishes it", () => {
-    // An ordinary managed profile follows the ambient Docker client
-    // configuration, so the local daemon reports nothing for it.
-    let selectionsProbed = 0;
-    vi.mocked(dockerPort).mockImplementation(() => {
-      selectionsProbed += 1;
-      return selectionsProbed === 1 ? "" : `0.0.0.0:${PUBLISHED_HOST_PORT}\n`;
+  it("finds the container only through the ambient Docker selection", () => {
+    // The local-daemon selection pins DOCKER_CONTEXT to "default"; the ambient
+    // selection carries whatever this process has configured. An ordinary
+    // managed profile is launched with the ambient one.
+    vi.stubEnv("DOCKER_CONTEXT", AMBIENT_CONTEXT);
+    const selectorsProbed: (string | undefined)[] = [];
+    vi.mocked(dockerPort).mockImplementation((_name, _port, opts) => {
+      const selector = opts?.env?.DOCKER_CONTEXT;
+      selectorsProbed.push(selector);
+      return selector === AMBIENT_CONTEXT ? `0.0.0.0:${PUBLISHED_HOST_PORT}\n` : "";
     });
     const probedArgv: string[] = [];
 
@@ -66,7 +70,8 @@ describe("managed vLLM status probe port resolution", () => {
       },
     });
 
-    expect(selectionsProbed).toBeGreaterThan(1);
+    expect(selectorsProbed).toContain("default");
+    expect(selectorsProbed).toContain(AMBIENT_CONTEXT);
     const endpoint = probedArgv.find((arg) => arg.includes("/v1/models")) ?? "";
     expect(endpoint).toContain(`:${PUBLISHED_HOST_PORT}`);
   });

--- a/src/lib/inference/local-vllm-published-port.test.ts
+++ b/src/lib/inference/local-vllm-published-port.test.ts
@@ -10,6 +10,7 @@ vi.mock("../adapters/docker/container", async (importOriginal) => ({
   dockerPort: vi.fn(() => `0.0.0.0:${PUBLISHED_HOST_PORT}\n[::]:${PUBLISHED_HOST_PORT}\n`),
 }));
 
+import { dockerPort } from "../adapters/docker/container";
 import { probeLocalProviderHealth } from "./local";
 
 describe("managed vLLM status probe port resolution", () => {
@@ -35,6 +36,37 @@ describe("managed vLLM status probe port resolution", () => {
       },
     });
 
+    const endpoint = probedArgv.find((arg) => arg.includes("/v1/models")) ?? "";
+    expect(endpoint).toContain(`:${PUBLISHED_HOST_PORT}`);
+  });
+  it("finds the container when only a non-default Docker context publishes it", () => {
+    // An ordinary managed profile follows the ambient Docker client
+    // configuration, so the local daemon reports nothing for it.
+    let selectionsProbed = 0;
+    vi.mocked(dockerPort).mockImplementation(() => {
+      selectionsProbed += 1;
+      return selectionsProbed === 1 ? "" : `0.0.0.0:${PUBLISHED_HOST_PORT}\n`;
+    });
+    const probedArgv: string[] = [];
+
+    probeLocalProviderHealth("vllm-local", {
+      model: "served-model",
+      getManagedVllmBaseUrlImpl: () => null,
+      loadVllmApiKeyImpl: () => null,
+      runCurlProbeImpl: (argv) => {
+        probedArgv.push(...argv);
+        return {
+          ok: true,
+          httpStatus: 200,
+          curlStatus: 0,
+          body: '{"data":[{"id":"served-model"}]}',
+          stderr: "",
+          message: "HTTP 200",
+        };
+      },
+    });
+
+    expect(selectionsProbed).toBeGreaterThan(1);
     const endpoint = probedArgv.find((arg) => arg.includes("/v1/models")) ?? "";
     expect(endpoint).toContain(`:${PUBLISHED_HOST_PORT}`);
   });

--- a/src/lib/inference/local-vllm-published-port.test.ts
+++ b/src/lib/inference/local-vllm-published-port.test.ts
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+const PUBLISHED_HOST_PORT = 46_145;
+
+vi.mock("../adapters/docker/container", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../adapters/docker/container")>()),
+  dockerPort: vi.fn(() => `0.0.0.0:${PUBLISHED_HOST_PORT}\n[::]:${PUBLISHED_HOST_PORT}\n`),
+}));
+
+import { probeLocalProviderHealth } from "./local";
+
+describe("managed vLLM status probe port resolution", () => {
+  it("probes the published host port of the managed container, not the default", () => {
+    const probedArgv: string[] = [];
+
+    probeLocalProviderHealth("vllm-local", {
+      model: "served-model",
+      // An unauthenticated managed container yields no recovered binding, which
+      // is the state reported in #11374 for a custom NEMOCLAW_VLLM_PORT run.
+      getManagedVllmBaseUrlImpl: () => null,
+      loadVllmApiKeyImpl: () => null,
+      runCurlProbeImpl: (argv) => {
+        probedArgv.push(...argv);
+        return {
+          ok: true,
+          httpStatus: 200,
+          curlStatus: 0,
+          body: '{"data":[{"id":"served-model"}]}',
+          stderr: "",
+          message: "HTTP 200",
+        };
+      },
+    });
+
+    const endpoint = probedArgv.find((arg) => arg.includes("/v1/models")) ?? "";
+    expect(endpoint).toContain(`:${PUBLISHED_HOST_PORT}`);
+  });
+});

--- a/src/lib/inference/local.ts
+++ b/src/lib/inference/local.ts
@@ -82,6 +82,7 @@ import {
   recoverInstalledManagedClusterVllmEndpoint,
 } from "./serving/managed-cluster-runtime-receipt";
 import {
+  observeManagedVllmHostPort,
   recoverHostLocalManagedVllmEndpoint,
   resolveManagedVllmBridgeHost,
 } from "./serving/vllm-host-local-lifecycle";
@@ -1229,7 +1230,7 @@ export function getLocalProviderBaseUrl(
         if (managed.kind === "unavailable") return null;
         if (managed.binding) return managed.binding.baseUrl;
       }
-      return `${hostUrl}:${VLLM_PORT}/v1`;
+      return `${hostUrl}:${managedVllmPublishedPort()}/v1`;
     }
     case "ollama-local":
       // Containers reach Ollama through the auth proxy, not directly.
@@ -1239,6 +1240,20 @@ export function getLocalProviderBaseUrl(
   }
 }
 
+/**
+ * Published host port for the managed vLLM listener.
+ *
+ * `NEMOCLAW_VLLM_PORT` is read once from this process's environment, so a
+ * status or routing call made from a shell that does not carry the onboarding
+ * override would otherwise address the default port while the container
+ * publishes another one. Observing the container's own binding keeps every
+ * derived URL on the port the listener actually serves, and the ambient value
+ * remains the answer when no managed container is published.
+ */
+function managedVllmPublishedPort(): number {
+  return observeManagedVllmHostPort() ?? VLLM_PORT;
+}
+
 export function getLocalProviderValidationBaseUrl(provider: string): string | null {
   switch (provider) {
     case "vllm-local": {
@@ -1246,7 +1261,7 @@ export function getLocalProviderValidationBaseUrl(provider: string): string | nu
       if (managed.kind === "unavailable") return null;
       return managed.binding
         ? (managed.binding.validationBaseUrl ?? managed.binding.baseUrl)
-        : `http://127.0.0.1:${VLLM_PORT}/v1`;
+        : `http://127.0.0.1:${managedVllmPublishedPort()}/v1`;
     }
     case "ollama-local":
       return `http://${getResolvedOllamaHost()}:${OLLAMA_PORT}/v1`;
@@ -1265,7 +1280,7 @@ export function getLocalProviderHealthEndpoint(provider: string): string | null 
         : null;
       return managedBaseUrl
         ? `${managedBaseUrl}/models`
-        : `http://127.0.0.1:${VLLM_PORT}/v1/models`;
+        : `http://127.0.0.1:${managedVllmPublishedPort()}/v1/models`;
     }
     case "ollama-local":
       return `http://${getResolvedOllamaHost()}:${OLLAMA_PORT}/api/tags`;
@@ -1286,7 +1301,7 @@ export function getLocalProviderAvailabilityEndpoint(provider: string): string |
       );
       return `${validationRoot}/health`;
     }
-    return `http://127.0.0.1:${VLLM_PORT}/v1/models`;
+    return `http://127.0.0.1:${managedVllmPublishedPort()}/v1/models`;
   }
   return getLocalProviderHealthEndpoint(provider);
 }
@@ -1523,7 +1538,7 @@ export function probeLocalProviderHealth(
   const endpoint = managedValidationBaseUrl
     ? `${managedValidationBaseUrl}/models`
     : provider === "vllm-local"
-      ? `http://127.0.0.1:${VLLM_PORT}/v1/models`
+      ? `http://127.0.0.1:${managedVllmPublishedPort()}/v1/models`
       : getLocalProviderHealthEndpoint(provider);
   if (!endpoint) return null;
 
@@ -1674,7 +1689,7 @@ export function getLocalProviderContainerReachabilityCheck(
         ...(managedBaseUrl ? ["-w", "%{http_code}"] : []),
         managedBaseUrl
           ? `${managedBaseUrl}/health`
-          : `http://host.openshell.internal:${VLLM_PORT}/v1/models`,
+          : `http://host.openshell.internal:${managedVllmPublishedPort()}/v1/models`,
       ];
     }
     case "ollama-local": {
@@ -1943,7 +1958,7 @@ function getContainerCheckUrl(provider: string): string | null {
       const managedBaseUrl = managed.binding?.baseUrl.replace(/\/v1\/?$/, "") ?? null;
       return managedBaseUrl
         ? `${managedBaseUrl}/health`
-        : `http://host.openshell.internal:${VLLM_PORT}/v1/models`;
+        : `http://host.openshell.internal:${managedVllmPublishedPort()}/v1/models`;
     }
     case "ollama-local":
       return `http://host.openshell.internal:${getOllamaContainerPort()}/api/tags`;

--- a/src/lib/inference/serving/vllm-host-local-lifecycle.ts
+++ b/src/lib/inference/serving/vllm-host-local-lifecycle.ts
@@ -9,7 +9,7 @@ import { dockerPort } from "../../adapters/docker/container";
 import { dockerCapture } from "../../adapters/docker/local-model-runtime";
 import { writeLocalAdapterJsonFile } from "../local-adapter-lifecycle";
 import { loadManagedVllmApiKey, managedVllmStateDir } from "../vllm-api-key";
-import { buildLocalManagedVllmDockerEnv } from "../vllm-docker-env";
+import { buildLocalManagedVllmDockerEnv, buildVllmDockerEnv } from "../vllm-docker-env";
 import { runtimeAuthFingerprint } from "./runtime-auth-fingerprint";
 import {
   resolveManagedVllmBridgeHost,
@@ -289,15 +289,23 @@ function inspectHostLocalContainer(
 export function observeManagedVllmHostPort(
   options: { readonly dockerPortImpl?: typeof dockerPort } = {},
 ): number | null {
-  const mapping = (options.dockerPortImpl ?? dockerPort)(
-    HOST_LOCAL_VLLM_CONTAINER_NAME,
-    HOST_LOCAL_VLLM_CONTAINER_PORT,
-    { env: buildLocalManagedVllmDockerEnv(), ignoreError: true, timeout: 10_000 },
-  );
-  const published = mapping?.match(/:(\d+)\s*$/);
-  if (!published) return null;
-  const port = Number(published[1]);
-  return Number.isSafeInteger(port) && port >= 1 && port <= 65_535 ? port : null;
+  const probe = options.dockerPortImpl ?? dockerPort;
+  // Match the Docker selection used to launch the runtime being observed: a
+  // managed container started for an authenticated profile lives on the local
+  // daemon, while an ordinary managed profile follows the ambient client
+  // configuration. Checking the local daemon first keeps the dual-Station pair
+  // authoritative, exactly as container ownership inspection resolves it.
+  for (const env of [buildLocalManagedVllmDockerEnv(), buildVllmDockerEnv()]) {
+    const published = probe(HOST_LOCAL_VLLM_CONTAINER_NAME, HOST_LOCAL_VLLM_CONTAINER_PORT, {
+      env,
+      ignoreError: true,
+      timeout: 10_000,
+    })?.match(/:(\d+)\s*$/);
+    if (!published) continue;
+    const port = Number(published[1]);
+    if (Number.isSafeInteger(port) && port >= 1 && port <= 65_535) return port;
+  }
+  return null;
 }
 
 /** Recover only the exact authenticated host-local container with bounded host bindings. */

--- a/src/lib/inference/serving/vllm-host-local-lifecycle.ts
+++ b/src/lib/inference/serving/vllm-host-local-lifecycle.ts
@@ -5,6 +5,7 @@ import { timingSafeEqual } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 
+import { dockerPort } from "../../adapters/docker/container";
 import { dockerCapture } from "../../adapters/docker/local-model-runtime";
 import { writeLocalAdapterJsonFile } from "../local-adapter-lifecycle";
 import { loadManagedVllmApiKey, managedVllmStateDir } from "../vllm-api-key";
@@ -274,6 +275,29 @@ function inspectHostLocalContainer(
     ignoreError: true,
     timeout: 10_000,
   });
+}
+
+/**
+ * Host port the managed container publishes for the vLLM listener.
+ *
+ * Endpoint recovery additionally proves the bearer binding and therefore
+ * returns nothing for a container started without managed authentication.
+ * Reachability does not depend on that proof, so callers that only need to
+ * know where the listener is published observe the published binding here
+ * instead of assuming the ambient `NEMOCLAW_VLLM_PORT` default.
+ */
+export function observeManagedVllmHostPort(
+  options: { readonly dockerPortImpl?: typeof dockerPort } = {},
+): number | null {
+  const mapping = (options.dockerPortImpl ?? dockerPort)(
+    HOST_LOCAL_VLLM_CONTAINER_NAME,
+    HOST_LOCAL_VLLM_CONTAINER_PORT,
+    { env: buildLocalManagedVllmDockerEnv(), ignoreError: true, timeout: 10_000 },
+  );
+  const published = mapping?.match(/:(\d+)\s*$/);
+  if (!published) return null;
+  const port = Number(published[1]);
+  return Number.isSafeInteger(port) && port >= 1 && port <= 65_535 ? port : null;
 }
 
 /** Recover only the exact authenticated host-local container with bounded host bindings. */


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

`nemoclaw <sandbox> status` now probes the host port the managed vLLM container actually publishes, so a sandbox onboarded with a custom `NEMOCLAW_VLLM_PORT` reports its healthy backend as reachable instead of unreachable. Every other locally derived vLLM URL follows the same published binding.

## Reason

`VLLM_PORT` is parsed once from this process's environment when `src/lib/core/ports.ts` loads, so it carries the override only for a shell that exports it. A status call made from any other shell fell back to the default 8000 while the container published, for example, `0.0.0.0:46145->8000/tcp`, and reported `unreachable (http://127.0.0.1:8000/v1/models)` for a listener that was serving normally.

The managed-endpoint recovery that would have supplied the real binding cannot cover this: it exists to prove the bearer credential, so it returns nothing for a container started without managed authentication, and the fallback below it assumed the ambient port.

### Related issues

Fixes #11374

This PR delivers the status half of that report. The leftover-container half is a separate failure boundary and is not addressed here.

## Changes

- `src/lib/inference/serving/vllm-host-local-lifecycle.ts` — add `observeManagedVllmHostPort()`, which reads the container's published binding for the fixed container port and validates it as a TCP port. It makes no authentication claim, and it checks the local daemon first and then the ambient Docker client configuration, matching how container ownership inspection resolves the same pair.
- `src/lib/inference/local.ts` — resolve the managed fallback port through that observation, falling back to the ambient value only when no managed container publishes one. The seven URLs that previously interpolated `VLLM_PORT` directly now share this single resolver.

## Verification

- `npx vitest run src/lib/inference/local-vllm-published-port.test.ts` — the new test fails on the unmodified source with `expected 'http://127.0.0.1:8000/v1/models' to contain ':46145'`, which is the endpoint string quoted in the issue, and passes with the change.
- `npx vitest run src/lib/inference/local-vllm-published-port.test.ts` — a second test covers a container visible only under a non-default Docker context. It fails when the observation is restricted to the local daemon and passes with both selections.
- `npx vitest run src/lib/inference/` — 121 files, 2646 passed, 1 skipped, 0 failed, repeated across four consecutive runs.
- `npm run validate:pr` — passed on a clean tree: 17 hooks passed, 17 skipped as not applicable, 0 failed, including `gitleaks (secret scan)`, `Codebase growth guardrails`, `Source-shape test budget`, and `TypeScript (CLI)`.
- `npm run format` — applied before the final commit; the tree is clean.
- Collision search — no open PR or merged commit touches `observeManagedVllmHostPort`, `getLocalProviderHealthEndpoint`, or the `VLLM_PORT` fallbacks; no other PR references #11374.
- Secret review — the diff adds no credential handling and reads only a container port mapping.

## Review notes

**Why one resolver instead of seven fixes.** The same ambient-port fallback appeared in `getLocalProviderBaseUrl`, `getLocalProviderValidationBaseUrl`, `getLocalProviderHealthEndpoint`, `getLocalProviderAvailabilityEndpoint`, the probe in `probeLocalProviderHealth`, and two `host.openshell.internal` URLs. Repairing only the status probe would have left the same defect reachable through the sibling paths, and repairing each in place would have duplicated the resolution seven times. Routing all of them through one resolver closes the class and leaves each call site a single expression.

**Why recovery was not changed.** `recoverHostLocalManagedVllmEndpoint` returns an API key and therefore must keep requiring the auth label, the exact bindings, and the credential fingerprint. Port observation is a separate concern with no credential claim, so it is a new function rather than a relaxation of that contract.

**Sibling checked and excluded.** `ollama-local` interpolates `OLLAMA_PORT` from the same ambient source, but Ollama is installed on the host through systemd rather than published by a NemoClaw-managed container, so there is no published binding to observe and the same repair does not apply. It is unchanged here.

**Review follow-up.** The first revision observed the port through the local-daemon Docker environment, which only matches a container started for an authenticated profile. An ordinary managed profile follows the ambient client configuration, so its container was missed under a non-default `DOCKER_HOST` or `DOCKER_CONTEXT` and the callers fell back to the ambient port again. The observation now tries the local daemon and then the ambient configuration, and the added test pins the non-default context.

**Fork CI.** `openshell-sdk-package` and the checks that depend on it cannot run for a fork pull request, so the local results above are the evidence for this change.

---
Signed-off-by: Ho Lim <subhoya@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved managed vLLM connectivity by automatically detecting the container’s published host port across supported Docker environments.
  - Health checks, availability checks, validation, diagnostics, and reachability checks now use the detected port when available, with a fallback to the configured port when detection is unavailable.
  - Improved reliability when managed container port bindings differ from the configured port.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->