### PR TITLE
fix(installer): name the connection failure when the install ref fetch cannot reach GitHub

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -66,6 +66,27 @@ has_payload_marker() {
   [[ -f "$file" ]] && grep -q "$PAYLOAD_MARKER" "$file"
 }
 
+# Git reports a transport failure as "unable to access" before it can look up
+# the ref, so that text separates a missing ref from a failed connection. curl
+# prints the same "Couldn't connect to server" for a refused and a timed-out
+# connect; only the reported connect duration tells them apart.
+INSTALL_REF_CONNECT_TIMEOUT_HINT_MS=10000
+
+classify_install_ref_fetch_failure() {
+  local git_error="$1" connect_ms=""
+  if [[ "$git_error" != *"unable to access"* ]]; then
+    printf 'missing-ref'
+    return 0
+  fi
+  [[ "$git_error" =~ after\ ([0-9]+)\ ms ]] && connect_ms="${BASH_REMATCH[1]}"
+  if [[ "$git_error" == *"timed out"* || "$git_error" == *"Timeout"* || "$git_error" == *"timeout"* ]] \
+    || [[ -n "$connect_ms" && "$connect_ms" -ge "$INSTALL_REF_CONNECT_TIMEOUT_HINT_MS" ]]; then
+    printf 'connect-timeout'
+    return 0
+  fi
+  printf 'connect-failed'
+}
+
 clone_nemoclaw_ref() {
   local ref="$1" dest="$2"
 
@@ -74,9 +95,23 @@ clone_nemoclaw_ref() {
     umask 022
     git init --quiet "$dest"
     git -C "$dest" remote add origin https://github.com/NVIDIA/NemoClaw.git
-    if ! git -C "$dest" fetch --quiet --depth 1 origin "+${ref}:refs/nemoclaw-install/target"; then
-      printf "[ERROR] Requested install ref '%s' is not available from https://github.com/NVIDIA/NemoClaw.git.\n" "$ref" >&2
-      printf "        Check NEMOCLAW_INSTALL_TAG/NEMOCLAW_INSTALL_REF and try again.\n" >&2
+    local fetch_error=""
+    if ! fetch_error="$(git -C "$dest" fetch --quiet --depth 1 origin "+${ref}:refs/nemoclaw-install/target" 2>&1)"; then
+      [[ -z "$fetch_error" ]] || printf '%s\n' "$fetch_error" >&2
+      case "$(classify_install_ref_fetch_failure "$fetch_error")" in
+        connect-timeout)
+          printf "[ERROR] Timed out connecting to https://github.com/NVIDIA/NemoClaw.git while looking up install ref '%s'.\n" "$ref" >&2
+          printf "        The installed CLI was not changed. Check network access to github.com and try again.\n" >&2
+          ;;
+        connect-failed)
+          printf "[ERROR] Could not connect to https://github.com/NVIDIA/NemoClaw.git to look up install ref '%s'.\n" "$ref" >&2
+          printf "        The installed CLI was not changed. Check network access to github.com and try again.\n" >&2
+          ;;
+        *)
+          printf "[ERROR] Requested install ref '%s' is not available from https://github.com/NVIDIA/NemoClaw.git.\n" "$ref" >&2
+          printf "        The installed CLI was not changed. Check NEMOCLAW_INSTALL_TAG/NEMOCLAW_INSTALL_REF and try again.\n" >&2
+          ;;
+      esac
       exit 1
     fi
     git -C "$dest" -c advice.detachedHead=false checkout --quiet --detach refs/nemoclaw-install/target

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3119,9 +3119,14 @@ install_nemoclaw() {
     if is_reusable_managed_nemoclaw_install "$nemoclaw_src"; then
       info "Reusing the installed ${_CLI_DISPLAY} CLI at the selected revision."
     else
-      rm -rf "$nemoclaw_src"
+      # Clone beside the installed source and swap only after the fetch
+      # succeeds, so a failed fetch leaves the installed CLI in place.
+      local nemoclaw_staging="${nemoclaw_src}.staging"
+      rm -rf "$nemoclaw_staging"
       mkdir -p "$(dirname "$nemoclaw_src")"
-      spin "Cloning ${_CLI_DISPLAY} source" clone_nemoclaw_ref "$release_ref" "$nemoclaw_src"
+      spin "Cloning ${_CLI_DISPLAY} source" clone_nemoclaw_ref "$release_ref" "$nemoclaw_staging"
+      rm -rf "$nemoclaw_src"
+      mv "$nemoclaw_staging" "$nemoclaw_src"
       # Fetch version tags into the shallow clone so `git describe --tags
       # --match "v*"` works at runtime (the shallow clone only has the
       # single ref we asked for).

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -187,6 +187,27 @@ resolve_stamped_version() {
   printf "%s" "$version"
 }
 
+# Git reports a transport failure as "unable to access" before it can look up
+# the ref, so that text separates a missing ref from a failed connection. curl
+# prints the same "Couldn't connect to server" for a refused and a timed-out
+# connect; only the reported connect duration tells them apart.
+INSTALL_REF_CONNECT_TIMEOUT_HINT_MS=10000
+
+classify_install_ref_fetch_failure() {
+  local git_error="$1" connect_ms=""
+  if [[ "$git_error" != *"unable to access"* ]]; then
+    printf 'missing-ref'
+    return 0
+  fi
+  [[ "$git_error" =~ after\ ([0-9]+)\ ms ]] && connect_ms="${BASH_REMATCH[1]}"
+  if [[ "$git_error" == *"timed out"* || "$git_error" == *"Timeout"* || "$git_error" == *"timeout"* ]] \
+    || [[ -n "$connect_ms" && "$connect_ms" -ge "$INSTALL_REF_CONNECT_TIMEOUT_HINT_MS" ]]; then
+    printf 'connect-timeout'
+    return 0
+  fi
+  printf 'connect-failed'
+}
+
 clone_nemoclaw_ref() {
   local ref="$1" dest="$2"
 
@@ -195,8 +216,20 @@ clone_nemoclaw_ref() {
     umask 022
     git init --quiet "$dest"
     git -C "$dest" remote add origin https://github.com/NVIDIA/NemoClaw.git
-    if ! git -C "$dest" fetch --quiet --depth 1 origin "+${ref}:refs/nemoclaw-install/target"; then
-      error "Requested install ref '$ref' is not available from https://github.com/NVIDIA/NemoClaw.git. Check NEMOCLAW_INSTALL_TAG/NEMOCLAW_INSTALL_REF and try again."
+    local fetch_error=""
+    if ! fetch_error="$(git -C "$dest" fetch --quiet --depth 1 origin "+${ref}:refs/nemoclaw-install/target" 2>&1)"; then
+      [[ -z "$fetch_error" ]] || printf '%s\n' "$fetch_error" >&2
+      case "$(classify_install_ref_fetch_failure "$fetch_error")" in
+        connect-timeout)
+          error "Timed out connecting to https://github.com/NVIDIA/NemoClaw.git while looking up install ref '$ref'. The installed CLI was not changed. Check network access to github.com and try again."
+          ;;
+        connect-failed)
+          error "Could not connect to https://github.com/NVIDIA/NemoClaw.git to look up install ref '$ref'. The installed CLI was not changed. Check network access to github.com and try again."
+          ;;
+        *)
+          error "Requested install ref '$ref' is not available from https://github.com/NVIDIA/NemoClaw.git. The installed CLI was not changed. Check NEMOCLAW_INSTALL_TAG/NEMOCLAW_INSTALL_REF and try again."
+          ;;
+      esac
     fi
     git -C "$dest" -c advice.detachedHead=false checkout --quiet --detach refs/nemoclaw-install/target
   )

--- a/test/installer-integration/install-clone-ref.test.ts
+++ b/test/installer-integration/install-clone-ref.test.ts
@@ -3,6 +3,7 @@
 
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
+import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 
@@ -196,6 +197,147 @@ describe("installer version stamping", testTimeoutOptions(15_000), () => {
       } finally {
         fs.rmSync(tmp, { recursive: true, force: true });
       }
+    },
+  );
+});
+
+describe("installer git checkout failures", testTimeoutOptions(15_000), () => {
+  const REPO_URL = "https://github.com/NVIDIA/NemoClaw.git";
+
+  const cloneWithGitConfig = (
+    installer: string,
+    ref: string,
+    destination: string,
+    gitConfig: Record<string, string>,
+  ) => {
+    const entries = Object.entries(gitConfig);
+    return spawnSync(
+      "bash",
+      ["-c", 'source "$INSTALLER_UNDER_TEST"\nclone_nemoclaw_ref "$REF" "$DESTINATION"'],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          DESTINATION: destination,
+          GIT_CONFIG_COUNT: String(entries.length),
+          ...Object.fromEntries(
+            entries.flatMap(([key, value], index) => [
+              [`GIT_CONFIG_KEY_${index}`, key],
+              [`GIT_CONFIG_VALUE_${index}`, value],
+            ]),
+          ),
+          INSTALLER_UNDER_TEST: installer,
+          REF: ref,
+        },
+      },
+    );
+  };
+
+  const closedLoopbackPort = () =>
+    new Promise<number>((resolve, reject) => {
+      const server = net.createServer();
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        const { port } = server.address() as net.AddressInfo;
+        server.close(() => resolve(port));
+      });
+    });
+
+  it.each([INSTALLER_PAYLOAD, CURL_PIPE_INSTALLER])(
+    "reports a missing ref and states that the installed CLI was not changed [case %#] (#11515)",
+    (installer) => {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-clone-missing-ref-"));
+      const origin = path.join(tmp, "origin");
+      fs.mkdirSync(origin);
+      const git = (args: string[]) => spawnSync("git", args, { cwd: origin, encoding: "utf8" });
+
+      try {
+        expect(git(["init", "--initial-branch=main"]).status).toBe(0);
+        expect(git(["config", "user.name", "NemoClaw Test"]).status).toBe(0);
+        expect(git(["config", "user.email", "nemoclaw-test@example.invalid"]).status).toBe(0);
+        fs.writeFileSync(path.join(origin, "README.md"), "fixture\n");
+        expect(git(["add", "README.md"]).status).toBe(0);
+        expect(git(["-c", "commit.gpgsign=false", "commit", "-m", "fixture"]).status).toBe(0);
+
+        const result = cloneWithGitConfig(
+          installer,
+          "refs/heads/does-not-exist",
+          path.join(tmp, "checkout"),
+          { [`url.file://${origin}.insteadOf`]: REPO_URL },
+        );
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain(
+          `Requested install ref 'refs/heads/does-not-exist' is not available from ${REPO_URL}.`,
+        );
+        expect(result.stderr).toContain("The installed CLI was not changed.");
+        expect(result.stderr).not.toContain("Could not connect");
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.each([INSTALLER_PAYLOAD, CURL_PIPE_INSTALLER])(
+    "reports a refused connection as unreachable instead of a missing ref [case %#] (#11515)",
+    async (installer) => {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-clone-refused-"));
+      const closedPort = await closedLoopbackPort();
+
+      try {
+        const result = cloneWithGitConfig(installer, "lkg", path.join(tmp, "checkout"), {
+          [`url.http://127.0.0.1:${closedPort}/NemoClaw.git.insteadOf`]: REPO_URL,
+          "http.proxy": "",
+        });
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain(
+          `Could not connect to ${REPO_URL} to look up install ref 'lkg'.`,
+        );
+        expect(result.stderr).toContain("The installed CLI was not changed.");
+        expect(result.stderr).not.toContain("is not available");
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.each([INSTALLER_PAYLOAD, CURL_PIPE_INSTALLER])(
+    "separates a timed-out connect from a refused one by the reported connect duration [case %#] (#11515)",
+    (installer) => {
+      const classify = (gitError: string) => {
+        const result = spawnSync(
+          "bash",
+          ["-c", 'source "$INSTALLER_UNDER_TEST"\nclassify_install_ref_fetch_failure "$GIT_ERROR"'],
+          {
+            encoding: "utf8",
+            env: { ...process.env, GIT_ERROR: gitError, INSTALLER_UNDER_TEST: installer },
+          },
+        );
+        expect(result.status, result.stderr).toBe(0);
+        return result.stdout;
+      };
+      const unableToAccess = `fatal: unable to access '${REPO_URL}/': `;
+
+      expect(
+        classify(
+          `${unableToAccess}Failed to connect to github.com port 443 after 3 ms: Couldn't connect to server`,
+        ),
+      ).toBe("connect-failed");
+      expect(
+        classify(
+          `${unableToAccess}Failed to connect to github.com port 443 after 131512 ms: Couldn't connect to server`,
+        ),
+      ).toBe("connect-timeout");
+      expect(
+        classify(
+          `${unableToAccess}Failed to connect to github.com port 443 after 129003 ms: Connection timed out`,
+        ),
+      ).toBe("connect-timeout");
+      expect(classify(`${unableToAccess}Could not resolve host: github.com`)).toBe(
+        "connect-failed",
+      );
+      expect(classify("fatal: couldn't find remote ref refs/heads/does-not-exist")).toBe(
+        "missing-ref",
+      );
     },
   );
 });

--- a/test/installer-integration/install-clone-ref.test.ts
+++ b/test/installer-integration/install-clone-ref.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import net from "node:net";
 import os from "node:os";
@@ -340,4 +341,92 @@ describe("installer git checkout failures", testTimeoutOptions(15_000), () => {
       );
     },
   );
+
+  const sha256 = (file: string) => createHash("sha256").update(fs.readFileSync(file)).digest("hex");
+
+  const installedCliFixture = (root: string) => {
+    const bin = path.join(root, "bin");
+    fs.mkdirSync(bin);
+    const cli = path.join(bin, "nemoclaw");
+    fs.writeFileSync(cli, "#!/usr/bin/env bash\nprintf 'nemoclaw v0.0.118\\n'\n", { mode: 0o755 });
+    return { bin, cli, digest: sha256(cli) };
+  };
+
+  const unreachableGitHubEnv = (closedPort: number) => ({
+    GIT_CONFIG_COUNT: "2",
+    GIT_CONFIG_KEY_0: `url.http://127.0.0.1:${closedPort}/NemoClaw.git.insteadOf`,
+    GIT_CONFIG_VALUE_0: REPO_URL,
+    GIT_CONFIG_KEY_1: "http.proxy",
+    GIT_CONFIG_VALUE_1: "",
+  });
+
+  it("leaves the installed CLI untouched when the curl|bash bootstrap cannot reach GitHub (#11515)", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-bootstrap-unreachable-"));
+    const closedPort = await closedLoopbackPort();
+
+    try {
+      const installed = installedCliFixture(root);
+      const result = spawnSync("bash", [], {
+        cwd: root,
+        input: fs.readFileSync(CURL_PIPE_INSTALLER, "utf8"),
+        encoding: "utf8",
+        env: {
+          HOME: root,
+          PATH: `${installed.bin}:/usr/bin:/bin`,
+          TMPDIR: root,
+          ...unreachableGitHubEnv(closedPort),
+        },
+      });
+      expect(result.status, result.stderr).toBe(1);
+      expect(result.stderr).toContain(
+        `[ERROR] Could not connect to ${REPO_URL} to look up install ref 'lkg'.`,
+      );
+      expect(result.stderr).toContain("The installed CLI was not changed.");
+      expect(sha256(installed.cli)).toBe(installed.digest);
+      expect(fs.readdirSync(root)).toEqual(["bin"]);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("leaves the installed CLI and managed source untouched when the payload cannot reach GitHub (#11515)", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-payload-unreachable-"));
+    const closedPort = await closedLoopbackPort();
+
+    try {
+      const installed = installedCliFixture(root);
+      const managedSource = path.join(root, ".nemoclaw", "source");
+      fs.mkdirSync(managedSource, { recursive: true });
+      const managedMarker = path.join(managedSource, "installed-marker.txt");
+      fs.writeFileSync(managedMarker, "previous managed install\n");
+      const result = spawnSync(
+        "bash",
+        [
+          "-c",
+          'source "$INSTALLER_PAYLOAD" >/dev/null\nresolve_repo_root() { printf "%s" "$NON_SOURCE_ROOT"; }\ninstall_nemoclaw',
+        ],
+        {
+          cwd: root,
+          encoding: "utf8",
+          env: {
+            HOME: root,
+            PATH: `${installed.bin}:/usr/bin:/bin`,
+            TMPDIR: root,
+            INSTALLER_PAYLOAD,
+            NON_SOURCE_ROOT: path.join(root, "not-a-checkout"),
+            ...unreachableGitHubEnv(closedPort),
+          },
+        },
+      );
+      expect(result.status, `${result.stdout}${result.stderr}`).toBe(1);
+      expect(result.stderr).toContain(
+        `Could not connect to ${REPO_URL} to look up install ref 'lkg'.`,
+      );
+      expect(result.stderr).toContain("The installed CLI was not changed.");
+      expect(sha256(installed.cli)).toBe(installed.digest);
+      expect(fs.readFileSync(managedMarker, "utf8")).toBe("previous managed install\n");
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Outcome
Before: `clone_nemoclaw_ref` reported every failed `git fetch` as `Requested install ref '<ref>' is not available from https://github.com/NVIDIA/NemoClaw.git. Check NEMOCLAW_INSTALL_TAG/NEMOCLAW_INSTALL_REF and try again.`, also when github.com refused or dropped the connection, and it did not say whether the installed CLI was touched. In the versioned payload, the previous managed source was removed before the fetch, so a failed fetch there left the installed CLI without its source. After: the installer prints git's own error, reports a transport failure as `Could not connect to https://github.com/NVIDIA/NemoClaw.git to look up install ref '<ref>'.` or `Timed out connecting to https://github.com/NVIDIA/NemoClaw.git while looking up install ref '<ref>'.`, keeps the old wording only for a ref that really does not exist, ends every message with `The installed CLI was not changed.`, and the payload keeps the installed source until the new fetch has succeeded, so that sentence is true for both callers.

## Reason
With github.com blocked (REJECT and DROP), both installer runs in #11515 printed the "install ref is not available" text. The operator would check the ref name instead of the network, and could not tell that no replacement had started. Git reports a curl transport failure as `fatal: unable to access …` before it can look the ref up, so that text separates the two cases. curl prints the same `Couldn't connect to server` for a refused and for a timed-out connect; only the `after N ms` connect duration differs, so the classifier uses it (10 s threshold).

### Related issues
Closes #11515

## Changes
- `install.sh` (curl|bash bootstrap) and `scripts/install.sh` (versioned payload): `clone_nemoclaw_ref` captures the fetch stderr, re-prints it, and classifies the failure with a new `classify_install_ref_fetch_failure` helper that returns `missing-ref`, `connect-failed`, or `connect-timeout`. Each script keeps its own message style (two `[ERROR]` lines in the bootstrap, the `error` helper in the payload). The helper is duplicated in both scripts because the bootstrap runs before the payload exists, the same reason `clone_nemoclaw_ref` itself is duplicated.
- `scripts/install.sh` `install_nemoclaw`: the managed clone now targets `<source>.staging` and the installed source is removed and replaced only after the fetch succeeds. Before this, `rm -rf "$nemoclaw_src"` ran before the clone, so a fetch failure on a non-reusable install deleted the source behind the linked CLI while the message claimed it was unchanged.
- Requirement: the expected results in #11515. Consumers: `exec_installer_from_ref` in the bootstrap and `install_nemoclaw` in the payload. Changing the message text alone cannot separate a refused connect from a timed-out one, so the classifier is the smallest mechanism that meets the expectation. Protecting tests are below.
- `test/installer-integration/install-clone-ref.test.ts`:
  - three `it.each` cases over both installers: a missing ref against a `file://` origin; a refused connection against a closed loopback port (`url.<base>.insteadOf` plus `http.proxy=` so a proxy cannot intercept); and the classifier over fixture strings (3 ms refused, 131512 ms Linux SYN timeout, `Connection timed out`, DNS failure, missing ref);
  - two production-caller cases with real `git` against a closed loopback port: the curl|bash bootstrap (installer piped through `bash` stdin, so `bootstrap_main` runs) and the payload (`install_nemoclaw` with a non-source repo root). Each places an installed `nemoclaw` stub on `PATH` and asserts its SHA-256 is unchanged after the nonzero exit; the payload case also pre-places a managed source directory and asserts it is untouched. Without the staging change the payload case fails (`ENOENT` on the pre-placed marker), so it is a red→green regression test for the second change.

## Verification
- `npx vitest run --project installer-integration test/installer-integration/install-clone-ref.test.ts` — 14 passed (8 new).
- `npx vitest run --project installer-integration test/installer-integration/install-downgrade-guard.test.ts` — 72 passed (this suite drives the real payload to the managed clone with a fake `git`).
- Red proof: with `scripts/install.sh` reset to the first commit, the payload production-caller test fails with `ENOENT … .nemoclaw/source/installed-marker.txt`; with the staging change it passes.
- `npm run validate:pr` — passed on both commits (pre-commit and pre-push stages). `NODE_OPTIONS=--max-old-space-size=8192` was needed on the local host because `tsc -p tsconfig.cli.json` exceeds the default V8 heap there; no effect on the diff.
- `shfmt -i 2 -ci -bn -d install.sh scripts/install.sh` and the repository `shellcheck` hook — clean.
- Manual: sourced each installer and ran `clone_nemoclaw_ref lkg <dir>` with the GitHub URL rewritten to a closed 127.0.0.1 port — exit 1, `Could not connect …`, `The installed CLI was not changed.`; the classifier returns `connect-failed`, `connect-timeout`, and `missing-ref` for the fixture strings.
- The live DROP case (a real ~130 s SYN timeout) is covered by the fixture string only; a unit test cannot stall for that long.
- The diff contains no secrets, API keys, or credentials.

## Review notes
Sensitive paths changed: `install.sh` and `scripts/install.sh` (Installer and runtime). PR Review Advisor run for `d2f245a` returned one blocker (Verification evidence: no test drove a production caller or checked the installed CLI as a side-effect oracle); commit `3d30783` adds those tests and the staging swap they exposed. No independent human pre-publication review exists. Opened as a draft so those paths can be reviewed.

---
Signed-off-by: Dongni Yang <dongniy@nvidia.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)