### PR TITLE
docs: correct July 14 release note vLLM storage preflight behavior

### DIFF
--- a/docs/changelog/2026-07-14.mdx
+++ b/docs/changelog/2026-07-14.mdx
@@ -14,8 +14,8 @@ It also makes shared inference route changes explicit and safe, warns on risky l
   For more information, refer to [Use Shared Gateway Routes](/user-guide/openclaw/inference/manage-inference/use-shared-gateway-routes) and [View Active Inference Route](/user-guide/openclaw/inference/manage-inference/view-active-inference-route).
 - Qualifying DGX Station GB300 systems enter the express-install path.
   This path availability does not change DGX Station's Deferred support status.
-  Managed vLLM storage preflight treats verified shortages as advisory during express and other non-interactive setup while the checks mature.
-  Interactive setup still requires explicit confirmation, and non-interactive setup still stops when model-cache capacity is inconclusive.
+  Express installation and other non-interactive setup stop after a verified warning that Docker image storage or model-cache storage is insufficient, before the guarded download starts.
+  Interactive setup still requires explicit confirmation, non-interactive setup stops with guidance when model-cache capacity is inconclusive, and an inconclusive Docker image-storage check continues automatically.
   For more information, refer to [Set Up vLLM](/user-guide/openclaw/inference/local-inference/set-up-vllm), [Platform Support and Launch Claims](/user-guide/openclaw/reference/platform-support), and [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
 - Onboarding warns when a bring-your-own vLLM server on DGX Spark appears to serve a large unquantized model that may exhaust GPU memory under agent tool-call load.
   The warning is suppressed for the managed Spark vLLM recipe.


### PR DESCRIPTION
## Outcome
The July 14 (v0.0.83) release note incorrectly stated that verified managed
vLLM storage shortages are advisory during express and other non-interactive
setup. The release note now states that those paths stop after a verified
insufficient-capacity warning, matching the Set Up vLLM page exactly.

## Reason
The two published pages contradicted each other. An operator reading both
could incorrectly conclude that non-interactive setup continues past a
verified storage warning when it actually stops before the guarded download.

### Related issues
Closes NVIDIA/NemoClaw#11146

## Changes
- `docs/changelog/2026-07-14.mdx`: corrected the v0.0.83 managed vLLM
  storage preflight bullet to state that express and other non-interactive
  setup stop after a verified insufficient-capacity warning, before the
  guarded download starts. Aligns the release note with the authoritative
  behavior documented on the Set Up vLLM page.

## Verification
- `npm run docs`  passed (0 errors, 5 pre-existing warnings, no generated files changed)
- Diff contains no secrets, API keys, or credentials.
- Independent documentation writer review  @mohamedboukari reviewed the
  changed sentence against `docs/inference/set-up-vllm.mdx` and confirmed
  factual accuracy and style compliance.

---
Signed-off-by: Hela Saoudi 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Setup now verifies available storage before downloading Docker images or model caches.
  - Non-interactive setup stops before downloads when required capacity is insufficient or model-cache availability cannot be verified.
  - Interactive setup requests confirmation when storage availability may be insufficient.
  - Setup continues automatically when Docker-image storage availability cannot be conclusively verified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->