### PR TITLE
fix(ci): publish complete review queue context

### DIFF
--- a/test/automation/pull-requests/pr-review-advisor-e2e-receipt.test.ts
+++ b/test/automation/pull-requests/pr-review-advisor-e2e-receipt.test.ts
@@ -7,6 +7,7 @@ import type { TrustedE2eRecommendationInventory } from "../../../tools/advisors/
 import { buildRiskPlan } from "../../../tools/advisors/risk-plan.mts";
 import {
   buildSpecialistE2eReceipt,
+  buildReviewQueueContext,
   collectE2eRecommendations,
   createE2eRecommendationRecorder,
   validateE2eRecommendations,
@@ -33,6 +34,110 @@ const expected = {
 };
 const receipt = (interest: string, advisor: unknown = empty) =>
   buildSpecialistE2eReceipt({ ...expected, interest, advisor });
+
+const hostedEnvironment = {
+  GITHUB_REPOSITORY: "NVIDIA/NemoClaw",
+  TARGET_REPO: "NVIDIA/NemoClaw",
+  PR_NUMBER: "11489",
+  GITHUB_WORKFLOW_SHA: "c".repeat(40),
+  GITHUB_EVENT_NAME: "workflow_run",
+  GITHUB_RUN_ID: "123456",
+  GITHUB_RUN_ATTEMPT: "2",
+};
+
+describe("Review queue context", () => {
+  it("exports the complete existing plan and inventories without session parsing (#11489)", () => {
+    const input = {
+      ...expected,
+      riskPlan: {
+        ...expected.riskPlan,
+        requiredJobs: [
+          {
+            id: "device-auth-health",
+            tier: 1 as const,
+            families: [],
+            reasons: ["Check authentication."],
+            matchedFiles: [],
+          },
+        ],
+        requiredTargets: [
+          {
+            id: "sample-target",
+            tier: 1 as const,
+            families: [],
+            reasons: ["Check target."],
+            matchedFiles: [],
+          },
+        ],
+      },
+    };
+    const context = buildReviewQueueContext(input, hostedEnvironment);
+    expect(JSON.parse(JSON.stringify(context)).deterministic).toEqual(input.riskPlan);
+    expect(context.deterministic).toEqual(input.riskPlan);
+    expect(context.selectorInventory).toEqual(inventory);
+    expect(context.expectedSpecialists).toEqual(expected.expectedSpecialists);
+    expect(context).toMatchObject({
+      kind: "nemoclaw-review-queue-context-v1",
+      headSha: "a".repeat(40),
+      baseSha: expected.baseSha,
+      provenance: {
+        repository: "NVIDIA/NemoClaw",
+        prNumber: 11489,
+        workflowRepository: "NVIDIA/NemoClaw",
+        workflowSha: "c".repeat(40),
+        runId: "123456",
+        runAttempt: "2",
+      },
+    });
+    context.deterministic.requiredJobs.length = 0;
+    context.selectorInventory.allowedJobIds.length = 0;
+    expect(input.riskPlan.requiredJobs).toHaveLength(1);
+    expect(inventory.allowedJobIds).toHaveLength(1);
+  });
+
+  it("matches the passive consumer fixture and existing receipt identity (#11489)", () => {
+    const fixture = JSON.parse(
+      readFileSync(new URL("../../fixtures/review-queue-context.json", import.meta.url), "utf8"),
+    );
+    expect(buildReviewQueueContext(expected, hostedEnvironment)).toEqual(fixture);
+    expect(receipt("first").deterministic).toEqual({
+      version: fixture.deterministic.version,
+      planHash: fixture.deterministic.planHash,
+    });
+  });
+
+  it("marks local and non-PR evidence without inventing hosted PR identity (#11489)", () => {
+    expect(buildReviewQueueContext(expected, {}).provenance).toBeNull();
+    expect(
+      buildReviewQueueContext(expected, { ...hostedEnvironment, PR_NUMBER: "" }).provenance
+        ?.prNumber,
+    ).toBeNull();
+  });
+
+  it.each([
+    { GITHUB_WORKFLOW_SHA: undefined },
+    { GITHUB_RUN_ID: "" },
+    { GITHUB_RUN_ATTEMPT: "0" },
+    { GITHUB_WORKFLOW_SHA: "main" },
+    { GITHUB_REPOSITORY: "other/repo" },
+    { TARGET_REPO: "../repo" },
+    { PR_NUMBER: "-1" },
+    { GITHUB_EVENT_NAME: "pull_request" },
+    { PR_NUMBER: "1e3" },
+  ])("rejects invalid or partial hosted provenance %j (#11489)", (change) => {
+    expect(() => buildReviewQueueContext(expected, { ...hostedEnvironment, ...change })).toThrow(
+      "provenance",
+    );
+  });
+
+  it.each([
+    { baseSha: "main" },
+    { expectedSpecialists: [] },
+    { expectedSpecialists: ["first", "first"] },
+  ])("rejects incomplete context identity %j (#11489)", (change) => {
+    expect(() => buildReviewQueueContext({ ...expected, ...change }, hostedEnvironment)).toThrow();
+  });
+});
 
 describe("Advisor E2E receipts", () => {
   it("validates the optional full-suite consumer fixture (#11489)", () => {

--- a/test/automation/pull-requests/pr-review-advisor-local.test.ts
+++ b/test/automation/pull-requests/pr-review-advisor-local.test.ts
@@ -113,6 +113,7 @@ function artifactLifecycle(stop = async (): Promise<void> => undefined): LocalRe
       fs.writeFileSync(path.join(output, "pr-review-" + interest + "-summary.md"), "review\n");
       fs.writeFileSync(path.join(output, "pr-review-" + interest + "-session.jsonl"), "{}\n");
       fs.writeFileSync(path.join(output, "pr-review-" + interest + "-e2e.json"), "{}\n");
+      fs.writeFileSync(path.join(output, "review-queue-context.json"), "{}\n");
     },
     remove: () => undefined,
   };
@@ -504,6 +505,7 @@ describe("local PR review advisor", () => {
         fs.writeFileSync(path.join(out, "pr-review-" + interest + "-summary.md"), "review\n");
         fs.writeFileSync(path.join(out, "pr-review-" + interest + "-session.jsonl"), "{}\n");
         fs.writeFileSync(path.join(out, "pr-review-" + interest + "-e2e.json"), "{}\n");
+        fs.writeFileSync(path.join(out, "review-queue-context.json"), "{}\n");
       },
       remove: (env) => {
         calls.push("remove:" + env.PR_REVIEW_ADVISOR_INTEREST);

--- a/test/automation/pull-requests/pr-review-advisor-local.test.ts
+++ b/test/automation/pull-requests/pr-review-advisor-local.test.ts
@@ -809,9 +809,11 @@ describe("local PR review advisor", () => {
   const interest = ADVISOR_SPECIALISTS[0]!.interest;
   const summary = `pr-review-${interest}-summary.md`;
   const session = `pr-review-${interest}-session.jsonl`;
+  const e2e = `pr-review-${interest}-e2e.json`;
   it.each([
     ["missing", [summary]],
-    ["extra", [summary, session, "extra.txt"]],
+    ["missing context", [summary, session, e2e]],
+    ["extra", [summary, session, e2e, "review-queue-context.json", "extra.txt"]],
   ])("rejects %s specialist artifact sets (#10611)", async (_case, files) => {
     const source = repository();
     const lifecycle: LocalReviewLifecycle = {
@@ -837,7 +839,7 @@ describe("local PR review advisor", () => {
     ).rejects.toMatchObject({
       message: expect.stringContaining("failed during validate"),
       cause: expect.objectContaining({
-        message: "Specialist artifacts do not match the E2E, Markdown, and JSONL contract",
+        message: "Specialist artifacts do not match the context, E2E, Markdown, and JSONL contract",
       }),
     });
   });

--- a/test/automation/pull-requests/pr-review-advisor-openshell.test.ts
+++ b/test/automation/pull-requests/pr-review-advisor-openshell.test.ts
@@ -1038,6 +1038,10 @@ describe("PR review advisor OpenShell wrapper", () => {
 
   it("creates, runs, downloads, and deletes the sandbox without host credentials", async () => {
     const env = advisorEnvironment();
+    env.GITHUB_RUN_ID = "123456";
+    env.GITHUB_RUN_ATTEMPT = "2";
+    env.GITHUB_WORKFLOW_SHA = "c".repeat(40);
+    env.GITHUB_EVENT_NAME = "workflow_run";
     env.GIT_DIR = "/untrusted/ambient-git-dir";
     env.GIT_WORK_TREE = "/untrusted/ambient-worktree";
     const commandResponses = new Map([["openshell sandbox list --names", "pr-advisor-test\n"]]);
@@ -1147,6 +1151,10 @@ describe("PR review advisor OpenShell wrapper", () => {
         "GIT_DIR=/pr-workdir/.git",
         "GIT_WORK_TREE=/pr-workdir",
         "TARGET_REPO=NVIDIA/NemoClaw",
+        "GITHUB_RUN_ID=123456",
+        "GITHUB_RUN_ATTEMPT=2",
+        `GITHUB_WORKFLOW_SHA=${"c".repeat(40)}`,
+        "GITHUB_EVENT_NAME=workflow_run",
         "/advisor/tools/pr-review-advisor/run-specialist.mts",
         "--base",
         "target/base",

--- a/test/fixtures/review-queue-context.json
+++ b/test/fixtures/review-queue-context.json
@@ -1,0 +1,34 @@
+{
+  "kind": "nemoclaw-review-queue-context-v1",
+  "headSha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "baseSha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "expectedSpecialists": ["first", "second"],
+  "deterministic": {
+    "version": 23,
+    "headSha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "planHash": "59382646287943f44ab820a5ebb0e8be6b177140c960ff97847d542488bb8048",
+    "changedFiles": ["docs/example.mdx"],
+    "tier": 0,
+    "families": [],
+    "requiredJobs": [],
+    "requiredTargets": []
+  },
+  "selectorInventory": {
+    "workflow": "e2e.yaml",
+    "fanoutId": "e2e-all",
+    "selectorTypes": ["all", "job", "target"],
+    "allowedJobIds": ["device-auth-health"],
+    "manualOnlyJobIds": ["hardware-check"],
+    "liveSupportedTargetIds": ["sample-target"]
+  },
+  "provenance": {
+    "repository": "NVIDIA/NemoClaw",
+    "prNumber": 11489,
+    "workflowRepository": "NVIDIA/NemoClaw",
+    "workflowSha": "cccccccccccccccccccccccccccccccccccccccc",
+    "workflowPath": ".github/workflows/pr-review-advisor.yaml",
+    "eventName": "workflow_run",
+    "runId": "123456",
+    "runAttempt": "2"
+  }
+}

--- a/tools/pr-review-advisor/README.md
+++ b/tools/pr-review-advisor/README.md
@@ -23,7 +23,7 @@ It intentionally does not report GitHub mergeability, branch protection, CI stat
 3. Prepares the target PR as inert analysis data and executes the trusted Advisor entrypoint from the workflow checkout.
 4. Runs model analysis inside OpenShell. The sandbox receives neither a GitHub token nor the upstream model credential.
 5. Runs one required Pi session for each valid Markdown prompt in `tools/pr-review-advisor/specialists`. Each specialist reads repository evidence and records a native session trace.
-6. Each specialist publishes its complete Markdown review as the job summary and uploads the Markdown, native session trace, and validated E2E recommendation receipt as one artifact.
+6. Each specialist publishes its Markdown review as the job summary. Its artifact contains the Markdown, native session trace, E2E receipt, and shared review-queue context.
 7. After every specialist completes successfully, one publisher attempts to post a sticky comment that links to the workflow run. A failed specialist keeps the workflow failed and suppresses publication.
 
 `investigate-turn.mts` owns the shared investigation turn and deterministic context contract. `specialist-tools.mts` owns specialist tool policy and implementations. `specialists.mts` applies each specialist prompt and tool policy. `trusted-guidance.mts` owns the system prompt and checked-in review guidance. `turn-context.mts` and the context modules build bounded deterministic evidence. `run-specialist.mts` composes these modules and writes each specialist's Markdown review and native session trace.

--- a/tools/pr-review-advisor/REVIEW-QUEUE.md
+++ b/tools/pr-review-advisor/REVIEW-QUEUE.md
@@ -26,7 +26,7 @@ The payload has these fields:
 A recommendation is `{selectorType, id, required, reason}`. `selectorType` is `job`, `target`, or `all`.
 `all` uses ID `e2e-all`. Preserve `required:false`: the review queue requires optional recommendations to pass too.
 Deduplicate by selector type and ID. A required occurrence takes precedence over an optional occurrence.
-Collection adds every job and typed target from the referenced trusted risk plan. Specialist output cannot remove that floor.
+Collection adds every job and typed target from the context's trusted risk plan. Specialist output cannot remove that floor.
 
 The recording tool validates IDs against the trusted inventory. An invalid or duplicate selection is rejected without recording a result.
 The specialist can correct rejected input. Missing successful recording fails the specialist run.
@@ -39,17 +39,42 @@ Tests in `test/automation/pull-requests/pr-review-advisor-e2e-receipt.test.ts` p
 
 ## Discovery and identity
 
+Each specialist artifact also contains `review-queue-context.json`, with kind `nemoclaw-review-queue-context-v1`.
+The trusted runner writes it before model execution from the same deterministic context used by that specialist.
+It contains no GitHub discussion context or session internals. No repository code execution is required to read it.
+
+| Field | Meaning |
+| --- | --- |
+| `headSha`, `baseSha` | Full candidate and comparison commits |
+| `expectedSpecialists` | Complete sorted trusted specialist inventory |
+| `deterministic` | Complete existing risk plan: `version`, `planHash`, `headSha`, `changedFiles`, `tier`, `families`, `requiredJobs`, `requiredTargets` |
+| `selectorInventory` | Existing trusted selector inventory: `workflow`, `fanoutId`, `selectorTypes`, `allowedJobIds`, `manualOnlyJobIds`, `liveSupportedTargetIds` |
+| `provenance` | Hosted identity described below; `null` for local runs |
+
+Hosted provenance contains `repository`, `prNumber`, `workflowRepository`, `workflowSha`, `workflowPath`, `eventName`, `runId`, and `runAttempt`.
+Run IDs and attempts are positive decimal strings. The PR number is a positive integer, or `null` for non-PR runs.
+The workflow repository is `NVIDIA/NemoClaw`; the path is `.github/workflows/pr-review-advisor.yaml`.
+Events are `workflow_run` or `workflow_dispatch`. Local or non-PR provenance cannot establish queue readiness.
+Every provenance value must match independently verified GitHub evidence. Payload identity does not authenticate an artifact.
+
+Preserve every `deterministic.requiredJobs` and `deterministic.requiredTargets` entry as required coverage, using its `id` and `reasons`.
+Both arrays contain `{id, tier, families, reasons, matchedFiles}` entries. Empty arrays explicitly represent an empty deterministic floor.
+Do not derive selectors from family descriptions or recompute a partial plan from changed files.
+The existing plan hash identifies the complete plan, including workflow-derived focused coverage; it is not an artifact signature.
+The producer copies that plan without truncation. Reject incomplete data rather than dropping unrecognized selections.
+`test/fixtures/review-queue-context.json` is a tested synthetic payload for passive consumers.
+
 1. Read the current PR candidate SHA, base SHA, and source repository from GitHub.
 2. Find the trusted `pr-review-advisor.yaml` run that reviewed that candidate. Validate the workflow path, repository, event, and trusted workflow revision.
-3. Read the expected specialist inventory from that trusted workflow revision. Never let a payload shorten the expected inventory.
+3. Read regular Markdown prompt filenames under `tools/pr-review-advisor/specialists` at the trusted workflow revision. Never let a payload shorten that inventory.
 4. List all artifacts for the run. Select one nonexpired artifact per expected specialist, with the current attempt suffix.
 5. Verify each immutable artifact ID belongs to that run and verify its download digest. Extract only bounded regular files without links or traversal.
-6. Require all receipt candidate/base identities, specialist identities, and risk-plan identities to agree with trusted evidence.
+6. Require identical contexts across all specialists, matching trusted identities and inventories. Match receipt candidate/base, specialist, and plan identities to that context.
 7. Recheck the PR identity and run attempt after collection. Discard the result if either changed.
 
 Run and attempt identity come from the GitHub artifact envelope. Payloads cannot establish their own provenance.
 Do not combine artifacts from different runs or attempts. Incomplete rerun artifacts remain unknown even if an earlier attempt passed.
-Use the deterministic context's existing focused-job selection when reconstructing the risk plan; a raw changed-file plan can omit workflow-derived focused coverage.
+Runs without the context sidecar remain unknown. Do not scrape Pi session chunks to supply missing evidence.
 
 The proposed #11047 finding ledger is separate. All validated P0/P1 findings count as blockers, including findings excluded from automated repair.
 Require every expected specialist ledger before reporting zero. A completion comment alone cannot establish zero blockers.

--- a/tools/pr-review-advisor/e2e-receipt.mts
+++ b/tools/pr-review-advisor/e2e-receipt.mts
@@ -54,7 +54,7 @@ export type SpecialistE2eReceipt = {
 
 const provenanceSchema = Type.Object(
   {
-    repository: Type.String({ pattern: "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$" }),
+    repository: Type.String({ pattern: "^[A-Za-z0-9][A-Za-z0-9_.-]*/[A-Za-z0-9][A-Za-z0-9_.-]*$" }),
     prNumber: Type.Union([
       Type.Integer({ minimum: 1, maximum: Number.MAX_SAFE_INTEGER }),
       Type.Null(),

--- a/tools/pr-review-advisor/e2e-receipt.mts
+++ b/tools/pr-review-advisor/e2e-receipt.mts
@@ -52,6 +52,73 @@ export type SpecialistE2eReceipt = {
   advisor: E2eRecommendationInput;
 };
 
+const provenanceSchema = Type.Object(
+  {
+    repository: Type.String({ pattern: "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$" }),
+    prNumber: Type.Union([
+      Type.Integer({ minimum: 1, maximum: Number.MAX_SAFE_INTEGER }),
+      Type.Null(),
+    ]),
+    workflowRepository: Type.Literal("NVIDIA/NemoClaw"),
+    workflowSha: Type.String({ pattern: "^[0-9a-f]{40}$" }),
+    workflowPath: Type.Literal(".github/workflows/pr-review-advisor.yaml"),
+    eventName: Type.Union([Type.Literal("workflow_run"), Type.Literal("workflow_dispatch")]),
+    runId: Type.String({ pattern: "^[1-9][0-9]*$" }),
+    runAttempt: Type.String({ pattern: "^[1-9][0-9]*$" }),
+  },
+  { additionalProperties: false },
+);
+
+type ReviewQueueContextInput = Omit<
+  Parameters<typeof buildSpecialistE2eReceipt>[0],
+  "advisor" | "interest"
+>;
+
+export function buildReviewQueueContext(input: ReviewQueueContextInput, env: NodeJS.ProcessEnv) {
+  validateE2eIdentity(input);
+  const hosted = [
+    env.GITHUB_RUN_ID,
+    env.GITHUB_RUN_ATTEMPT,
+    env.GITHUB_WORKFLOW_SHA,
+    env.GITHUB_EVENT_NAME,
+  ].some((value) => value !== undefined);
+  const provenance = hosted
+    ? {
+        repository: env.TARGET_REPO || env.GITHUB_REPOSITORY,
+        prNumber: env.PR_NUMBER ? Number(env.PR_NUMBER) : null,
+        workflowRepository: env.GITHUB_REPOSITORY,
+        workflowSha: env.GITHUB_WORKFLOW_SHA,
+        workflowPath: ".github/workflows/pr-review-advisor.yaml",
+        eventName: env.GITHUB_EVENT_NAME,
+        runId: env.GITHUB_RUN_ID,
+        runAttempt: env.GITHUB_RUN_ATTEMPT,
+      }
+    : null;
+  if (provenance !== null && !Check(provenanceSchema, provenance))
+    throw new Error("Review queue context requires complete hosted provenance");
+  if (provenance !== null && env.PR_NUMBER && !/^[1-9][0-9]*$/.test(env.PR_NUMBER))
+    throw new Error("Review queue context requires decimal PR provenance");
+  return {
+    kind: "nemoclaw-review-queue-context-v1" as const,
+    headSha: input.riskPlan.headSha,
+    baseSha: input.baseSha,
+    expectedSpecialists: [...input.expectedSpecialists].sort(),
+    deterministic: structuredClone(input.riskPlan),
+    selectorInventory: structuredClone(input.inventory),
+    provenance,
+  };
+}
+
+function validateE2eIdentity(input: ReviewQueueContextInput): void {
+  if (![input.baseSha, input.riskPlan.headSha].every((sha) => /^[0-9a-f]{40}$/.test(sha)))
+    throw new Error("E2E receipt requires full candidate and base SHAs");
+  if (
+    input.expectedSpecialists.length === 0 ||
+    new Set(input.expectedSpecialists).size !== input.expectedSpecialists.length
+  )
+    throw new Error("E2E receipt requires a nonempty unique specialist inventory");
+}
+
 export function validateE2eRecommendations(
   value: unknown,
   inventory: TrustedE2eRecommendationInventory,
@@ -108,13 +175,8 @@ export function buildSpecialistE2eReceipt(input: {
   advisor: unknown;
   inventory: TrustedE2eRecommendationInventory;
 }): SpecialistE2eReceipt {
-  if (![input.baseSha, input.riskPlan.headSha].every((sha) => /^[0-9a-f]{40}$/.test(sha))) {
-    throw new Error("E2E receipt requires full candidate and base SHAs");
-  }
-  if (
-    !input.expectedSpecialists.includes(input.interest) ||
-    new Set(input.expectedSpecialists).size !== input.expectedSpecialists.length
-  ) {
+  validateE2eIdentity(input);
+  if (!input.expectedSpecialists.includes(input.interest)) {
     throw new Error("E2E receipt requires a unique specialist inventory containing its owner");
   }
   return {

--- a/tools/pr-review-advisor/local-review-implementation.mts
+++ b/tools/pr-review-advisor/local-review-implementation.mts
@@ -306,9 +306,12 @@ function validateSpecialistArtifacts(root: string, interest: string): void {
     `pr-review-${interest}-e2e.json`,
     `pr-review-${interest}-session.jsonl`,
     `pr-review-${interest}-summary.md`,
+    "review-queue-context.json",
   ];
   if (JSON.stringify(fs.readdirSync(directory).sort()) !== JSON.stringify(expected))
-    throw new Error("Specialist artifacts do not match the E2E, Markdown, and JSONL contract");
+    throw new Error(
+      "Specialist artifacts do not match the context, E2E, Markdown, and JSONL contract",
+    );
   if (
     expected.some((name) => {
       const stat = fs.lstatSync(path.join(directory, name));

--- a/tools/pr-review-advisor/openshell.mts
+++ b/tools/pr-review-advisor/openshell.mts
@@ -319,6 +319,10 @@ function passthroughEnvironment(env: NodeJS.ProcessEnv): Record<string, string> 
   for (const name of [
     "BASE_REF",
     "GITHUB_REPOSITORY",
+    "GITHUB_RUN_ID",
+    "GITHUB_RUN_ATTEMPT",
+    "GITHUB_WORKFLOW_SHA",
+    "GITHUB_EVENT_NAME",
     "HEAD_REF",
     "PR_NUMBER",
     "PR_REVIEW_ADVISOR_ARTIFACT_DIR",

--- a/tools/pr-review-advisor/run-specialist.mts
+++ b/tools/pr-review-advisor/run-specialist.mts
@@ -18,7 +18,11 @@ import {
 } from "../advisors/session.mts";
 import { collectDeterministicContext } from "./deterministic-context.mts";
 import { trustedE2eRecommendationInventory } from "../advisors/e2e-recommendations.mts";
-import { buildSpecialistE2eReceipt, createE2eRecommendationRecorder } from "./e2e-receipt.mts";
+import {
+  buildReviewQueueContext,
+  buildSpecialistE2eReceipt,
+  createE2eRecommendationRecorder,
+} from "./e2e-receipt.mts";
 import { collectGitHubReviewContext } from "./github-context.mts";
 import {
   ADVISOR_SPECIALISTS,
@@ -123,6 +127,17 @@ async function main(): Promise<void> {
     reconciliation: buildReconciliationTurnContext(deterministic),
   });
   const inventory = trustedE2eRecommendationInventory();
+  const evidenceContext = {
+    baseSha: getHeadSha(baseRef),
+    expectedSpecialists: ADVISOR_SPECIALISTS.map((specialist) => specialist.interest),
+    riskPlan: deterministic.riskPlan,
+    inventory,
+  };
+  fs.writeFileSync(
+    path.join(outDir, "review-queue-context.json"),
+    `${JSON.stringify(buildReviewQueueContext(evidenceContext, process.env), null, 2)}\n`,
+    { flag: "wx", mode: 0o600 },
+  );
   const recommendations = createE2eRecommendationRecorder(inventory);
   const run = await runSpecialistAdvisor(
     interest,
@@ -150,12 +165,9 @@ async function main(): Promise<void> {
   const errors = advisorRunErrors(run);
   if (errors.length > 0) throw new Error(errors.join("; "));
   const receipt = buildSpecialistE2eReceipt({
-    baseSha: getHeadSha(baseRef),
+    ...evidenceContext,
     interest,
-    expectedSpecialists: ADVISOR_SPECIALISTS.map((specialist) => specialist.interest),
-    riskPlan: deterministic.riskPlan,
     advisor: recommendations.snapshot(),
-    inventory,
   });
   fs.writeFileSync(
     path.join(outDir, `pr-review-${interest}-e2e.json`),


### PR DESCRIPTION
## Outcome

Passive review-queue consumers can read the complete deterministic E2E plan and trusted inventories without executing repository TypeScript or parsing Pi session chunks. Each existing specialist artifact gains `review-queue-context.json`; the E2E receipt v1 remains unchanged.

## Reason

#11495 published only a risk-plan hash in specialist receipts. The GitHub Monitor Review Queue needs the full job and target requirements, specialist inventory, selector inventory, and hosted identity to interpret those receipts.

### Related issues

Refs #11489. Follows #11495. Structured blocker evidence remains owned by #11047; this PR does not introduce a competing ledger or automated repairs.

## Changes

- Serialize the same complete deterministic context already used by the specialist. Reuse the existing risk planner, inventories, artifact upload, and receipt identity checks.
- Bind the context to candidate/base commits and validated repository, PR, workflow revision/path/event, run, and attempt metadata. Consumers must independently verify GitHub artifact provenance.
- Pass four non-secret GitHub identity variables through the existing OpenShell environment allowlist. Credential and publisher boundaries remain unchanged.
- Require the context file in local specialist artifact validation. Document identical-context collection, old-run unknown status, full job/target requirements, and local/non-PR limitations.
- Extend existing receipt, artifact, and OpenShell tests; add one synthetic consumer fixture. No new dependency, planner, workflow job, or E2E dispatch is added.

## Verification

- `npx vitest run --silent --project integration test/automation/pull-requests/pr-review-advisor-e2e-receipt.test.ts test/automation/pull-requests/pr-review-advisor-local.test.ts test/automation/pull-requests/pr-review-advisor-openshell.test.ts test/automation/pull-requests/pr-review-advisor-specialists.test.ts test/automation/pull-requests/pr-risk-plan.test.ts test/automation/e2e/e2e-recommendations.test.ts` — 320/320 passed as a non-root user on Docker-native storage.
- `npm run build:cli` and `npm --prefix nemoclaw run build` — passed.
- `npm run validate:pr` — passed, including formatting, lint, repository checks, secret scanning, Markdown checks, source-shape and growth checks, commitlint, and CLI TypeScript.
- `git diff --check` — passed. The diff contains no secrets, API keys, or credentials.
- Validation used candidate `e314879ac8e08bd3f7e6c6ce88daf32c3b19e9c8` against canonical base `c5d9cb2b1873a5e2397cd67656c505304e848818`. GitHub's base API and canonical HTTPS fetch agreed. Validation configuration, manifests, lockfiles, and transitive validator sources are unchanged from that base.
- Isolation: independent checkout in Docker `node:22.23.2-trixie`, digest `sha256:2082d2bf902c8835655c6bcfee3594c00ea900498a9f6e2b96d3352536f9e8d8`, 8 GiB/8 CPUs. No contributor home, credentials, SSH agent, or Docker socket was exposed. Host hooks were suppressed per command; complete publication checks ran in the isolated container.
- The first test run caught and led to correction of an overly permissive repository-name pattern. A later bind-mounted run hit an unchanged temporary-Git fixture failure. The complete suite passed on Docker-native storage. Container-local ownership was corrected before the successful build and publication validation.

## Review notes

Sensitive paths: `tools/pr-review-advisor/**`. Full-diff self-review covered NVIDIA/NemoClaw candidate `e314879ac8e08bd3f7e6c6ce88daf32c3b19e9c8`, identity validation, complete-plan preservation, immutable artifact creation, credential allowlisting, local artifact checks, and owning documentation. No unresolved candidate finding remains from that review; it is not independent approval.

Alternative review completed under the standing shepherd workflow. `npm run review:local` could not run model analysis in the credential-free container: `PR_REVIEW_ADVISOR_API_KEY is required for local review`. No Advisor clearance or CI waiver is claimed. Hosted CI and independent automated review remain required; this PR opens as a draft.

No live E2E or hardware dispatch was performed. Deterministic and boundary tests cover this serialization change. The new context appears only after the producer reaches trusted main. Old runs remain unknown.

#11047 is still open and draft at `bd5b4f7ddf365de0eab266d57e8e36530598751b`. [Owner coordination](https://github.com/NVIDIA/NemoClaw/pull/11047#issuecomment-5635759682) requests the smallest independent read-only ledger slice. Until that producer lands, missing blocker ledgers remain unknown; they do not mean zero blockers.

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Review artifacts now include a shared context file with commit, planning, selector, identity, and workflow provenance details.
  - Hosted workflow metadata, including run and attempt information, is preserved in review execution records.

- **Bug Fixes**
  - Artifact validation now rejects missing, incomplete, inconsistent, or invalid review context data.
  - Review coverage checks now account for all trusted jobs and typed targets.

- **Documentation**
  - Updated review queue and specialist artifact documentation to describe the required context artifact and validation contract.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->