### PR TITLE
chore(deps): trust OpenClaw 2026.9.1 manifests

### DIFF
--- a/ci/reviewed-npm-audit.json
+++ b/ci/reviewed-npm-audit.json
@@ -12,7 +12,9 @@
     "integrity": "sha512-MFnyX2vs47f/yVJRUXKmA7C6wZDH03ZGFFg+R5gZME+yMQDg9WF6G4Kdz/APM7nCUpaoGk2bwNEdUUmR60J54A==",
     "tarballUrl": "https://npm.pkg.github.com/download/@nvidia/openshell-sdk/0.0.116/3380652847354127ed1bb8010490f8815040ada3"
   },
-  "sourceNestedShrinkwrapPackages": ["@earendil-works/pi-coding-agent@0.80.6"],
+  "sourceNestedShrinkwrapPackages": [
+    "@earendil-works/pi-coding-agent@0.80.6"
+  ],
   "sourceRegistryPackagesWithoutIntegrity": [
     {
       "label": "Pi agent core 0.80.6 nested shrinkwrap entry",
@@ -37,10 +39,10 @@
   "artifactDirectory": "coverage/reviewed-npm-audit",
   "archivePackages": [
     {
-      "label": "OpenClaw 2026.7.1",
-      "packageSpec": "openclaw@2026.7.1",
-      "integrity": "sha512-ge/Xss99CHAjPL/ikmH/UFoiOrjcxDB4sW3y9mhyCD+dYW3wzV7TKbAVdkrXFgAG2d2BjpJofP97zUZ+umxo8g==",
-      "tarballUrl": "https://registry.npmjs.org/openclaw/-/openclaw-2026.7.1.tgz"
+      "label": "OpenClaw 2026.9.1",
+      "packageSpec": "openclaw@2026.9.1",
+      "integrity": "sha512-0Ve0631CdgkJDwd4NNG1BawIdF5yCL2sO+Tts8amStw+H6vKURTj0K4rOa4+hFpJk1Dnw5LyKl5twzwX1VtA2w==",
+      "tarballUrl": "https://registry.npmjs.org/openclaw/-/openclaw-2026.9.1.tgz"
     },
     {
       "label": "Codex ACP 0.11.1",
@@ -49,40 +51,40 @@
       "tarballUrl": "https://registry.npmjs.org/@zed-industries/codex-acp/-/codex-acp-0.11.1.tgz"
     },
     {
-      "label": "OpenClaw diagnostics OTEL 2026.7.1",
-      "packageSpec": "@openclaw/diagnostics-otel@2026.7.1",
-      "integrity": "sha512-XXhMifYWTgoR6yFN4T3JkHxdPvQCe8k1cNZjVIgXNmk1svCdBWuALfQQicmpemlmWwauIQuHYgBURY6k63e+rw==",
-      "tarballUrl": "https://registry.npmjs.org/@openclaw/diagnostics-otel/-/diagnostics-otel-2026.7.1.tgz"
+      "label": "OpenClaw diagnostics OTEL 2026.9.1",
+      "packageSpec": "@openclaw/diagnostics-otel@2026.9.1",
+      "integrity": "sha512-3MWLli9L6HTVdrjqHmwOvNvIr6emsnuNQe4iE2sDqb8E5wn4Vq1rcsz+InL1YFudbStr089ZtS0tNAQ6qU+tnA==",
+      "tarballUrl": "https://registry.npmjs.org/@openclaw/diagnostics-otel/-/diagnostics-otel-2026.9.1.tgz"
     },
     {
-      "label": "OpenClaw Brave plugin 2026.7.1",
-      "packageSpec": "@openclaw/brave-plugin@2026.7.1",
-      "integrity": "sha512-7Z+GZ/6K6a8LlkTsWVnAZ1hv8EarORzHQvFHD7ekcg033FGJOXYPEZSbvvE3qR9vM+vnoZplNjMZ7vFMRcvQgw==",
-      "tarballUrl": "https://registry.npmjs.org/@openclaw/brave-plugin/-/brave-plugin-2026.7.1.tgz"
+      "label": "OpenClaw Brave plugin 2026.9.1",
+      "packageSpec": "@openclaw/brave-plugin@2026.9.1",
+      "integrity": "sha512-4+j+eQTToV3k7Cb25MUL6h2uL8cJYyuLytfpd/sJK/HjR43dgKBqKpBsb1+I3w1Jr6PLpnjSf6/I3//3K0cdnA==",
+      "tarballUrl": "https://registry.npmjs.org/@openclaw/brave-plugin/-/brave-plugin-2026.9.1.tgz"
     },
     {
-      "label": "OpenClaw Discord plugin 2026.7.1",
-      "packageSpec": "@openclaw/discord@2026.7.1",
-      "integrity": "sha512-tZfdC1YA8oVLvc2BK1w0F6rUljS5ugCOp2uWe0vPsbG1fbzVVIO4V32RoqZznGHe5u2R9u4n1aV5Z/qa1m2oFg==",
-      "tarballUrl": "https://registry.npmjs.org/@openclaw/discord/-/discord-2026.7.1.tgz"
+      "label": "OpenClaw Discord plugin 2026.9.1",
+      "packageSpec": "@openclaw/discord@2026.9.1",
+      "integrity": "sha512-qNmN2a8A9dET4igPp0RML171sEn8PDMyNCYNp/DqcJ4tn3XTHpacSOTkqBmv5yXTycJRC9rfFP8FT/SdW0Rldg==",
+      "tarballUrl": "https://registry.npmjs.org/@openclaw/discord/-/discord-2026.9.1.tgz"
     },
     {
-      "label": "OpenClaw Slack plugin 2026.7.1",
-      "packageSpec": "@openclaw/slack@2026.7.1",
-      "integrity": "sha512-dwVGEVCmoTQrOIeZaSCIOPg8pT7hB883QQEXdp9EZUDzTGuvSc+KxH2iERSOV/59hROQctYdcobGn/vdB1H4XA==",
-      "tarballUrl": "https://registry.npmjs.org/@openclaw/slack/-/slack-2026.7.1.tgz"
+      "label": "OpenClaw Slack plugin 2026.9.1",
+      "packageSpec": "@openclaw/slack@2026.9.1",
+      "integrity": "sha512-tU372jE40nnPcKQ6oxmDHf2/UhGtdz8ysi4JKsRZIO1QBAEkZd2YfsOw8aucmb2r0B0vjcFD3OmIV/Qzb57COg==",
+      "tarballUrl": "https://registry.npmjs.org/@openclaw/slack/-/slack-2026.9.1.tgz"
     },
     {
-      "label": "OpenClaw WhatsApp plugin 2026.7.1",
-      "packageSpec": "@openclaw/whatsapp@2026.7.1",
-      "integrity": "sha512-wLY/Omc5fleRpl2lKGN8sxt/8hYfHGwLRezmWsk8oCbea5pRKUPE6ZX+wJO1O52NOJkAGCuiXvS7x0qIeKxXbQ==",
-      "tarballUrl": "https://registry.npmjs.org/@openclaw/whatsapp/-/whatsapp-2026.7.1.tgz"
+      "label": "OpenClaw WhatsApp plugin 2026.9.1",
+      "packageSpec": "@openclaw/whatsapp@2026.9.1",
+      "integrity": "sha512-llIcoMa6FM4SgYn7GG1FQIeTTA5JDdcHW5D7PT+3aGYT3/E2eLFutKwDvD/w7G0hvDwSftzZgLi3iA8dzK7a3A==",
+      "tarballUrl": "https://registry.npmjs.org/@openclaw/whatsapp/-/whatsapp-2026.9.1.tgz"
     },
     {
-      "label": "OpenClaw Microsoft Teams plugin 2026.7.1",
-      "packageSpec": "@openclaw/msteams@2026.7.1",
-      "integrity": "sha512-gG/Yk6HZAguHwrmKjsqdONbFz5WNy126PEAXQWNW/TulO1kIifQ6tktM16BQPNLnkmWqLbj+TrrO55Cjas1aFg==",
-      "tarballUrl": "https://registry.npmjs.org/@openclaw/msteams/-/msteams-2026.7.1.tgz"
+      "label": "OpenClaw Microsoft Teams plugin 2026.9.1",
+      "packageSpec": "@openclaw/msteams@2026.9.1",
+      "integrity": "sha512-seRGr9/X6Vk9xU5elLVpDwq8R+TO0QFvUmxPEitqkngqDnMoXW0LEEXkriG6jgue74w2YLcNnAv/Rjf0a9jong==",
+      "tarballUrl": "https://registry.npmjs.org/@openclaw/msteams/-/msteams-2026.9.1.tgz"
     },
     {
       "label": "Tencent WeChat plugin 2.4.3",
@@ -94,12 +96,12 @@
   "lockedGraphs": [
     {
       "id": "openclaw-runtime",
-      "label": "OpenClaw 2026.7.1 locked runtime graph",
-      "packageSpec": "openclaw@2026.7.1",
-      "integrity": "sha512-ge/Xss99CHAjPL/ikmH/UFoiOrjcxDB4sW3y9mhyCD+dYW3wzV7TKbAVdkrXFgAG2d2BjpJofP97zUZ+umxo8g==",
-      "tarballUrl": "https://registry.npmjs.org/openclaw/-/openclaw-2026.7.1.tgz",
+      "label": "OpenClaw 2026.9.1 locked runtime graph",
+      "packageSpec": "openclaw@2026.9.1",
+      "integrity": "sha512-0Ve0631CdgkJDwd4NNG1BawIdF5yCL2sO+Tts8amStw+H6vKURTj0K4rOa4+hFpJk1Dnw5LyKl5twzwX1VtA2w==",
+      "tarballUrl": "https://registry.npmjs.org/openclaw/-/openclaw-2026.9.1.tgz",
       "directory": "agents/openclaw/openclaw-runtime",
-      "lockSha256": "248d881ca125bb83da293c4b3f40b46d057095a9fe90b5165255da0de78af9f9"
+      "lockSha256": "9f99aa4f5d10280b4d809e0d54f20bcbe786d4140d30fc10ed502b1305ff9a8d"
     },
     {
       "id": "mcporter-runtime",


### PR DESCRIPTION
<!-- nemopatch:action=sha256:cd7968141b8713076222c6cee3eff6add780a4ea34ecb96e6f5ee8d448a96102 -->
<!-- nemopatch:manifest=sha256:3188891f6f26df2f06bac46400dfe0295a7b42d66a19356b268a7869fbb0227f -->
<!-- nemopatch:dependency=OpenClaw -->
<!-- nemopatch:target=2026.9.1 -->

<!-- markdownlint-disable MD041 -->
## Outcome

Adds the base-trusted OpenClaw 2026.9.1 release-manifest digests required before a separate runtime-pin migration. This prerequisite PR does not change the selected dependency version and remains draft for human review.
<!-- State the result first. Describe the before-and-after behavior in 1–3 sentences. -->

## Reason

The sealed NemoPin handoff requires an exact OpenClaw 2026.7.1 to 2026.9.1 upgrade candidate so current-head CI, E2E, and qualification can prove the identified compatibility risks.
<!-- Explain why this change is needed. -->

### Related issues

- #10964: candidate update fix
- #8837: open upstream work
- #8554: open upstream work
- #8466: open upstream work
- #4781: open upstream work
- #4871: open upstream work
<!-- Name each issue relationship with the keyword that applies, such as Fixes, Closes, Resolves, Refs, Relates to, or Part of. Remove this subsection if no issue applies. -->

## Changes

- Applies only paths authorized by `sha256:3188891f6f26df2f06bac46400dfe0295a7b42d66a19356b268a7869fbb0227f`.
- Migrates the exact base `e6068115cc5e02e0d05abdb46ea4509138847617` across 5 adjacent release ranges.
- Changed paths: `ci/reviewed-npm-audit.json`

### Release ranges

| Range | Commits | State | Concerns |
|---|---|---|---|
| 2026.7.1 → v2026.7.1-1 | `2d2ddc43d0dc` → `81ac4f3bddc8` | published | 2 |
| v2026.7.1-1 → v2026.7.1-2 | `81ac4f3bddc8` → `0790d9f593ad` | published | 0 |
| v2026.7.1-2 → v2026.8.1 | `0790d9f593ad` → `ea806575e645` | published | 9 |
| v2026.8.1 → v2026.8.2 | `ea806575e645` → `0965053fe6b9` | published | 9 |
| v2026.8.2 → v2026.9.1 | `0965053fe6b9` → `ad6fe23aecb9` | published | 9 |

### Concern dispositions

| Concern | Surface | Planned disposition | Failure prevented | Remaining gate |
|---|---|---|---|---|
| `openclaw-2026.7.1..v2026.7.1-1-lifecycle-state-1` | lifecycle state | test | v2026.7.1-1 reports lifecycle state: ### Fixes - **Codex progress replies:** keep app-server turns running after delivered progress messages so GPT/Codex reaches its authoritati... | none |
| `openclaw-2026.7.1..v2026.7.1-1-runtime-topology-2` | runtime topology | test | v2026.7.1-1 reports runtime topology: ### Fixes - **Codex progress replies:** keep app-server turns running after delivered progress messages so GPT/Codex reaches its authoritat... | none |
| `openclaw-v2026.7.1-2..v2026.8.1-compatibility-change-1` | compatibility change | test | v2026.8.1 reports compatibility change: ### Highlights - **Find past conversations:** search visible conversation text by exact words or phrases and reopen the surrounding messa... | none |
| `openclaw-v2026.7.1-2..v2026.8.1-configuration-2` | configuration | test | v2026.8.1 reports configuration: ### Highlights - **Find past conversations:** search visible conversation text by exact words or phrases and reopen the surrounding messages fro... | none |
| `openclaw-v2026.7.1-2..v2026.8.1-execution-control-3` | execution control | guard | v2026.8.1 reports execution control: ### Highlights - **Find past conversations:** search visible conversation text by exact words or phrases and reopen the surrounding messages... | none |
| `openclaw-v2026.7.1-2..v2026.8.1-lifecycle-state-4` | lifecycle state | test | v2026.8.1 reports lifecycle state: ### Highlights - **Find past conversations:** search visible conversation text by exact words or phrases and reopen the surrounding messages f... | none |
| `openclaw-v2026.7.1-2..v2026.8.1-network-5` | network | test | v2026.8.1 reports network: ### Highlights - **Find past conversations:** search visible conversation text by exact words or phrases and reopen the surrounding messages from a ma... | none |
| `openclaw-v2026.7.1-2..v2026.8.1-packaging-artifact-6` | packaging artifact | test | v2026.8.1 reports packaging artifact: ### Highlights - **Find past conversations:** search visible conversation text by exact words or phrases and reopen the surrounding message... | none |
| `openclaw-v2026.7.1-2..v2026.8.1-protocol-schema-7` | protocol schema | test | v2026.8.1 reports protocol schema: ### Highlights - **Find past conversations:** search visible conversation text by exact words or phrases and reopen the surrounding messages f... | none |
| `openclaw-v2026.7.1-2..v2026.8.1-runtime-topology-8` | runtime topology | test | v2026.8.1 reports runtime topology: ### Highlights - **Find past conversations:** search visible conversation text by exact words or phrases and reopen the surrounding messages ... | none |
| `openclaw-v2026.7.1-2..v2026.8.1-security-identity-9` | security identity | guard | v2026.8.1 reports security identity: ### Highlights - **Find past conversations:** search visible conversation text by exact words or phrases and reopen the surrounding messages... | none |
| `openclaw-v2026.8.1..v2026.8.2-compatibility-change-1` | compatibility change | test | v2026.8.2 reports compatibility change: ### Highlights - **Your Home agent, beside your work:** open Home in a right or bottom dock with `Cmd/Ctrl+Shift+H`, keep your current pa... | none |
| `openclaw-v2026.8.1..v2026.8.2-configuration-2` | configuration | test | v2026.8.2 reports configuration: ### Highlights - **Your Home agent, beside your work:** open Home in a right or bottom dock with `Cmd/Ctrl+Shift+H`, keep your current page in v... | none |
| `openclaw-v2026.8.1..v2026.8.2-execution-control-3` | execution control | guard | v2026.8.2 reports execution control: ### Highlights - **Your Home agent, beside your work:** open Home in a right or bottom dock with `Cmd/Ctrl+Shift+H`, keep your current page ... | none |
| `openclaw-v2026.8.1..v2026.8.2-lifecycle-state-4` | lifecycle state | test | v2026.8.2 reports lifecycle state: ### Highlights - **Your Home agent, beside your work:** open Home in a right or bottom dock with `Cmd/Ctrl+Shift+H`, keep your current page in... | none |
| `openclaw-v2026.8.1..v2026.8.2-network-5` | network | test | v2026.8.2 reports network: ### Highlights - **Your Home agent, beside your work:** open Home in a right or bottom dock with `Cmd/Ctrl+Shift+H`, keep your current page in view, a... | none |
| `openclaw-v2026.8.1..v2026.8.2-packaging-artifact-6` | packaging artifact | test | v2026.8.2 reports packaging artifact: ### Highlights - **Your Home agent, beside your work:** open Home in a right or bottom dock with `Cmd/Ctrl+Shift+H`, keep your current page... | none |
| `openclaw-v2026.8.1..v2026.8.2-protocol-schema-7` | protocol schema | test | v2026.8.2 reports protocol schema: ### Highlights - **Your Home agent, beside your work:** open Home in a right or bottom dock with `Cmd/Ctrl+Shift+H`, keep your current page in... | none |
| `openclaw-v2026.8.1..v2026.8.2-runtime-topology-8` | runtime topology | test | v2026.8.2 reports runtime topology: ### Highlights - **Your Home agent, beside your work:** open Home in a right or bottom dock with `Cmd/Ctrl+Shift+H`, keep your current page i... | none |
| `openclaw-v2026.8.1..v2026.8.2-security-identity-9` | security identity | guard | v2026.8.2 reports security identity: ### Highlights - **Your Home agent, beside your work:** open Home in a right or bottom dock with `Cmd/Ctrl+Shift+H`, keep your current page ... | none |
| `openclaw-v2026.8.2..v2026.9.1-compatibility-change-1` | compatibility change | test | v2026.9.1 reports compatibility change: ### Highlights - **Diagrams in every chat:** Mermaid blocks now render as diagrams in the Control UI and in the native macOS, iOS, and An... | none |
| `openclaw-v2026.8.2..v2026.9.1-configuration-2` | configuration | test | v2026.9.1 reports configuration: ### Highlights - **Diagrams in every chat:** Mermaid blocks now render as diagrams in the Control UI and in the native macOS, iOS, and Android a... | none |
| `openclaw-v2026.8.2..v2026.9.1-execution-control-3` | execution control | guard | v2026.9.1 reports execution control: ### Highlights - **Diagrams in every chat:** Mermaid blocks now render as diagrams in the Control UI and in the native macOS, iOS, and Andro... | none |
| `openclaw-v2026.8.2..v2026.9.1-lifecycle-state-4` | lifecycle state | test | v2026.9.1 reports lifecycle state: ### Highlights - **Diagrams in every chat:** Mermaid blocks now render as diagrams in the Control UI and in the native macOS, iOS, and Android... | none |
| `openclaw-v2026.8.2..v2026.9.1-network-5` | network | test | v2026.9.1 reports network: ### Highlights - **Diagrams in every chat:** Mermaid blocks now render as diagrams in the Control UI and in the native macOS, iOS, and Android apps, w... | none |
| `openclaw-v2026.8.2..v2026.9.1-packaging-artifact-6` | packaging artifact | test | v2026.9.1 reports packaging artifact: ### Highlights - **Diagrams in every chat:** Mermaid blocks now render as diagrams in the Control UI and in the native macOS, iOS, and Andr... | none |
| `openclaw-v2026.8.2..v2026.9.1-protocol-schema-7` | protocol schema | test | v2026.9.1 reports protocol schema: ### Highlights - **Diagrams in every chat:** Mermaid blocks now render as diagrams in the Control UI and in the native macOS, iOS, and Android... | none |
| `openclaw-v2026.8.2..v2026.9.1-runtime-topology-8` | runtime topology | test | v2026.9.1 reports runtime topology: ### Highlights - **Diagrams in every chat:** Mermaid blocks now render as diagrams in the Control UI and in the native macOS, iOS, and Androi... | none |
| `openclaw-v2026.8.2..v2026.9.1-security-identity-9` | security identity | guard | v2026.9.1 reports security identity: ### Highlights - **Diagrams in every chat:** Mermaid blocks now render as diagrams in the Control UI and in the native macOS, iOS, and Andro... | none |

### Immutable artifacts

| Artifact | SHA-256 |
|---|---|
| openclaw-2026.9.1.tgz | `1bfcac877d53f1e4…` |
<!-- List the concrete changes that produce the stated outcome. If this adds a mechanism, name its current requirement and consumer. Explain why a direct change is insufficient. Identify the test that protects the mechanism. -->

## Verification

| Gate | Current result |
|---|---|
| targeted | Pending on this exact draft head |
<!-- List each completed command or manual check and its result. If no test applies, explain why. For a broad change, record the applicable broad gate and result. Do not claim a gate that you did not run. For documentation changes, record the docs build result and applicable style or new-page checks. Confirm that the diff contains no secrets, API keys, or credentials. -->
- Exact-head verification starts only after this draft is published.

## Review notes

- Documentation review: `no-docs-needed`
- Documentation evidence: No documentation paths changed. The patch updates only the reviewed npm audit trust-anchor metadata for OpenClaw 2026.9.1 and does not update the runtime dependency pin or user-facing behavior.
- Agent: NemoPatch documentation reviewer (OpenClaw in NemoClaw)
<!-- docs-review-head-sha: d11bd4069e00143df49ad799190ed855348327fe -->
<!-- docs-review-agents-blob-sha: 4ccc34629c6670f3a02dcc4faf6feeb5049bb753 -->
<!-- Remove this section if no note applies.
For a sensitive-path change, record the review context or maintainer-approved waiver.
For an accepted non-success, skipped, or missing CI check, name the check, approval link, and follow-up issue.
If scripts/prepare-dgx-station-host.sh changes, identify the tested commit, Station profile or scenario, result, and supporting link. Maintainers must review that evidence before merge. If repository governance permits an exception, document the reason. -->

---
<!-- DCO sign-off is required in this PR description. Every commit must appear as Verified in GitHub. -->
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>