### PR TITLE
test(e2e): keep EXDEV forwards on canonical OpenShell

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -784,8 +784,10 @@ write failure propagates, so that retry artifact may be absent. `tools.invoke`
 assertions prove the plugin version after onboarding, restart, and recreation.
 The job also keeps the test-only tmpfs mount and uses OpenClaw's plugin installer
 across the proven filesystem boundary before restart. `e2e-support` tests own
-deterministic wrapper argument rewriting. Deterministic tests own exact package
-versions and third-party replacement internals. Runtime inspection and catalog
+sandbox-create interception and wrapper argument rewriting. Onboarding and
+recreation load the test-only interceptor; all other OpenShell commands use the
+canonical binary so dashboard forward ownership remains verifiable. Deterministic
+tests own exact package versions and third-party replacement internals. Runtime inspection and catalog
 permutations are outside this live contract. Workspace preservation and policy
 selection retain their focused coverage instead of another assertion in this
 target. The `rebuild-openclaw` job remains the canonical live rebuild coverage.

--- a/test/e2e/live/openclaw-plugin-runtime-exdev-trusted-prebuild.ts
+++ b/test/e2e/live/openclaw-plugin-runtime-exdev-trusted-prebuild.ts
@@ -106,6 +106,7 @@ const TRUSTED_EXDEV_IMAGE_REF_PATTERN = new RegExp(
 );
 
 export type OpenShellTrustedImageWrapper = OpenShellDriverConfigTestWrapper & {
+  createPreloadPath: string;
   selectImage(image: TrustedPluginFixtureImage): void;
 };
 
@@ -207,9 +208,28 @@ exec ${shellQuote(process.execPath)} ${shellQuote(rewriterPath)} "$@"
     { encoding: "utf8", mode: 0o700 },
   );
 
+  // Keep the canonical CLI as the forward listener's executable. Intercept only
+  // sandbox creation to retain this fixture's image and tmpfs setup.
+  const createPreloadPath = path.join(directory, "sandbox-create-preload.cjs");
+  fs.writeFileSync(
+    createPreloadPath,
+    `const childProcess = require("node:child_process");
+const spawn = childProcess.spawn;
+childProcess.spawn = function (command, args, options) {
+  const executable = command === ${JSON.stringify(canonicalComponents.cli)} &&
+    args?.[0] === "sandbox" && args[1] === "create"
+      ? ${JSON.stringify(executable)} : command;
+  return spawn(executable, args, options);
+};
+require("node:module").syncBuiltinESMExports();
+`,
+    { encoding: "utf8", mode: 0o600 },
+  );
+
   return {
     directory,
     executable,
+    createPreloadPath,
     selectImage: (image) => {
       assert.match(image.imageRef, TRUSTED_EXDEV_IMAGE_REF_PATTERN);
       fs.writeFileSync(imageSelectionPath, `${JSON.stringify(image)}\n`, {

--- a/test/e2e/live/openclaw-plugin-runtime-exdev.test.ts
+++ b/test/e2e/live/openclaw-plugin-runtime-exdev.test.ts
@@ -507,6 +507,8 @@ test(
         host.command(
           "node",
           [
+            "--require",
+            openshellWrapper.createPreloadPath,
             CLI_ENTRYPOINT,
             "onboard",
             "--fresh",
@@ -554,7 +556,7 @@ test(
       [CLI_ENTRYPOINT, SANDBOX_NAME, "gateway", "restart"],
       {
         artifactName: "openclaw-weather-plugin-gateway-restart",
-        env: { ...sandboxEnv, NEMOCLAW_OPENSHELL_BIN: openshell.cli },
+        env: sandboxEnv,
         timeoutMs: 180_000,
       },
     );
@@ -604,6 +606,8 @@ test(
         host.command(
           "node",
           [
+            "--require",
+            openshellWrapper.createPreloadPath,
             CLI_ENTRYPOINT,
             "onboard",
             "--fresh",

--- a/test/e2e/live/openshell-driver-config-test-wrapper.ts
+++ b/test/e2e/live/openshell-driver-config-test-wrapper.ts
@@ -108,7 +108,7 @@ export function withOpenShellDriverConfigWrapperEnv(
   return {
     ...env,
     PATH: `${wrapper.directory}${path.delimiter}${env.PATH ?? ""}`,
-    NEMOCLAW_OPENSHELL_BIN: wrapper.executable,
+    NEMOCLAW_OPENSHELL_BIN: components.cli,
     NEMOCLAW_OPENSHELL_GATEWAY_BIN: components.gateway,
     NEMOCLAW_OPENSHELL_SANDBOX_BIN: components.sandbox,
   };

--- a/test/e2e/mock-parity.json
+++ b/test/e2e/mock-parity.json
@@ -736,6 +736,7 @@
       "live": "test/e2e/live/openclaw-plugin-runtime-exdev.test.ts",
       "liveSources": [
         "test/e2e/live/openclaw-plugin-runtime-exdev-trusted-prebuild.ts",
+        "test/e2e/live/openshell-driver-config-test-wrapper.ts",
         "test/e2e/live/json-envelope.ts"
       ],
       "fast": [

--- a/test/e2e/support/openclaw-plugin-runtime-exdev-trusted-prebuild.test.ts
+++ b/test/e2e/support/openclaw-plugin-runtime-exdev-trusted-prebuild.test.ts
@@ -8,6 +8,8 @@ import path from "node:path";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { resolveOpenshell } from "../../../src/lib/adapters/openshell/resolve.ts";
+
 import {
   hasRequiredOpenshellMessagingFeatures,
   REQUIRED_OPENSHELL_MCP_FEATURES,
@@ -375,6 +377,85 @@ describe("trusted EXDEV OpenShell wrapper", () => {
     }
   });
 
+  it.each([
+    {
+      operation: "create",
+      expectedBinary: "wrapper",
+      args: ["sandbox", "create", "--from", "/tmp/staged/Dockerfile", "--name", "demo"],
+      expectedArgs: [
+        "sandbox",
+        "create",
+        "--driver-config-json",
+        DRIVER_CONFIG_JSON,
+        "--from",
+        IMAGE_ID,
+        "--name",
+        "demo",
+      ],
+    },
+    {
+      operation: "forward",
+      expectedBinary: "canonical",
+      args: ["--gateway", "nemoclaw", "--workspace", "default", "forward", "service", "demo"],
+      expectedArgs: [
+        "--gateway",
+        "nemoclaw",
+        "--workspace",
+        "default",
+        "forward",
+        "service",
+        "demo",
+      ],
+    },
+    {
+      operation: "list",
+      expectedBinary: "canonical",
+      args: ["sandbox", "list"],
+      expectedArgs: ["sandbox", "list"],
+    },
+  ] as const)(
+    "uses the image wrapper only for sandbox creation: $operation",
+    ({ args, expectedArgs, expectedBinary }) => {
+      const fixture = createWrapperFixture();
+      try {
+        fixture.wrapper.selectImage({
+          imageId: IMAGE_ID,
+          imageRef: trustedExdevImageRef("create-only"),
+        });
+        const executable = resolveOpenshell({
+          env: withOpenShellDriverConfigWrapperEnv({}, fixture.wrapper, fixture.components),
+        });
+        expect(executable).toBe(fixture.components.cli);
+        const probe = `
+const { spawn } = require("node:child_process");
+const child = spawn(process.argv[1], process.argv.slice(2));
+let stdout = "";
+child.stdout.on("data", (data) => { stdout += data; });
+child.stderr.pipe(process.stderr);
+child.on("close", (status) => {
+  process.stdout.write(JSON.stringify({ executable: child.spawnfile, args: stdout.trimEnd().split("\\n") }));
+  process.exit(status ?? 1);
+});
+`;
+        const result = spawnSync(
+          process.execPath,
+          ["--require", fixture.wrapper.createPreloadPath, "-e", probe, executable!, ...args],
+          { encoding: "utf8", timeout: 30_000 },
+        );
+        expect(result.status, result.stderr).toBe(0);
+        const observed = JSON.parse(result.stdout);
+        expect(observed).toEqual({
+          executable: { wrapper: fixture.wrapper.executable, canonical: fixture.components.cli }[
+            expectedBinary
+          ],
+          args: expectedArgs,
+        });
+      } finally {
+        fixture.remove();
+      }
+    },
+  );
+
   it("rejects missing and untrusted selected image refs", () => {
     const fixture = createWrapperFixture();
     try {
@@ -570,7 +651,7 @@ describe("trusted EXDEV OpenShell wrapper", () => {
         ),
       ).toMatchObject({
         PATH: `${fixture.wrapper.directory}${path.delimiter}/usr/bin`,
-        NEMOCLAW_OPENSHELL_BIN: fixture.wrapper.executable,
+        NEMOCLAW_OPENSHELL_BIN: fixture.components.cli,
         NEMOCLAW_OPENSHELL_GATEWAY_BIN: fixture.components.gateway,
         NEMOCLAW_OPENSHELL_SANDBOX_BIN: fixture.components.sandbox,
       });


### PR DESCRIPTION
## Outcome

The custom-plugin EXDEV test can verify dashboard forward ownership during onboarding and recreation. Its image and tmpfs wrapper runs only for sandbox creation; forwarding uses the canonical OpenShell executable.

## Reason

[Main run 34587100109](https://github.com/NVIDIA/NemoClaw/actions/runs/34587100109/job/103269383042) failed onboarding after #11427 added forward ownership verification. The fixture selected a wrapper as its OpenShell executable, but the listener ran the real binary. Existing wrapper tests checked arguments without exercising that executable selection.

### Related issues

Refs #6108. Regression from #11427.

## Changes

- Select the canonical CLI in the shared fixture environment. The other consumer already receives its driver configuration from NemoClaw.
- Load a fixture-only Node preload for onboarding and recreation. It sends only the canonical CLI's `sandbox create` spawn through the existing image and tmpfs wrapper. A global executable override cannot preserve forward identity.
- Cover executable resolution, create argument rewriting, and direct forward/list execution in the support tests. Register the shared wrapper in the existing EXDEV mock-parity entry. Keep the EXDEV install, restart, recreation, image checks, and cleanup assertions.

## Verification

- Focused E2E-support tests: 33 passed across the trusted prebuild, driver configuration, and workflow-boundary suites.
- Regression evidence: all three new routing cases failed when the previous wrapper executable selection was restored, then passed with the fix.
- `npm run e2e:assertions:check`: passed; existing live assertion budget unchanged.
- CLI and plugin builds passed. `NODE_OPTIONS=--max-old-space-size=8192 npm run validate:pr` passed on `855d5fce999acab6b21260902a580a4aa8826888`, using canonical main `41c5625e8b831ed213cd5c381385973adc58659c`. The larger heap is required by this host’s TypeScript check.
- The mock/live parity checker reproduced the missing ownership entry and passed after its one-line correction. The final correction changes only that mapping; fixture source and test results are unchanged.
- [CI 34622479660](https://github.com/NVIDIA/NemoClaw/actions/runs/34622479660): passed on `855d5fce999acab6b21260902a580a4aa8826888`, including all 12 CLI shards, coverage, static checks, builds, and type checks.
- [Focused live E2E 34622865200](https://github.com/NVIDIA/NemoClaw/actions/runs/34622865200/job/103341797795): passed. Onboarding, production installation across distinct filesystems, restart with the installed payload, recreation with plugin v2, and cleanup all passed. Onboarding and recreation passed on their first attempts. Downloaded artifact digests, dispatch identity, target results, and aggregate `pass` receipt were verified against the unchanged PR.
- E2E source: `NVIDIA/NemoClaw` (owner `NVIDIA`, organization); candidate `855d5fce999acab6b21260902a580a4aa8826888`; base `e6068115cc5e02e0d05abdb46ea4509138847617`; trusted workflow `70cfff5f946a9bb31d1147f78ffbda914a2efaa2`. Selector: `jobs=openclaw-plugin-runtime-exdev`, empty targets, mock inference. Correlation: `e40a0daf-e1bb-4a56-bfe0-711faf7da239`.
- [Advisor 34623885835](https://github.com/NVIDIA/NemoClaw/actions/runs/34623885835): blocked before review. All nine specialists failed with `/sandbox/.profile: Permission denied` followed by `exec relay closed before the command reported an exit status`; none produced review artifacts. The same startup failure occurs in the independent [PR #11212 Advisor run](https://github.com/NVIDIA/NemoClaw/actions/runs/34622883136/job/103341140685). Keep this fixture fix unchanged; a maintainer decision is needed for the shared runtime blocker and subsequent full Advisor rerun.
- All paginated PR comments, reviews, and threads were collected. No code review findings were published. CodeRabbit skipped this draft; its success status does not represent a completed review.
- No secrets, API keys, or credentials were added.

---

Signed-off-by: San Dang <sdang@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded end-to-end coverage for OpenShell lifecycle workflows, including onboarding, recreation, gateway restart, and sandbox listing.
  - Improved validation that command routing remains consistent across supported workflows.
  - Added coverage for trusted prebuilt image handling and cross-device rename scenarios.
  - Updated test fixtures and environment checks to reflect the canonical command configuration.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->