### PR TITLE
fix(test): let the host timeout own supervisor cleanup

### DIFF
--- a/test/e2e/support/launch-agent-turn.test.ts
+++ b/test/e2e/support/launch-agent-turn.test.ts
@@ -527,7 +527,7 @@ exec "$@"
       NEMOCLAW_LAUNCH_RUNTIME_ENV_SCRIPT: OPENCLAW_LAUNCH_RUNTIME_ENV_SCRIPT,
       NEMOCLAW_LAUNCH_SANDBOX: invocationEnv.NEMOCLAW_LAUNCH_SANDBOX ?? "sandbox",
       NEMOCLAW_LAUNCH_SESSION_BUDGET_SECONDS:
-        mode === "restored-canonical-timeout"
+        mode === "restored-canonical-timeout" || mode === "supervisor-timeout"
           ? "10"
           : mode === "pty-socket-timeout"
             ? "5"


### PR DESCRIPTION
## Outcome

The launch supervisor timeout test now lets the host timeout terminate the command before the fixture's internal deadline expires.

## Reason

The fixture's two-second session budget could expire before the 2.5-second host timeout. This caused `fixture.result.timedOut` to be false.
The same assertion failed on [main CI](https://github.com/NVIDIA/NemoClaw/actions/runs/34602042635/job/103271974108) and blocked [PR #11487](https://github.com/NVIDIA/NemoClaw/pull/11487).

## Changes

Give `supervisor-timeout` the existing ten-second session budget used by `restored-canonical-timeout`. Keep the host timeout and all descendant-cleanup assertions unchanged.
No production code, retry policy, or new mechanism changes.

## Verification

- Linux, Node 22.23.2 container with `--init`: `npx vitest run --project e2e-support test/e2e/support/launch-agent-turn.test.ts -t "host command times out" --reporter=verbose` — passed; 1 test passed, 43 deselected. This ran before rebase; the test file is unchanged by rebase.
- macOS: `npx vitest run --project e2e-support test/e2e/support/launch-agent-turn.test.ts` — 6 passed, 38 Linux-only tests skipped.
- `npm --prefix nemoclaw run build` and `npm run build:cli` — passed.
- `NODE_OPTIONS=--max-old-space-size=5120 npm run validate:pr` — passed for `b1aeedef5b80ae061745a502eb5938b755526f43`, with canonical validation base `41c5625e8b831ed213cd5c381385973adc58659c`.
- Diff review found no secrets, API keys, or credentials.

## Review notes

Local Advisor sandbox creation is unavailable in this shepherd session. Alternative review completed for the one-line diff: correctness, unchanged cleanup assertions, sibling timeout budgets, and security boundaries were checked. This is self-review, not independent Advisor clearance. Hosted checks and review remain pending.
An initial Linux container without an init process retained zombie descendants; the corrected container passed the affected test. The full Linux suite did not complete, so no full-suite pass is claimed.

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the supervisor timeout test scenario to use a 10-second launch session budget, aligning it with the restored canonical timeout scenario.
  * Other timeout modes and default budgets remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->