### PR TITLE
feat(ci): publish read-only Advisor blocker ledgers

### DIFF
--- a/test/automation/pull-requests/pr-review-advisor-finding-ledger.test.ts
+++ b/test/automation/pull-requests/pr-review-advisor-finding-ledger.test.ts
@@ -156,3 +156,19 @@ it("writes a private ledger without replacing an existing file or symlink (#1148
   expect(() => writeAdvisorFindingLedger(directory, identity.interest, ledger)).toThrow();
   expect(fs.readFileSync(target, "utf8")).toBe("unchanged");
 });
+
+it("keeps recorded exclusions immutable after the finding ID is derived (#11489)", async () => {
+  const controller = createAdvisorFindingToolController(identity);
+  await controller.tools[0]!.execute(
+    "record",
+    { findings: [blocker], noFindingsReason: null },
+    undefined,
+    undefined,
+    undefined as never,
+  );
+  const snapshot = controller.snapshot();
+  const exclusions = snapshot.findings[0]!.exclusions as string[];
+  expect(() => exclusions.push("external-mutation")).toThrow(TypeError);
+  expect(controller.snapshot()).toEqual(snapshot);
+  expect(parseAdvisorFindingLedger(controller.snapshot(), identity)).toEqual(snapshot);
+});

--- a/test/automation/pull-requests/pr-review-advisor-finding-ledger.test.ts
+++ b/test/automation/pull-requests/pr-review-advisor-finding-ledger.test.ts
@@ -1,0 +1,158 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { expect, it, onTestFinished } from "vitest";
+import {
+  buildAdvisorFindingLedger,
+  createAdvisorFindingToolController,
+  parseAdvisorFindingLedger,
+  writeAdvisorFindingLedger,
+  MAX_FINDING_LEDGER_BYTES,
+} from "../../../tools/pr-review-advisor/finding-ledger.mts";
+
+const identity = { headSha: "a".repeat(40), interest: "security-standard-work" };
+const blocker = {
+  severity: "P1" as const,
+  kind: "security" as const,
+  summary: "The fallback exposes a credential.",
+  path: "src/lib/example.ts",
+  line: 42,
+  impact: "A diagnostic includes the credential value.",
+  smallestSafeFix: "Remove the credential from the diagnostic.",
+  regressionTest: "Assert that the diagnostic contains no credential value.",
+  exclusions: ["security-sensitive", "credential-access"] as const,
+};
+const clear = { findings: [], noFindingsReason: "No P0/P1 blocker remains in the reviewed area." };
+const build = (input: Parameters<typeof buildAdvisorFindingLedger>[0]["input"]) =>
+  buildAdvisorFindingLedger({ ...identity, input });
+
+it.each([
+  ["clear", clear],
+  ["excluded-blocker", { findings: [blocker], noFindingsReason: null }],
+] as const)("matches the producer-generated %s ledger fixture (#11489)", (name, input) => {
+  const ledger = build(input);
+  const fixture = JSON.parse(
+    fs.readFileSync(
+      path.join(process.cwd(), "test/fixtures", `review-queue-findings-${name}.json`),
+      "utf8",
+    ),
+  );
+  expect(ledger).toEqual(fixture);
+  expect(parseAdvisorFindingLedger(fixture, identity)).toEqual(ledger);
+  expect(ledger.status).toBe(name === "clear" ? "clear" : "findings");
+  expect(ledger.findings).toHaveLength(name === "clear" ? 0 : 1);
+});
+
+it("normalizes text and exclusions before deriving stable finding IDs (#11489)", () => {
+  const first = build({ findings: [blocker], noFindingsReason: null });
+  const second = build({
+    findings: [
+      {
+        ...blocker,
+        summary: `  ${blocker.summary}\n`,
+        exclusions: [...blocker.exclusions].reverse(),
+      },
+    ],
+    noFindingsReason: null,
+  });
+  expect(second).toEqual(first);
+  expect(first.findings[0]!.exclusions).toEqual(["credential-access", "security-sensitive"]);
+});
+
+it.each([
+  { findings: [], noFindingsReason: null },
+  { findings: [], noFindingsReason: "  " },
+  { findings: [blocker], noFindingsReason: "No blockers" },
+  { findings: [blocker, blocker], noFindingsReason: null },
+  { findings: Array.from({ length: 21 }, () => blocker), noFindingsReason: null },
+  { findings: [{ ...blocker, path: "../outside" }], noFindingsReason: null },
+  { findings: [{ ...blocker, path: "/absolute" }], noFindingsReason: null },
+  { findings: [{ ...blocker, severity: "P2" }], noFindingsReason: null },
+  { findings: [{ ...blocker, line: 0 }], noFindingsReason: null },
+  { findings: [{ ...blocker, summary: "x\u0000y" }], noFindingsReason: null },
+  { findings: [{ ...blocker, summary: "é".repeat(251) }], noFindingsReason: null },
+  { ...clear, unexpected: true },
+])("rejects invalid finding input %j (#11489)", (input) => {
+  expect(() => build(input as Parameters<typeof build>[0])).toThrow();
+});
+
+it.each([
+  { version: 2 },
+  { revision: 2 },
+  { identity: "stale" },
+  { headSha: "b".repeat(40) },
+  { interest: "other" },
+  { status: "findings" },
+  { noFindingsReason: ` ${clear.noFindingsReason}` },
+  { extra: true },
+])("rejects stale or noncanonical ledger fields %j (#11489)", (change) => {
+  expect(() => parseAdvisorFindingLedger({ ...build(clear), ...change }, identity)).toThrow();
+});
+
+it.each([{ id: "F-forged" }, { interest: "other" }, { exclusions: [...blocker.exclusions] }])(
+  "rejects forged or noncanonical finding fields %j (#11489)",
+  (change) => {
+    const ledger = build({ findings: [blocker], noFindingsReason: null });
+    expect(() =>
+      parseAdvisorFindingLedger(
+        { ...ledger, findings: [{ ...ledger.findings[0], ...change }] },
+        identity,
+      ),
+    ).toThrow();
+  },
+);
+
+it("sorts multiple findings and rejects a reordered ledger (#11489)", () => {
+  const ledger = build({ findings: [blocker, { ...blocker, line: 43 }], noFindingsReason: null });
+  expect(ledger.findings.map(({ id }) => id)).toEqual(ledger.findings.map(({ id }) => id).sort());
+  expect(() =>
+    parseAdvisorFindingLedger({ ...ledger, findings: [...ledger.findings].reverse() }, identity),
+  ).toThrow("not canonical");
+});
+
+it("requires a successful recording and permits correction of rejected input (#11489)", async () => {
+  const controller = createAdvisorFindingToolController(identity);
+  const record = controller.tools[0]!;
+  expect(() => controller.snapshot()).toThrow("did not commit");
+  await expect(
+    record.execute(
+      "bad",
+      { findings: [], noFindingsReason: null },
+      undefined,
+      undefined,
+      undefined as never,
+    ),
+  ).rejects.toThrow();
+  expect(() => controller.snapshot()).toThrow("did not commit");
+  const result = await record.execute("clear", clear, undefined, undefined, undefined as never);
+  expect(result).toMatchObject({ terminate: true });
+  expect(controller.snapshot()).toEqual(build(clear));
+  await expect(
+    record.execute("again", clear, undefined, undefined, undefined as never),
+  ).rejects.toThrow("already has");
+});
+
+it("writes a private ledger without replacing an existing file or symlink (#11489)", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "advisor-ledger-"));
+  onTestFinished(() => fs.rmSync(directory, { recursive: true, force: true }));
+  const ledger = build(clear);
+  expect(() =>
+    writeAdvisorFindingLedger(directory, identity.interest, {
+      ...ledger,
+      noFindingsReason: "x".repeat(MAX_FINDING_LEDGER_BYTES),
+    }),
+  ).toThrow("size limit");
+  const file = writeAdvisorFindingLedger(directory, identity.interest, ledger);
+  expect(JSON.parse(fs.readFileSync(file, "utf8"))).toEqual(ledger);
+  expect(fs.statSync(file).mode & 0o777).toBe(0o600);
+  expect(() => writeAdvisorFindingLedger(directory, identity.interest, ledger)).toThrow();
+  fs.unlinkSync(file);
+  const target = path.join(directory, "target");
+  fs.writeFileSync(target, "unchanged");
+  fs.symlinkSync(target, file);
+  expect(() => writeAdvisorFindingLedger(directory, identity.interest, ledger)).toThrow();
+  expect(fs.readFileSync(target, "utf8")).toBe("unchanged");
+});

--- a/test/automation/pull-requests/pr-review-advisor-local.test.ts
+++ b/test/automation/pull-requests/pr-review-advisor-local.test.ts
@@ -113,6 +113,7 @@ function artifactLifecycle(stop = async (): Promise<void> => undefined): LocalRe
       fs.writeFileSync(path.join(output, "pr-review-" + interest + "-summary.md"), "review\n");
       fs.writeFileSync(path.join(output, "pr-review-" + interest + "-session.jsonl"), "{}\n");
       fs.writeFileSync(path.join(output, "pr-review-" + interest + "-e2e.json"), "{}\n");
+      fs.writeFileSync(path.join(output, "pr-review-" + interest + "-findings.json"), "{}\n");
       fs.writeFileSync(path.join(output, "review-queue-context.json"), "{}\n");
     },
     remove: () => undefined,
@@ -505,6 +506,7 @@ describe("local PR review advisor", () => {
         fs.writeFileSync(path.join(out, "pr-review-" + interest + "-summary.md"), "review\n");
         fs.writeFileSync(path.join(out, "pr-review-" + interest + "-session.jsonl"), "{}\n");
         fs.writeFileSync(path.join(out, "pr-review-" + interest + "-e2e.json"), "{}\n");
+        fs.writeFileSync(path.join(out, "pr-review-" + interest + "-findings.json"), "{}\n");
         fs.writeFileSync(path.join(out, "review-queue-context.json"), "{}\n");
       },
       remove: (env) => {
@@ -810,10 +812,12 @@ describe("local PR review advisor", () => {
   const summary = `pr-review-${interest}-summary.md`;
   const session = `pr-review-${interest}-session.jsonl`;
   const e2e = `pr-review-${interest}-e2e.json`;
+  const findings = `pr-review-${interest}-findings.json`;
   it.each([
     ["missing", [summary]],
-    ["missing context", [summary, session, e2e]],
-    ["extra", [summary, session, e2e, "review-queue-context.json", "extra.txt"]],
+    ["missing context", [summary, session, e2e, findings]],
+    ["missing findings", [summary, session, e2e, "review-queue-context.json"]],
+    ["extra", [summary, session, e2e, findings, "review-queue-context.json", "extra.txt"]],
   ])("rejects %s specialist artifact sets (#10611)", async (_case, files) => {
     const source = repository();
     const lifecycle: LocalReviewLifecycle = {
@@ -839,7 +843,8 @@ describe("local PR review advisor", () => {
     ).rejects.toMatchObject({
       message: expect.stringContaining("failed during validate"),
       cause: expect.objectContaining({
-        message: "Specialist artifacts do not match the context, E2E, Markdown, and JSONL contract",
+        message:
+          "Specialist artifacts do not match the context, E2E, findings, Markdown, and JSONL contract",
       }),
     });
   });

--- a/test/automation/pull-requests/pr-review-advisor-specialists.test.ts
+++ b/test/automation/pull-requests/pr-review-advisor-specialists.test.ts
@@ -10,6 +10,10 @@ import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
 import { canonicalRepoReadPath } from "../../../tools/advisors/repo-read-only-tools.mts";
 import { describe, expect, it, onTestFinished, vi } from "vitest";
 
+import {
+  createAdvisorFindingToolController,
+  RECORD_ADVISOR_FINDINGS_TOOL,
+} from "../../../tools/pr-review-advisor/finding-ledger.mts";
 import { TERMINOLOGY_TRACE_TOOL } from "../../../tools/pr-review-advisor/terminology.mts";
 import { E2E_RECEIPT_TOOL } from "../../../tools/pr-review-advisor/e2e-receipt.mts";
 import {
@@ -63,7 +67,9 @@ describe("PR review advisor specialist prompts", () => {
     const file = writeSpecialistDiff(directory, "diff evidence");
 
     expect(file).toBe(expected);
-    await expect(canonicalRepoReadPath(directory, "diff.patch")).resolves.toBe(expected);
+    await expect(canonicalRepoReadPath(directory, "diff.patch")).resolves.toBe(
+      fs.realpathSync(expected),
+    );
     expect(fs.readFileSync(file, "utf8")).toBe("diff evidence");
     expect(fs.statSync(directory).mode & 0o777).toBe(0o700);
     expect(fs.statSync(file).mode & 0o777).toBe(0o600);
@@ -213,7 +219,8 @@ describe("PR review advisor specialist prompts", () => {
       expect(turn.prompt).toContain("Inspect changed files and their diffs on demand");
       expect(turn.prompt).toContain("do not try to preload the complete diff");
       expect(turn.atomicTerminalToolName).toBeUndefined();
-      expect(turn.terminalSubmitToolName).toBeUndefined();
+      expect(turn.terminalSubmitToolName).toBe(RECORD_ADVISOR_FINDINGS_TOOL);
+      expect(turn.terminalSubmitRepairPrompt).toContain(RECORD_ADVISOR_FINDINGS_TOOL);
     },
   );
 
@@ -258,7 +265,7 @@ describe("PR review advisor specialist prompts", () => {
     expect(expected).toContain("Concrete reduction.");
   });
 
-  it("passes terminology tracing only to the documentation specialist runner (#9968)", async () => {
+  it("passes finding recording to every specialist and terminology tracing only to documentation (#9968)", async () => {
     const directory = fs.mkdtempSync(path.join(process.cwd(), ".tmp-specialist-runner-"));
     onTestFinished(() => fs.rmSync(directory, { recursive: true, force: true }));
     const git = (args: string[]) =>
@@ -298,10 +305,15 @@ describe("PR review advisor specialist prompts", () => {
 
     await Promise.all(
       ADVISOR_INTERESTS.map((interest) =>
-        runSpecialistAdvisor(interest, { baseRef, headRef }, options, async (runnerOptions) => {
-          captured.push([interest, runnerOptions.customTools ?? []]);
-          return result;
-        }),
+        runSpecialistAdvisor(
+          interest,
+          { baseRef, headRef, headSha: headRef },
+          options,
+          async (runnerOptions) => {
+            captured.push([interest, runnerOptions.customTools ?? []]);
+            return result;
+          },
+        ),
       ),
     );
 
@@ -313,13 +325,17 @@ describe("PR review advisor specialist prompts", () => {
       Object.fromEntries(
         ADVISOR_INTERESTS.map((interest) => [
           interest,
-          interest === "documentation-standard-work" ? [TERMINOLOGY_TRACE_TOOL] : [],
+          interest === "documentation-standard-work"
+            ? [TERMINOLOGY_TRACE_TOOL, RECORD_ADVISOR_FINDINGS_TOOL]
+            : [RECORD_ADVISOR_FINDINGS_TOOL],
         ]),
       ),
     );
     const documentationTools =
       captured.find(([interest]) => interest === "documentation-standard-work")?.[1] ?? [];
-    const trace = documentationTools[0] as CallableTool;
+    const trace = documentationTools.find(
+      ({ name }) => name === TERMINOLOGY_TRACE_TOOL,
+    ) as CallableTool;
     const evidence = await trace.execute(
       "trace-1",
       { term: "checkout-bound" },
@@ -337,8 +353,8 @@ describe("PR review advisor specialist prompts", () => {
       const turn = buildSpecialistInvestigateTurn(interest, context);
       const expected =
         interest === "documentation-standard-work"
-          ? ["read", "grep", "find", "ls", TERMINOLOGY_TRACE_TOOL]
-          : ["read", "grep", "find", "ls"];
+          ? ["read", "grep", "find", "ls", TERMINOLOGY_TRACE_TOOL, RECORD_ADVISOR_FINDINGS_TOOL]
+          : ["read", "grep", "find", "ls", RECORD_ADVISOR_FINDINGS_TOOL];
 
       expect(turn.activeToolNames).toEqual([...expected, E2E_RECEIPT_TOOL]);
       expect(turn.activeToolNames).not.toContain("record_findings");
@@ -347,4 +363,81 @@ describe("PR review advisor specialist prompts", () => {
       expect(turn.activeToolNames).not.toContain("submit_review");
     },
   );
+
+  it("commits a canonical exact-head finding ledger through one terminal tool", async () => {
+    const headSha = "a".repeat(40);
+    const controller = createAdvisorFindingToolController({ headSha, interest: "behavior" });
+    const record = controller.tools[0] as CallableTool;
+
+    await record.execute(
+      "record-1",
+      {
+        findings: [
+          {
+            severity: "P1",
+            kind: "correctness",
+            summary: "The fallback loses the recorded value.",
+            path: "src/lib/example.ts",
+            line: 42,
+            impact: "A valid invocation returns the wrong state.",
+            smallestSafeFix: "Preserve the value when the fallback runs.",
+            regressionTest: "Add a focused fallback-state regression.",
+            exclusions: [],
+          },
+        ],
+        noFindingsReason: null,
+      },
+      undefined,
+      undefined,
+      undefined as never,
+    );
+
+    const ledger = controller.snapshot();
+    expect(ledger).toMatchObject({
+      version: 1,
+      revision: 1,
+      identity: "exact-head",
+      headSha,
+      interest: "behavior",
+      status: "findings",
+      noFindingsReason: null,
+    });
+    expect(ledger.findings[0]?.id).toMatch(/^F-behavior-[0-9a-f]{20}$/u);
+    const nextHead = createAdvisorFindingToolController({
+      headSha: "b".repeat(40),
+      interest: "behavior",
+    });
+    await (nextHead.tools[0] as CallableTool).execute(
+      "record-next-head",
+      {
+        findings: [
+          {
+            severity: "P1",
+            kind: "correctness",
+            summary: "The fallback loses the recorded value.",
+            path: "src/lib/example.ts",
+            line: 42,
+            impact: "A valid invocation returns the wrong state.",
+            smallestSafeFix: "Preserve the value when the fallback runs.",
+            regressionTest: "Add a focused fallback-state regression.",
+            exclusions: [],
+          },
+        ],
+        noFindingsReason: null,
+      },
+      undefined,
+      undefined,
+      undefined as never,
+    );
+    expect(nextHead.snapshot().findings[0]?.id).toBe(ledger.findings[0]?.id);
+    await expect(
+      record.execute(
+        "record-2",
+        { findings: [], noFindingsReason: "No blocking behavior issue remains." },
+        undefined,
+        undefined,
+        undefined as never,
+      ),
+    ).rejects.toThrow("already has a committed receipt");
+  });
 });

--- a/test/fixtures/review-queue-findings-clear.json
+++ b/test/fixtures/review-queue-findings-clear.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "revision": 1,
+  "identity": "exact-head",
+  "headSha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "interest": "security-standard-work",
+  "status": "clear",
+  "findings": [],
+  "noFindingsReason": "No P0/P1 blocker remains in the reviewed area."
+}

--- a/test/fixtures/review-queue-findings-excluded-blocker.json
+++ b/test/fixtures/review-queue-findings-excluded-blocker.json
@@ -1,0 +1,27 @@
+{
+  "version": 1,
+  "revision": 1,
+  "identity": "exact-head",
+  "headSha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "interest": "security-standard-work",
+  "status": "findings",
+  "findings": [
+    {
+      "id": "F-security-standard-work-c0576369ed672f84bc23",
+      "interest": "security-standard-work",
+      "severity": "P1",
+      "kind": "security",
+      "summary": "The fallback exposes a credential.",
+      "path": "src/lib/example.ts",
+      "line": 42,
+      "impact": "A diagnostic includes the credential value.",
+      "smallestSafeFix": "Remove the credential from the diagnostic.",
+      "regressionTest": "Assert that the diagnostic contains no credential value.",
+      "exclusions": [
+        "credential-access",
+        "security-sensitive"
+      ]
+    }
+  ],
+  "noFindingsReason": null
+}

--- a/tools/advisors/canonical-json.mts
+++ b/tools/advisors/canonical-json.mts
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash } from "node:crypto";
+
+export function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, item]) => `${JSON.stringify(key)}:${canonicalJson(item)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+export function sha256(value: string | Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+export function hasControlCharacters(value: string, allowedCodes: readonly number[] = []): boolean {
+  return [...value].some((character) => {
+    const code = character.charCodeAt(0);
+    return (code <= 31 || code === 127) && !allowedCodes.includes(code);
+  });
+}

--- a/tools/pr-review-advisor/README.md
+++ b/tools/pr-review-advisor/README.md
@@ -23,7 +23,7 @@ It intentionally does not report GitHub mergeability, branch protection, CI stat
 3. Prepares the target PR as inert analysis data and executes the trusted Advisor entrypoint from the workflow checkout.
 4. Runs model analysis inside OpenShell. The sandbox receives neither a GitHub token nor the upstream model credential.
 5. Runs one required Pi session for each valid Markdown prompt in `tools/pr-review-advisor/specialists`. Each specialist reads repository evidence and records a native session trace.
-6. Each specialist publishes its Markdown review as the job summary. Its artifact contains the Markdown, native session trace, E2E receipt, and shared review-queue context.
+6. Each specialist publishes its Markdown review as the job summary. Its artifact contains the Markdown, native session trace, E2E receipt, findings ledger, and shared review-queue context.
 7. After every specialist completes successfully, one publisher attempts to post a sticky comment that links to the workflow run. A failed specialist keeps the workflow failed and suppresses publication.
 
 `investigate-turn.mts` owns the shared investigation turn and deterministic context contract. `specialist-tools.mts` owns specialist tool policy and implementations. `specialists.mts` applies each specialist prompt and tool policy. `trusted-guidance.mts` owns the system prompt and checked-in review guidance. `turn-context.mts` and the context modules build bounded deterministic evidence. `run-specialist.mts` composes these modules and writes each specialist's Markdown review and native session trace.
@@ -127,7 +127,7 @@ The discovered specialists use the workflow-configured model and share the same 
 
 ## Artifacts
 
-Each specialist artifact contains a Markdown review, Pi's unchanged native JSONL session, and an E2E recommendation receipt. The
+Each specialist artifact contains a Markdown review, Pi's unchanged native JSONL session, E2E recommendations, a findings ledger, and shared review-queue context. See [Review queue evidence](REVIEW-QUEUE.md) for the consumer contract. The
 workflow run also displays each Markdown review as a job summary. Replace `<interest>` with the
 specialist interest and `<attempt>` with the workflow run attempt number, then download the artifact
 with `gh run download <run-id> --name pr-review-specialist-<interest>-<attempt>`.

--- a/tools/pr-review-advisor/REVIEW-QUEUE.md
+++ b/tools/pr-review-advisor/REVIEW-QUEUE.md
@@ -5,7 +5,34 @@
 
 Issue #11489 owns this read-only consumer contract. These artifacts are advisory evidence, not merge authorization.
 The consumer must verify GitHub provenance before parsing their contents. New artifacts appear only after this producer reaches trusted `main`.
-Older runs remain unknown. The blocker ledger is a separate dependency proposed by PR #11047; this change does not publish blocker counts.
+Older runs without the required evidence remain unknown.
+
+## Advisor blockers
+
+Each successful specialist writes `pr-review-<interest>-findings.json` in its existing specialist artifact.
+The read-only ledger and canonical JSON implementation are adapted from @cjagwani's PR #11047.
+The producer includes no repair selection, generated commits, or repair workflow.
+
+The ledger requires `version:1`, `revision:1`, `identity:"exact-head"`, `headSha`, and `interest`.
+`status:"clear"` requires an empty `findings` array and a nonempty normalized `noFindingsReason`.
+`status:"findings"` requires one to twenty findings and `noFindingsReason:null`.
+Each finding contains `id`, `interest`, `severity`, `kind`, `summary`, `path`, `line`, `impact`, `smallestSafeFix`, `regressionTest`, and `exclusions`.
+Only P0/P1 findings are accepted. All findings count as blockers, including every excluded finding.
+Exclusions describe constraints on a possible correction; they never remove a blocker.
+
+The trusted recorder normalizes text, sorts exclusions, and derives IDs before sorting findings by ID.
+Each ID is `F-<interest>-` followed by the first twenty hexadecimal characters of SHA-256 over canonical JSON of the finding without `id`.
+Canonical JSON recursively sorts object keys and preserves array order. The ledger parser rebuilds and compares the canonical result.
+Reject files larger than 512 KiB, unsupported fields, stale identities, malformed findings, and noncanonical IDs or ordering.
+The producer writes private files without replacing an existing file or following a symlink.
+
+The specialist must record its complete P0/P1 set after its human-readable analysis, including an explicit reason for zero blockers.
+Missing recording fails the specialist run. Missing artifacts never mean zero blockers.
+Require every trusted specialist, a successful matching workflow, and the provenance checks below before calculating the blocker count.
+The ledger does not authenticate itself; bind its candidate and specialist to the shared context and GitHub artifact envelope.
+
+`test/fixtures/review-queue-findings-clear.json` and `test/fixtures/review-queue-findings-excluded-blocker.json` are producer-generated synthetic fixtures.
+The focused ledger tests rebuild both fixtures, validate canonical identity, and prove excluded findings remain present.
 
 ## Advisor recommendations
 
@@ -76,7 +103,6 @@ Run and attempt identity come from the GitHub artifact envelope. Payloads cannot
 Do not combine artifacts from different runs or attempts. Incomplete rerun artifacts remain unknown even if an earlier attempt passed.
 Runs without the context sidecar remain unknown. Do not scrape Pi session chunks to supply missing evidence.
 
-The proposed #11047 finding ledger is separate. All validated P0/P1 findings count as blockers, including findings excluded from automated repair.
 Require every expected specialist ledger before reporting zero. A completion comment alone cannot establish zero blockers.
 
 ## Dispatch

--- a/tools/pr-review-advisor/finding-ledger.mts
+++ b/tools/pr-review-advisor/finding-ledger.mts
@@ -197,7 +197,7 @@ export function buildAdvisorFindingLedger(input: {
       impact: boundedText(candidate.impact, "impact", 1000),
       smallestSafeFix: boundedText(candidate.smallestSafeFix, "smallestSafeFix", 1000),
       regressionTest: boundedText(candidate.regressionTest, "regressionTest", 1000),
-      exclusions: [...exclusions].sort(),
+      exclusions: Object.freeze(exclusions.sort()),
     } as const;
     const id = `F-${input.interest}-${sha256(canonicalJson(normalized)).slice(0, 20)}`;
     return Object.freeze({ id, ...normalized });

--- a/tools/pr-review-advisor/finding-ledger.mts
+++ b/tools/pr-review-advisor/finding-ledger.mts
@@ -1,0 +1,326 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+
+import { defineTool, type ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+import { Check } from "typebox/value";
+
+import { canonicalJson, hasControlCharacters, sha256 } from "../advisors/canonical-json.mts";
+import type { AdvisorInterest } from "./specialist-catalog.mts";
+
+export const RECORD_ADVISOR_FINDINGS_TOOL = "pr_review_record_findings";
+export const MAX_FINDINGS_PER_SPECIALIST = 20;
+export const MAX_FINDING_LEDGER_BYTES = 512 * 1024;
+
+export const ADVISOR_FINDING_EXCLUSIONS = [
+  "ambiguous-intent",
+  "author-attestation",
+  "commit-verification",
+  "credential-access",
+  "dco",
+  "dependency-change",
+  "external-mutation",
+  "maintainer-decision",
+  "product-scope",
+  "security-sensitive",
+  "unsupported-path",
+] as const;
+
+export const ADVISOR_FINDING_KINDS = [
+  "behavior",
+  "code-quality",
+  "correctness",
+  "dependency",
+  "design",
+  "documentation",
+  "migration",
+  "operations",
+  "product-scope",
+  "security",
+  "test-design",
+] as const;
+
+export const ADVISOR_FINDING_SEVERITIES = ["P0", "P1"] as const;
+
+export type AdvisorFindingExclusion = (typeof ADVISOR_FINDING_EXCLUSIONS)[number];
+export type AdvisorFindingKind = (typeof ADVISOR_FINDING_KINDS)[number];
+export type AdvisorFindingSeverity = (typeof ADVISOR_FINDING_SEVERITIES)[number];
+
+export type AdvisorFinding = Readonly<{
+  id: string;
+  interest: AdvisorInterest;
+  severity: AdvisorFindingSeverity;
+  kind: AdvisorFindingKind;
+  summary: string;
+  path: string;
+  line: number | null;
+  impact: string;
+  smallestSafeFix: string;
+  regressionTest: string;
+  exclusions: readonly AdvisorFindingExclusion[];
+}>;
+
+export type AdvisorFindingLedger = Readonly<{
+  version: 1;
+  revision: 1;
+  identity: "exact-head";
+  headSha: string;
+  interest: AdvisorInterest;
+  status: "clear" | "findings";
+  findings: readonly AdvisorFinding[];
+  noFindingsReason: string | null;
+}>;
+
+type FindingInput = Omit<AdvisorFinding, "id" | "interest">;
+
+type FindingCommitInput = Readonly<{
+  findings: readonly FindingInput[];
+  noFindingsReason: string | null;
+}>;
+
+export type AdvisorFindingToolController = Readonly<{
+  tools: ToolDefinition[];
+  snapshot(): AdvisorFindingLedger;
+}>;
+
+const findingSchema = Type.Object(
+  {
+    severity: Type.Union(ADVISOR_FINDING_SEVERITIES.map((value) => Type.Literal(value))),
+    kind: Type.Union(ADVISOR_FINDING_KINDS.map((value) => Type.Literal(value))),
+    summary: Type.String({ minLength: 1, maxLength: 500 }),
+    path: Type.String({ minLength: 1, maxLength: 512 }),
+    line: Type.Union([Type.Integer({ minimum: 1 }), Type.Null()]),
+    impact: Type.String({ minLength: 1, maxLength: 1000 }),
+    smallestSafeFix: Type.String({ minLength: 1, maxLength: 1000 }),
+    regressionTest: Type.String({ minLength: 1, maxLength: 1000 }),
+    exclusions: Type.Array(
+      Type.Union(ADVISOR_FINDING_EXCLUSIONS.map((value) => Type.Literal(value))),
+      { maxItems: ADVISOR_FINDING_EXCLUSIONS.length, uniqueItems: true },
+    ),
+  },
+  { additionalProperties: false },
+);
+
+const commitSchema = Type.Object(
+  {
+    findings: Type.Array(findingSchema, {
+      maxItems: MAX_FINDINGS_PER_SPECIALIST,
+    }),
+    noFindingsReason: Type.Union([Type.String({ minLength: 1, maxLength: 1000 }), Type.Null()]),
+  },
+  { additionalProperties: false },
+);
+
+const ledgerSchema = Type.Object(
+  {
+    version: Type.Literal(1),
+    revision: Type.Literal(1),
+    identity: Type.Literal("exact-head"),
+    headSha: Type.String({ pattern: "^[0-9a-f]{40}$" }),
+    interest: Type.String(),
+    status: Type.Union([Type.Literal("clear"), Type.Literal("findings")]),
+    findings: Type.Array(
+      Type.Object(
+        {
+          id: Type.String({ minLength: 1, maxLength: 128 }),
+          interest: Type.String(),
+          ...findingSchema.properties,
+        },
+        { additionalProperties: false },
+      ),
+      { maxItems: MAX_FINDINGS_PER_SPECIALIST },
+    ),
+    noFindingsReason: commitSchema.properties.noFindingsReason,
+  },
+  { additionalProperties: false },
+);
+
+export function createAdvisorFindingToolController(input: {
+  headSha: string;
+  interest: AdvisorInterest;
+}): AdvisorFindingToolController {
+  const headSha = fullSha(input.headSha, "headSha");
+  const interest = input.interest;
+  let ledger: AdvisorFindingLedger | undefined;
+  const recordFindings = defineTool({
+    name: RECORD_ADVISOR_FINDINGS_TOOL,
+    label: "Record exact-head Advisor blockers",
+    description:
+      "Commit the complete machine-readable blocker set for this specialist. Record only P0/P1 issues that require a repository change. Use an empty finding list and a concrete reason when no blocker remains.",
+    parameters: commitSchema,
+    executionMode: "sequential",
+    execute: async (_id, rawInput) => {
+      if (ledger) throw new Error("Advisor finding ledger already has a committed receipt");
+      ledger = buildAdvisorFindingLedger({
+        headSha,
+        interest,
+        input: rawInput as FindingCommitInput,
+      });
+      return toolResult(ledger, true);
+    },
+  });
+  return {
+    tools: [recordFindings],
+    snapshot() {
+      if (!ledger) throw new Error("Advisor specialist did not commit its finding ledger");
+      return ledger;
+    },
+  };
+}
+
+export function buildAdvisorFindingLedger(input: {
+  headSha: string;
+  interest: AdvisorInterest;
+  input: FindingCommitInput;
+}): AdvisorFindingLedger {
+  const headSha = fullSha(input.headSha, "headSha");
+  if (!Check(commitSchema, input.input)) throw new Error("Advisor finding input is invalid");
+  if (input.input.findings.length === 0 && input.input.noFindingsReason === null) {
+    throw new Error("An empty finding ledger requires noFindingsReason");
+  }
+  if (input.input.findings.length > 0 && input.input.noFindingsReason !== null) {
+    throw new Error("noFindingsReason is mutually exclusive with findings");
+  }
+
+  const findings = input.input.findings.map((candidate): AdvisorFinding => {
+    const exclusions = [...candidate.exclusions];
+    const normalized = {
+      interest: input.interest,
+      severity: candidate.severity,
+      kind: candidate.kind,
+      summary: boundedText(candidate.summary, "summary", 500),
+      path: safeEvidencePath(candidate.path),
+      line: candidate.line === null ? null : positiveInteger(candidate.line, "line"),
+      impact: boundedText(candidate.impact, "impact", 1000),
+      smallestSafeFix: boundedText(candidate.smallestSafeFix, "smallestSafeFix", 1000),
+      regressionTest: boundedText(candidate.regressionTest, "regressionTest", 1000),
+      exclusions: [...exclusions].sort(),
+    } as const;
+    const id = `F-${input.interest}-${sha256(canonicalJson(normalized)).slice(0, 20)}`;
+    return Object.freeze({ id, ...normalized });
+  });
+  findings.sort((left, right) => left.id.localeCompare(right.id));
+  if (new Set(findings.map(({ id }) => id)).size !== findings.length) {
+    throw new Error("Advisor finding ledger contains duplicate canonical findings");
+  }
+  const noFindingsReason =
+    findings.length === 0
+      ? boundedText(input.input.noFindingsReason ?? "", "noFindingsReason", 1000)
+      : null;
+  return Object.freeze({
+    version: 1,
+    revision: 1,
+    identity: "exact-head",
+    headSha,
+    interest: input.interest,
+    status: findings.length > 0 ? "findings" : "clear",
+    findings: Object.freeze(findings),
+    noFindingsReason,
+  });
+}
+
+export function parseAdvisorFindingLedger(
+  value: unknown,
+  expected: { headSha: string; interest: AdvisorInterest },
+): AdvisorFindingLedger {
+  if (!Check(ledgerSchema, value)) throw new Error("Advisor finding ledger is invalid");
+  const raw = value as Record<string, unknown>;
+  if (
+    raw.version !== 1 ||
+    raw.revision !== 1 ||
+    raw.identity !== "exact-head" ||
+    raw.headSha !== expected.headSha ||
+    raw.interest !== expected.interest
+  ) {
+    throw new Error("Advisor finding ledger identity does not match the exact specialist head");
+  }
+  const rebuilt = buildAdvisorFindingLedger({
+    headSha: expected.headSha,
+    interest: expected.interest,
+    input: {
+      findings: (raw.findings as unknown[]).map((value, index): FindingInput => {
+        const finding = value as Record<string, unknown>;
+        if (finding.interest !== expected.interest) {
+          throw new Error(`Advisor finding ${index} interest does not match its ledger`);
+        }
+        return {
+          severity: finding.severity as AdvisorFindingSeverity,
+          kind: finding.kind as AdvisorFindingKind,
+          summary: finding.summary as string,
+          path: finding.path as string,
+          line: finding.line as number | null,
+          impact: finding.impact as string,
+          smallestSafeFix: finding.smallestSafeFix as string,
+          regressionTest: finding.regressionTest as string,
+          exclusions: finding.exclusions as AdvisorFindingExclusion[],
+        };
+      }),
+      noFindingsReason: raw.noFindingsReason as string | null,
+    },
+  });
+  if (canonicalJson(raw) !== canonicalJson(rebuilt)) {
+    throw new Error("Advisor finding ledger is not canonical");
+  }
+  return rebuilt;
+}
+
+export function writeAdvisorFindingLedger(
+  outputDirectory: string,
+  interest: AdvisorInterest,
+  ledger: AdvisorFindingLedger,
+): string {
+  const file = path.join(outputDirectory, `pr-review-${interest}-findings.json`);
+  const content = `${JSON.stringify(ledger, null, 2)}\n`;
+  if (Buffer.byteLength(content, "utf8") > MAX_FINDING_LEDGER_BYTES) {
+    throw new Error("Advisor finding ledger exceeds its size limit");
+  }
+  fs.writeFileSync(file, content, { flag: "wx", mode: 0o600 });
+  return file;
+}
+
+function safeEvidencePath(value: string): string {
+  const result = boundedText(value, "path", 512);
+  if (
+    !/^[A-Za-z0-9._/-]+$/u.test(result) ||
+    result.startsWith("/") ||
+    result.endsWith("/") ||
+    result.includes("//") ||
+    path.posix.normalize(result) !== result ||
+    result.split("/").some((segment) => segment === "." || segment === "..")
+  ) {
+    throw new Error("Finding path must be a normalized repository-relative path");
+  }
+  return result;
+}
+
+function boundedText(value: string, label: string, maximum: number): string {
+  if (typeof value !== "string") throw new Error(`${label} must be a string`);
+  const result = value.trim().replace(/\s+/gu, " ");
+  if (!result || Buffer.byteLength(result, "utf8") > maximum || hasControlCharacters(result)) {
+    throw new Error(`${label} must be bounded printable text`);
+  }
+  return result;
+}
+
+function fullSha(value: string, label: string): string {
+  if (!/^[0-9a-f]{40}$/u.test(value)) throw new Error(`${label} must be a full SHA`);
+  return value;
+}
+
+function positiveInteger(value: number, label: string): number {
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new Error(`${label} must be a positive integer`);
+  }
+  return value;
+}
+
+function toolResult(value: unknown, terminate = false) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(value) }],
+    details: {},
+    ...(terminate ? { terminate } : {}),
+  };
+}

--- a/tools/pr-review-advisor/local-review-implementation.mts
+++ b/tools/pr-review-advisor/local-review-implementation.mts
@@ -304,13 +304,14 @@ function validateSpecialistArtifacts(root: string, interest: string): void {
   const directory = path.join(root, "artifacts", "pr-review-specialist-" + interest);
   const expected = [
     `pr-review-${interest}-e2e.json`,
+    `pr-review-${interest}-findings.json`,
     `pr-review-${interest}-session.jsonl`,
     `pr-review-${interest}-summary.md`,
     "review-queue-context.json",
   ];
   if (JSON.stringify(fs.readdirSync(directory).sort()) !== JSON.stringify(expected))
     throw new Error(
-      "Specialist artifacts do not match the context, E2E, Markdown, and JSONL contract",
+      "Specialist artifacts do not match the context, E2E, findings, Markdown, and JSONL contract",
     );
   if (
     expected.some((name) => {

--- a/tools/pr-review-advisor/run-specialist.mts
+++ b/tools/pr-review-advisor/run-specialist.mts
@@ -17,6 +17,11 @@ import {
   type RunReadOnlyAdvisorOptions,
 } from "../advisors/session.mts";
 import { collectDeterministicContext } from "./deterministic-context.mts";
+import {
+  createAdvisorFindingToolController,
+  type AdvisorFindingToolController,
+  writeAdvisorFindingLedger,
+} from "./finding-ledger.mts";
 import { trustedE2eRecommendationInventory } from "../advisors/e2e-recommendations.mts";
 import {
   buildReviewQueueContext,
@@ -62,15 +67,20 @@ export function writeSpecialistSummary(
 
 export function runSpecialistAdvisor(
   interest: AdvisorInterest,
-  refs: { baseRef: string; headRef: string },
+  refs: { baseRef: string; headRef: string; headSha: string },
   options: RunReadOnlyAdvisorOptions,
   run: (options: RunReadOnlyAdvisorOptions) => Promise<RunAdvisorResult> = runReadOnlyAdvisor,
+  findingController: AdvisorFindingToolController = createAdvisorFindingToolController({
+    headSha: refs.headSha,
+    interest,
+  }),
 ): Promise<RunAdvisorResult> {
   return run({
     ...options,
     customTools: [
       ...specialistCustomTools(interest, { ...refs, cwd: options.cwd }),
       ...(options.customTools ?? []),
+      ...findingController.tools,
     ],
   });
 }
@@ -126,6 +136,7 @@ async function main(): Promise<void> {
     operations: buildOperationsTurnContext(deterministic),
     reconciliation: buildReconciliationTurnContext(deterministic),
   });
+  const findingController = createAdvisorFindingToolController({ headSha, interest });
   const inventory = trustedE2eRecommendationInventory();
   const evidenceContext = {
     baseSha: getHeadSha(baseRef),
@@ -141,7 +152,7 @@ async function main(): Promise<void> {
   const recommendations = createE2eRecommendationRecorder(inventory);
   const run = await runSpecialistAdvisor(
     interest,
-    { baseRef, headRef },
+    { baseRef, headRef, headSha },
     {
       cwd: process.cwd(),
       additionalReadRoots: [path.dirname(diffPath)],
@@ -161,6 +172,8 @@ async function main(): Promise<void> {
       logPrefix: `pr-review-${interest}`,
       logProgress: (message) => console.log(`[pr-review-${interest}] ${message}`),
     },
+    runReadOnlyAdvisor,
+    findingController,
   );
   const errors = advisorRunErrors(run);
   if (errors.length > 0) throw new Error(errors.join("; "));
@@ -175,6 +188,7 @@ async function main(): Promise<void> {
     { flag: "wx", mode: 0o600 },
   );
   writeSpecialistSummary(outDir, interest, run.text);
+  writeAdvisorFindingLedger(outDir, interest, findingController.snapshot());
   if (!run.sessionFile) throw new Error("Pi did not persist a specialist JSONL session");
   const sessionStat = fs.lstatSync(run.sessionFile);
   if (!sessionStat.isFile() || sessionStat.isSymbolicLink()) {

--- a/tools/pr-review-advisor/specialists.mts
+++ b/tools/pr-review-advisor/specialists.mts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { AdvisorPromptTurn } from "../advisors/session.mts";
+import { RECORD_ADVISOR_FINDINGS_TOOL } from "./finding-ledger.mts";
 import { buildInvestigateTurn, type InvestigateTurnContext } from "./investigate-turn.mts";
 import {
   ADVISOR_SPECIALISTS,
@@ -80,7 +81,7 @@ Reach a conclusion for the assigned area. Support it with repository evidence. R
 
 Record every additional E2E recommendation, including optional coverage, with pr_review_record_e2e_recommendations before your final Markdown review. Give an explicit reason when no additional E2E is needed. Record needed coverage without a supported selector as unresolved. The recorded recommendations must include every E2E recommendation in your Markdown review.
 
-This is an investigation-only specialist turn. Do not emit a final result schema, canonical finding ID, merge recommendation, or GitHub comment. Do not mutate files, execute repository code, access the network, run a package manager, or run tests.`;
+This is an investigation-only specialist turn. Do not invent a finding ID, merge recommendation, or GitHub comment. After writing the human-readable analysis, call \`${RECORD_ADVISOR_FINDINGS_TOOL}\` exactly once as the terminal action. Record only P0/P1 issues that require a repository change; the trusted host derives exact-head IDs. For each blocker, name one exact repository path and disclose every applicable exclusion. Use an empty finding list with a concrete reason when no blocker remains. Do not mutate files, execute repository code, access the network, run a package manager, or run tests.`;
 
 export function buildSpecialistInvestigateTurn(
   interest: AdvisorInterest,
@@ -91,9 +92,17 @@ export function buildSpecialistInvestigateTurn(
   return {
     ...fullTurn,
     name: `investigate-${interest}`,
-    activeToolNames: [...specialistToolNames(interest), E2E_RECEIPT_TOOL],
+    activeToolNames: [
+      ...specialistToolNames(interest),
+      RECORD_ADVISOR_FINDINGS_TOOL,
+      E2E_RECEIPT_TOOL,
+    ],
     requiredToolNames: [...(fullTurn.requiredToolNames ?? []), E2E_RECEIPT_TOOL],
     requiredReadOneOfPaths: [context.diffPath],
+    terminalSubmitToolName: RECORD_ADVISOR_FINDINGS_TOOL,
+    terminalSubmitRepairPrompt:
+      `Commit the complete blocker ledger now by calling ${RECORD_ADVISOR_FINDINGS_TOOL}. ` +
+      "Do not emit more prose. If there are no P0/P1 blockers, submit an empty finding list and a concrete noFindingsReason.",
     prompt: `Review the ${specialist.label} area.
 
 ${COMMON_PROMPT}


### PR DESCRIPTION
## Outcome

Each Advisor specialist publishes a structured P0/P1 findings ledger or an explicit zero-blocker reason. The read-only review queue can count blockers without parsing Markdown or Pi traces.

## Reason

The complete review context is on `main` through #11543, but the monitor still lacks structured blocker evidence. This PR extracts only the read-only prerequisite from #11047.

### Related issues

Refs #11489. Reuses the ledger from #11047; does not close or replace its repair-lifecycle work.

## Changes

- Reuse the canonical JSON and finding-ledger implementation from @cjagwani's #11047 at `dfa726a8edcd5d846ed8b8b85ef37763fd95318d`, preserving license headers and co-author attribution. Omit the repair digest helper and unrelated control-character replacement helper.
- Register the existing terminal-submission mechanism for every specialist. Require one complete ledger after the human-readable analysis; missing recording fails the run.
- Write `pr-review-<interest>-findings.json` inside existing specialist artifacts and require it in local artifact validation. No workflow, permission, publisher, repair-selection, generated-commit, opt-in, or E2E dispatch changes.
- Preserve schema version 1/revision 1/exact-head identity. Count every P0/P1 finding, including excluded findings. Add producer-generated clear and excluded-blocker fixtures and focused validation tests.

## Verification

- Credential-free Linux Docker, `node:22.23.2-trixie` (`sha256:2082d2bf902c8835655c6bcfee3594c00ea900498a9f6e2b96d3352536f9e8d8`), using current-base locked dependencies installed with `npm ci --ignore-scripts --no-audit --no-fund`.
- `npx vitest run --silent --project integration test/automation/pull-requests/pr-review-advisor-finding-ledger.test.ts test/automation/pull-requests/pr-review-advisor-specialists.test.ts test/automation/pull-requests/pr-review-advisor-local.test.ts test/automation/pull-requests/pr-review-advisor-e2e-receipt.test.ts` — 114 passed as a non-root user, including the snapshot-mutation regression requested by automated review.
- The monitor task independently ran `swift test --filter ReviewFindingLedgerTests`: four passed. The actual TypeScript fixtures produced counts 0 and 1, including canonical excluded-blocker ID `F-security-standard-work-c0576369ed672f84bc23`.
- Negative cases cover missing recording, invalid or duplicate findings, stale identity, noncanonical ordering/IDs, excluded blockers, size limits, and existing-file/symlink rejection.
- `npm run build:cli`, `npm --prefix nemoclaw run build`, and `npm run test:projects:check` — passed. The membership check covered 2690 files in seven disjoint projects.
- `NODE_OPTIONS=--max-old-space-size=6144 npm run typecheck:cli` — passed. The initial default-heap run exhausted Node's 2 GiB heap; the isolated container has 8 GiB available.
- `NODE_OPTIONS=--max-old-space-size=6144 npm run validate:pr` — passed on `82929b99d0870387b1f420c096023c1d4d9477cd` against refreshed canonical base `95b2eee9c46e9a9c5655f5fc760bc7c3fa135742`. Includes pre-commit, commitlint, and pre-push checks. Validation configuration and executables were unchanged from the trusted base; no hooks ran candidate code on the credential-bearing host.
- Full-diff self-review found no secrets, credentials, permission expansion, or repair automation. New schema code is required by the current passive consumer; it reuses #11047 rather than defining a second schema.

## Review notes

`npm run review:local` was attempted in credential-free Docker and stopped with `PR_REVIEW_ADVISOR_API_KEY is required for local review`. Alternative review completed under the user's standing shepherd instruction: full-diff self-review and focused tests. This is not independent approval or Advisor clearance.

On `82929b99d0870387b1f420c096023c1d4d9477cd`, all 12 CI shards and the aggregate check passed in https://github.com/NVIDIA/NemoClaw/actions/runs/34628587822. CodeRabbit marked its exclusions-mutation finding addressed and resolved; its current-head check is successful. The deterministic E2E plan selects no jobs or targets. The user requested skipping the release label.

Rollout requires this producer to reach trusted `main` and a successful fresh Advisor run. Old or missing ledgers remain unknown. Artifact provenance still comes from verified GitHub run/attempt identity and the shared review context, not the ledger alone. No live E2E is needed for these deterministic data and artifact contracts.

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>
