### PR TITLE
fix(hermes): restore launch forwards and bound auxiliary output

### DIFF
--- a/agents/hermes/Dockerfile
+++ b/agents/hermes/Dockerfile
@@ -93,6 +93,7 @@ COPY agents/hermes/a2a-neutral.patch agents/hermes/patch-gateway-runtime-metadat
 COPY agents/hermes/patch-gateway-process-identity.py /opt/nemoclaw-hermes-config/patch-gateway-process-identity.py
 COPY agents/hermes/patch-cron-execution-runtime.py /opt/nemoclaw-hermes-config/patch-cron-execution-runtime.py
 COPY agents/hermes/patch-cron-restore-drain.py /opt/nemoclaw-hermes-config/patch-cron-restore-drain.py
+COPY agents/hermes/patch-auxiliary-token-limit.py /opt/nemoclaw-hermes-config/patch-auxiliary-token-limit.py
 COPY agents/hermes/patch-neutral-platform-env-activation.py /opt/nemoclaw-hermes-config/patch-neutral-platform-env-activation.py
 COPY agents/hermes/patch-session-list-preview.py /opt/nemoclaw-hermes-config/patch-session-list-preview.py
 COPY agents/hermes/patch-profile-policy-defaults.py /opt/nemoclaw-hermes-config/patch-profile-policy-defaults.py
@@ -455,7 +456,7 @@ COPY --from=hermes-agent-payload / /
 # published base can carry the expected Hermes version while omitting either
 # optional dependency group. This is a build-time package/import guard; live
 # protocol behavior remains a separate E2E concern.
-ARG NEMOCLAW_HERMES_IMAGE_BUILD_PROBES_SHA256=ba0ac83296f802780b48ecc6807620a2050c7407e654f20bf7f30bfad4746038
+ARG NEMOCLAW_HERMES_IMAGE_BUILD_PROBES_SHA256=e52443b42315fde3f1a1c7dd2e3c86a3fdea7c9bea73c57e67399f61d47bbbb7
 # hadolint ignore=DL3059,DL4006
 RUN printf '%s  %s\n' \
         "$NEMOCLAW_HERMES_IMAGE_BUILD_PROBES_SHA256" /opt/nemoclaw-hermes-config/image-build-probes.py \
@@ -483,7 +484,7 @@ RUN find /opt/nemoclaw-hermes-config -type d -exec chmod 755 {} + \
 # same-version wheel selected by its lazy installer. Bind that production
 # boundary to NVIDIA/NemoClaw's reviewed wheel hashes.
 ARG NEMOCLAW_HERMES_HINDSIGHT_LAZY_INTEGRITY_PATCH_SHA256=5c619477c10e0b76cffd7adc214cbccf3beb77e7a1121f394c443502d9e0b736
-ARG NEMOCLAW_HERMES_IMAGE_BUILD_PROBES_SHA256=ba0ac83296f802780b48ecc6807620a2050c7407e654f20bf7f30bfad4746038
+ARG NEMOCLAW_HERMES_IMAGE_BUILD_PROBES_SHA256=e52443b42315fde3f1a1c7dd2e3c86a3fdea7c9bea73c57e67399f61d47bbbb7
 # hadolint ignore=DL4006
 RUN printf '%s  %s\n' \
         "$NEMOCLAW_HERMES_HINDSIGHT_LAZY_INTEGRITY_PATCH_SHA256" /opt/nemoclaw-hermes-config/hindsight-lazy-integrity.patch \
@@ -702,6 +703,21 @@ RUN set -eu; \
         /opt/nemoclaw-hermes-config/patch-gateway-process-identity.py \
         /opt/nemoclaw-hermes-config/patch-cron-execution-runtime.py \
         /opt/nemoclaw-hermes-config/patch-cron-restore-drain.py
+
+# Hermes v0.20.6 drops explicit auxiliary output limits on custom endpoints.
+# Preserve those limits on NemoClaw's managed inference route so session-title
+# generation cannot occupy Ollama's only inference slot until the context fills.
+ARG NEMOCLAW_HERMES_AUXILIARY_TOKEN_LIMIT_PATCHER_SHA256=d04ffc133e115caddd6a1243979e317a512a4ffd8b259ec2b053a5057c26ba93
+# hadolint ignore=DL4006
+RUN printf '%s  %s\n' \
+        "$NEMOCLAW_HERMES_AUXILIARY_TOKEN_LIMIT_PATCHER_SHA256" /opt/nemoclaw-hermes-config/patch-auxiliary-token-limit.py \
+    | sha256sum -c - \
+    || { echo "ERROR: patch-auxiliary-token-limit.py hash mismatch (update NEMOCLAW_HERMES_AUXILIARY_TOKEN_LIMIT_PATCHER_SHA256)" >&2; exit 1; }; \
+    /usr/bin/python3 -I /opt/nemoclaw-hermes-config/patch-auxiliary-token-limit.py \
+    && /opt/hermes/.venv/bin/python -m py_compile /opt/hermes/agent/auxiliary_client.py \
+    && /opt/hermes/.venv/bin/python -I \
+        /opt/nemoclaw-hermes-config/image-build-probes.py auxiliary-token-limit \
+    && rm /opt/nemoclaw-hermes-config/patch-auxiliary-token-limit.py
 
 # Hermes v0.20.6 computes `sessions list` preview from the first user message.
 # Its workspace-aware titled table then hides the preview behind an automatic
@@ -1646,6 +1662,7 @@ RUN check_metadata() { \
     && check_absent /opt/nemoclaw-hermes-config/patch-gateway-process-identity.py \
     && check_absent /opt/nemoclaw-hermes-config/patch-cron-execution-runtime.py \
     && check_absent /opt/nemoclaw-hermes-config/patch-cron-restore-drain.py \
+    && check_absent /opt/nemoclaw-hermes-config/patch-auxiliary-token-limit.py \
     && check_absent /opt/nemoclaw-hermes-config/patch-session-list-preview.py \
     && check_absent /opt/nemoclaw-hermes-config/patch-profile-policy-defaults.py \
     && check_absent /opt/nemoclaw-hermes-config/patch-neutral-platform-env-activation.py \

--- a/agents/hermes/Dockerfile
+++ b/agents/hermes/Dockerfile
@@ -456,7 +456,7 @@ COPY --from=hermes-agent-payload / /
 # published base can carry the expected Hermes version while omitting either
 # optional dependency group. This is a build-time package/import guard; live
 # protocol behavior remains a separate E2E concern.
-ARG NEMOCLAW_HERMES_IMAGE_BUILD_PROBES_SHA256=e52443b42315fde3f1a1c7dd2e3c86a3fdea7c9bea73c57e67399f61d47bbbb7
+ARG NEMOCLAW_HERMES_IMAGE_BUILD_PROBES_SHA256=5a3c5e9b51228649dc916aa36b3c51f2df8fa6807b139a35926844fd81b7a100
 # hadolint ignore=DL3059,DL4006
 RUN printf '%s  %s\n' \
         "$NEMOCLAW_HERMES_IMAGE_BUILD_PROBES_SHA256" /opt/nemoclaw-hermes-config/image-build-probes.py \
@@ -484,7 +484,7 @@ RUN find /opt/nemoclaw-hermes-config -type d -exec chmod 755 {} + \
 # same-version wheel selected by its lazy installer. Bind that production
 # boundary to NVIDIA/NemoClaw's reviewed wheel hashes.
 ARG NEMOCLAW_HERMES_HINDSIGHT_LAZY_INTEGRITY_PATCH_SHA256=5c619477c10e0b76cffd7adc214cbccf3beb77e7a1121f394c443502d9e0b736
-ARG NEMOCLAW_HERMES_IMAGE_BUILD_PROBES_SHA256=e52443b42315fde3f1a1c7dd2e3c86a3fdea7c9bea73c57e67399f61d47bbbb7
+ARG NEMOCLAW_HERMES_IMAGE_BUILD_PROBES_SHA256=5a3c5e9b51228649dc916aa36b3c51f2df8fa6807b139a35926844fd81b7a100
 # hadolint ignore=DL4006
 RUN printf '%s  %s\n' \
         "$NEMOCLAW_HERMES_HINDSIGHT_LAZY_INTEGRITY_PATCH_SHA256" /opt/nemoclaw-hermes-config/hindsight-lazy-integrity.patch \
@@ -683,13 +683,18 @@ RUN /usr/bin/python3 -I \
 ARG NEMOCLAW_HERMES_CRON_RUNTIME_PATCHER_SHA256=b8aae8925cacad654d7b09900bd1cc02d776feaec4662c06dde8f4b2f356e22e
 ARG NEMOCLAW_HERMES_CRON_EXECUTIONS_SOURCE_SHA256=b4a685a901abdffe2d1232099b3c27391775775a7011d52c90276cb15d3fd75d
 ARG NEMOCLAW_HERMES_BACKUP_SOURCE_SHA256=b0838c1f2e120d8f97076c6321297077edc1f150dc6d4b84ba3d13327fcbb156
+# Hermes v0.20.6 drops explicit auxiliary output limits on custom endpoints.
+# Preserve those limits on NemoClaw's managed inference route so session-title
+# generation cannot occupy Ollama's only inference slot until the context fills.
+ARG NEMOCLAW_HERMES_AUXILIARY_TOKEN_LIMIT_PATCHER_SHA256=d04ffc133e115caddd6a1243979e317a512a4ffd8b259ec2b053a5057c26ba93
 # hadolint ignore=DL4006
 RUN printf '%s  %s\n' \
         "$NEMOCLAW_HERMES_CRON_RUNTIME_PATCHER_SHA256" /opt/nemoclaw-hermes-config/patch-cron-execution-runtime.py \
         "$NEMOCLAW_HERMES_CRON_EXECUTIONS_SOURCE_SHA256" /opt/hermes/cron/executions.py \
         "$NEMOCLAW_HERMES_BACKUP_SOURCE_SHA256" /opt/hermes/hermes_cli/backup.py \
+        "$NEMOCLAW_HERMES_AUXILIARY_TOKEN_LIMIT_PATCHER_SHA256" /opt/nemoclaw-hermes-config/patch-auxiliary-token-limit.py \
     | sha256sum -c - \
-    || { echo "ERROR: Hermes cron execution runtime source identity mismatch" >&2; exit 1; }
+    || { echo "ERROR: Hermes cron or auxiliary token-limit source identity mismatch" >&2; exit 1; }
 RUN /usr/bin/python3 -I \
         /opt/nemoclaw-hermes-config/patch-cron-execution-runtime.py \
         --executions /opt/hermes/cron/executions.py \
@@ -699,25 +704,15 @@ RUN set -eu; \
     trap 'rm -rf "$probe_home"' EXIT; \
     HERMES_HOME="$probe_home" /opt/hermes/.venv/bin/python -I \
         /opt/nemoclaw-hermes-config/image-build-probes.py cron-runtime-source \
-    && rm /opt/nemoclaw-hermes-config/patch-gateway-runtime-metadata.py \
-        /opt/nemoclaw-hermes-config/patch-gateway-process-identity.py \
-        /opt/nemoclaw-hermes-config/patch-cron-execution-runtime.py \
-        /opt/nemoclaw-hermes-config/patch-cron-restore-drain.py
-
-# Hermes v0.20.6 drops explicit auxiliary output limits on custom endpoints.
-# Preserve those limits on NemoClaw's managed inference route so session-title
-# generation cannot occupy Ollama's only inference slot until the context fills.
-ARG NEMOCLAW_HERMES_AUXILIARY_TOKEN_LIMIT_PATCHER_SHA256=d04ffc133e115caddd6a1243979e317a512a4ffd8b259ec2b053a5057c26ba93
-# hadolint ignore=DL4006
-RUN printf '%s  %s\n' \
-        "$NEMOCLAW_HERMES_AUXILIARY_TOKEN_LIMIT_PATCHER_SHA256" /opt/nemoclaw-hermes-config/patch-auxiliary-token-limit.py \
-    | sha256sum -c - \
-    || { echo "ERROR: patch-auxiliary-token-limit.py hash mismatch (update NEMOCLAW_HERMES_AUXILIARY_TOKEN_LIMIT_PATCHER_SHA256)" >&2; exit 1; }; \
-    /usr/bin/python3 -I /opt/nemoclaw-hermes-config/patch-auxiliary-token-limit.py \
+    && /usr/bin/python3 -I /opt/nemoclaw-hermes-config/patch-auxiliary-token-limit.py \
     && /opt/hermes/.venv/bin/python -m py_compile /opt/hermes/agent/auxiliary_client.py \
     && /opt/hermes/.venv/bin/python -I \
         /opt/nemoclaw-hermes-config/image-build-probes.py auxiliary-token-limit \
-    && rm /opt/nemoclaw-hermes-config/patch-auxiliary-token-limit.py
+    && rm /opt/nemoclaw-hermes-config/patch-gateway-runtime-metadata.py \
+        /opt/nemoclaw-hermes-config/patch-gateway-process-identity.py \
+        /opt/nemoclaw-hermes-config/patch-cron-execution-runtime.py \
+        /opt/nemoclaw-hermes-config/patch-cron-restore-drain.py \
+        /opt/nemoclaw-hermes-config/patch-auxiliary-token-limit.py
 
 # Hermes v0.20.6 computes `sessions list` preview from the first user message.
 # Its workspace-aware titled table then hides the preview behind an automatic

--- a/agents/hermes/image-build-probes.py
+++ b/agents/hermes/image-build-probes.py
@@ -195,6 +195,31 @@ def verify_gateway_process_identity() -> None:
     )
 
 
+def verify_auxiliary_token_limit() -> None:
+    """Keep explicit auxiliary limits on the managed inference route."""
+    from agent.auxiliary_client import _build_call_kwargs
+
+    common = {
+        "provider": "custom",
+        "model": "qwen3-vl:4b",
+        "messages": [{"role": "user", "content": "probe"}],
+        "max_tokens": 64,
+        "task": "title_generation",
+    }
+    managed = _build_call_kwargs(
+        **common,
+        base_url="https://inference.local/v1",
+    )
+    external = _build_call_kwargs(
+        **common,
+        base_url="https://example.test/v1",
+    )
+
+    assert managed.get("max_tokens") == 64, managed
+    assert "max_tokens" not in external, external
+    assert "max_completion_tokens" not in external, external
+
+
 def verify_neutral_platform_inertness() -> None:
     import socket
 
@@ -704,6 +729,7 @@ def verify_managed_runtime_capability() -> None:
 
 
 COMMANDS: dict[str, Callable[[], None]] = {
+    "auxiliary-token-limit": verify_auxiliary_token_limit,
     "compatibility-retirement": verify_compatibility_retirement,
     "cron-backup": verify_cron_backup,
     "cron-create": verify_cron_create,

--- a/agents/hermes/image-build-probes.py
+++ b/agents/hermes/image-build-probes.py
@@ -214,10 +214,15 @@ def verify_auxiliary_token_limit() -> None:
         **common,
         base_url="https://example.test/v1",
     )
+    external_moa = _build_call_kwargs(
+        **{**common, "task": "moa_reference"},
+        base_url="https://example.test/v1",
+    )
 
     assert managed.get("max_tokens") == 64, managed
     assert "max_tokens" not in external, external
     assert "max_completion_tokens" not in external, external
+    assert external_moa.get("max_tokens") == 64, external_moa
 
 
 def verify_neutral_platform_inertness() -> None:

--- a/agents/hermes/patch-auxiliary-token-limit.py
+++ b/agents/hermes/patch-auxiliary-token-limit.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Preserve explicit Hermes auxiliary output limits on managed inference.
+
+Hermes v0.20.6 drops ``max_tokens`` from auxiliary OpenAI-compatible
+requests unless the provider belongs to a small allowlist. This removes the
+64-token limit from session-title generation on NemoClaw's managed Ollama
+route. A thinking model can then occupy Ollama's only inference slot until it
+fills the context window, which blocks the user's first prompt.
+
+The source fix belongs in Hermes. This pinned image patch keeps the caller's
+explicit limit only for ``inference.local``. Other custom endpoints retain
+Hermes's compatibility behavior.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+UNPATCHED = """        if (
+            _is_anthropic_compat_endpoint(provider, _effective_base)
+            or _nous_on_messages
+            or _is_nvidia_nim
+            or _is_moa
+            or _is_gemini_native
+        ):"""
+
+PATCHED = """        if (
+            _is_anthropic_compat_endpoint(provider, _effective_base)
+            or _nous_on_messages
+            or _is_nvidia_nim
+            or _is_moa
+            or _is_gemini_native
+            or base_url_host_matches(_effective_base, "inference.local")
+        ):"""
+
+
+def patch_file(path: Path) -> None:
+    source = path.read_text(encoding="utf-8")
+    unpatched_count = source.count(UNPATCHED)
+    patched_count = source.count(PATCHED)
+
+    if unpatched_count == 0 and patched_count == 1:
+        return
+    if unpatched_count != 1 or patched_count != 0:
+        raise SystemExit(
+            "ERROR: Hermes auxiliary max_tokens condition changed; "
+            f"found {unpatched_count} unpatched and {patched_count} patched blocks"
+        )
+
+    path.write_text(source.replace(UNPATCHED, PATCHED), encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "path",
+        nargs="?",
+        default="/opt/hermes/agent/auxiliary_client.py",
+        help="Hermes auxiliary client module to patch",
+    )
+    args = parser.parse_args()
+    patch_file(Path(args.path))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/lib/actions/sandbox/connect-flow.test.ts
+++ b/src/lib/actions/sandbox/connect-flow.test.ts
@@ -1096,6 +1096,24 @@ describe("connectSandbox flow", () => {
       portableReceiptDisposition: { kind: "hermes", phase: "active" },
       portableRecoveryResult: { kind: "already-running" },
     });
+    const captureResolved = harness.captureResolvedOpenshellSpy.getMockImplementation()!;
+    const forwardRecovery = requireDist("../../src/lib/actions/sandbox/forward-recovery.js");
+    let forwardsRestored = false;
+    harness.captureResolvedOpenshellSpy.mockImplementation(((args: unknown, options: unknown) => {
+      const argv = Array.isArray(args) ? args.map(String) : [];
+      return argv[0] === "forward" && argv[1] === "list"
+        ? {
+            status: 0,
+            output: forwardsRestored
+              ? "SANDBOX BIND PORT PID STATUS\nalpha 127.0.0.1 18789 12345 running"
+              : "SANDBOX BIND PORT PID STATUS\n",
+          }
+        : captureResolved(args, options);
+    }) as never);
+    harness.forwardReachabilitySpy.mockImplementation(() => forwardsRestored);
+    harness.launchForwardServiceSpy.mockImplementation(() => {
+      forwardsRestored = true;
+    });
 
     await expect(harness.connectSandbox("alpha")).rejects.toThrow("process.exit(0)");
 
@@ -1107,11 +1125,11 @@ describe("connectSandbox flow", () => {
     expect(harness.readSandboxConfigSpy).not.toHaveBeenCalled();
     expect(harness.writeSandboxConfigSpy).not.toHaveBeenCalled();
     expect(harness.recoverHermesPortableOllamaInferenceSpy).not.toHaveBeenCalled();
-    expect(
-      harness.captureResolvedOpenshellSpy.mock.calls.some(([args]) =>
-        Array.isArray(args) ? args[0] === "forward" && args[1] === "list" : false,
-      ),
-    ).toBe(true);
+    expect(harness.launchForwardServiceSpy).toHaveBeenCalledOnce();
+    expect(forwardRecovery.areSandboxLaunchForwardsHealthy("alpha", "nemoclaw")).toBe(true);
+    expect(harness.launchForwardServiceSpy.mock.invocationCallOrder[0]!).toBeLessThan(
+      harness.startSandboxSessionSpy.mock.invocationCallOrder[0]!,
+    );
     expect(sandboxVersion.checkAgentVersion).not.toHaveBeenCalled();
     expect(brokerSpy).not.toHaveBeenCalled();
     expect(harness.startSandboxSessionSpy).toHaveBeenCalledWith({

--- a/src/lib/actions/sandbox/connect-flow.test.ts
+++ b/src/lib/actions/sandbox/connect-flow.test.ts
@@ -1107,6 +1107,11 @@ describe("connectSandbox flow", () => {
     expect(harness.readSandboxConfigSpy).not.toHaveBeenCalled();
     expect(harness.writeSandboxConfigSpy).not.toHaveBeenCalled();
     expect(harness.recoverHermesPortableOllamaInferenceSpy).not.toHaveBeenCalled();
+    expect(
+      harness.captureResolvedOpenshellSpy.mock.calls.some(([args]) =>
+        Array.isArray(args) ? args[0] === "forward" && args[1] === "list" : false,
+      ),
+    ).toBe(true);
     expect(sandboxVersion.checkAgentVersion).not.toHaveBeenCalled();
     expect(brokerSpy).not.toHaveBeenCalled();
     expect(harness.startSandboxSessionSpy).toHaveBeenCalledWith({

--- a/src/lib/actions/sandbox/connect.ts
+++ b/src/lib/actions/sandbox/connect.ts
@@ -2303,6 +2303,14 @@ export async function prepareInteractiveSession(sandboxName: string): Promise<{
         ? await verifyHermesPortableInferenceRouteOrExit(sandboxName, agent)
         : await ensureSandboxInferenceRouteOrExit(sandboxName, agent);
       requalify();
+      if (hermesPortable) {
+        const authority = requireHermesPortableActiveLifecycleAuthority(
+          sandboxName,
+          undefined,
+          portableAgentLifecycleAuthorityDeps(),
+        );
+        recoverHermesPortableForwardsForConnectProbeOrExit(sandboxName, authority);
+      }
       if (!hermesPortable && !(await settlePortablePairingOrExit(sandboxName))) {
         completeInteractiveSessionSetup(sandboxName, sb);
       }

--- a/src/lib/onboard/experimental/hermes-portable-build-context-files.ts
+++ b/src/lib/onboard/experimental/hermes-portable-build-context-files.ts
@@ -29,6 +29,7 @@ export const HERMES_PORTABLE_BUILD_CONTEXT_FILES = [
   { path: "agents/hermes/image-build-probes.py", mode: "100644" },
   { path: "agents/hermes/managed_policy.py", mode: "100644" },
   { path: "agents/hermes/mcp-config-transaction.py", mode: "100755" },
+  { path: "agents/hermes/patch-auxiliary-token-limit.py", mode: "100755" },
   { path: "agents/hermes/patch-cron-execution-runtime.py", mode: "100755" },
   { path: "agents/hermes/patch-cron-restore-drain.py", mode: "100755" },
   { path: "agents/hermes/patch-discord-recovery-permissions.py", mode: "100755" },

--- a/src/lib/onboard/experimental/hermes-portable-build-context.ts
+++ b/src/lib/onboard/experimental/hermes-portable-build-context.ts
@@ -48,6 +48,7 @@ const LOCAL_COPY_SOURCES = [
   "agents/hermes/managed_policy.py",
   "agents/hermes/managed_policy.py",
   "agents/hermes/mcp-config-transaction.py",
+  "agents/hermes/patch-auxiliary-token-limit.py",
   "agents/hermes/patch-cron-execution-runtime.py",
   "agents/hermes/patch-cron-restore-drain.py",
   "agents/hermes/patch-discord-recovery-permissions.py",

--- a/src/lib/onboard/managed-startup/profile.ts
+++ b/src/lib/onboard/managed-startup/profile.ts
@@ -849,6 +849,7 @@ export const MANAGED_STARTUP_PROFILE_EXCLUDED_DOCKER_INPUTS = {
     { input: "NEMOCLAW_HERMES_CRON_RESTORE_CONTROLLER_SHA256", reason: "integrity-pin" },
     { input: "NEMOCLAW_HERMES_CRON_RUNTIME_PATCHER_SHA256", reason: "integrity-pin" },
     { input: "NEMOCLAW_HERMES_IMAGE_BUILD_PROBES_SHA256", reason: "integrity-pin" },
+    { input: "NEMOCLAW_HERMES_AUXILIARY_TOKEN_LIMIT_PATCHER_SHA256", reason: "integrity-pin" },
     { input: "NEMOCLAW_HERMES_CRON_EXECUTIONS_SOURCE_SHA256", reason: "integrity-pin" },
     { input: "NEMOCLAW_HERMES_BACKUP_SOURCE_SHA256", reason: "integrity-pin" },
     { input: "NEMOCLAW_HERMES_SQLITE_TEMP_STORE_PATCHER_SHA256", reason: "integrity-pin" },

--- a/test/agents/hermes/hermes-auxiliary-token-limit.test.ts
+++ b/test/agents/hermes/hermes-auxiliary-token-limit.test.ts
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const root = path.join(import.meta.dirname, "../../..");
+const patcher = path.join(root, "agents", "hermes", "patch-auxiliary-token-limit.py");
+const fixtures: string[] = [];
+
+const condition = `        if (
+            _is_anthropic_compat_endpoint(provider, _effective_base)
+            or _nous_on_messages
+            or _is_nvidia_nim
+            or _is_moa
+            or _is_gemini_native
+        ):`;
+
+function moduleSource(target = condition): string {
+  return `from urllib.parse import urlparse
+
+def base_url_host_matches(value, expected):
+    return (urlparse(value).hostname or "").lower() == expected
+
+def _is_anthropic_compat_endpoint(_provider, _base_url):
+    return False
+
+def auxiliary_max_tokens_param(value, *, model):
+    return {"max_tokens": value, "model_seen": model}
+
+def build(provider, model, base_url, max_tokens, task="title_generation"):
+    kwargs = {}
+    _effective_base = base_url
+    _provider_norm = provider
+    _is_nvidia_nim = False
+    _is_moa = task == "moa_reference"
+    _is_gemini_native = False
+    _nous_on_messages = False
+    if max_tokens is not None:
+${target}
+            kwargs.update(auxiliary_max_tokens_param(max_tokens, model=model))
+    return kwargs
+`;
+}
+
+function fixtureFile(source = moduleSource()): string {
+  const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-hermes-aux-limit-"));
+  fixtures.push(fixture);
+  const file = path.join(fixture, "auxiliary_client.py");
+  fs.writeFileSync(file, source);
+  return file;
+}
+
+function runPatcher(file: string) {
+  return spawnSync("python3", ["-I", patcher, file], {
+    encoding: "utf8",
+    timeout: 5000,
+  });
+}
+
+function evaluate(file: string, baseUrl: string) {
+  const source = `
+import importlib.util
+import json
+import sys
+
+spec = importlib.util.spec_from_file_location("fixture", sys.argv[1])
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+print(json.dumps(module.build("custom", "qwen3-vl:4b", sys.argv[2], 64)))
+`;
+  return spawnSync("python3", ["-I", "-c", source, file, baseUrl], {
+    encoding: "utf8",
+    timeout: 5000,
+  });
+}
+
+afterEach(() => {
+  for (const fixture of fixtures.splice(0)) {
+    fs.rmSync(fixture, { recursive: true, force: true });
+  }
+});
+
+describe("Hermes managed auxiliary output limit", () => {
+  it("preserves the title limit on inference.local", () => {
+    const file = fixtureFile();
+
+    const patchResult = runPatcher(file);
+    const request = evaluate(file, "https://inference.local/v1");
+
+    expect(patchResult.status, patchResult.stderr).toBe(0);
+    expect(request.status, request.stderr).toBe(0);
+    expect(JSON.parse(request.stdout)).toEqual({ max_tokens: 64, model_seen: "qwen3-vl:4b" });
+  });
+
+  it("keeps the upstream omission for another custom endpoint", () => {
+    const file = fixtureFile();
+    expect(runPatcher(file).status).toBe(0);
+
+    const request = evaluate(file, "https://example.test/v1");
+
+    expect(request.status, request.stderr).toBe(0);
+    expect(JSON.parse(request.stdout)).toEqual({});
+  });
+
+  it("accepts one already-patched module without rewriting it", () => {
+    const file = fixtureFile();
+    expect(runPatcher(file).status).toBe(0);
+    const patched = fs.readFileSync(file, "utf8");
+
+    const result = runPatcher(file);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(fs.readFileSync(file, "utf8")).toBe(patched);
+  });
+
+  it.each([
+    ["missing", moduleSource(condition.replace("or _is_moa\n", ""))],
+    ["duplicate", `${moduleSource()}\n${moduleSource()}`],
+  ])("rejects a %s upstream condition", (_name, source) => {
+    const file = fixtureFile(source);
+
+    const result = runPatcher(file);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Hermes auxiliary max_tokens condition changed");
+    expect(fs.readFileSync(file, "utf8")).toBe(source);
+  });
+});

--- a/test/agents/hermes/hermes-auxiliary-token-limit.test.ts
+++ b/test/agents/hermes/hermes-auxiliary-token-limit.test.ts
@@ -62,7 +62,7 @@ function runPatcher(file: string) {
   });
 }
 
-function evaluate(file: string, baseUrl: string) {
+function evaluate(file: string, baseUrl: string, task = "title_generation") {
   const source = `
 import importlib.util
 import json
@@ -71,9 +71,9 @@ import sys
 spec = importlib.util.spec_from_file_location("fixture", sys.argv[1])
 module = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(module)
-print(json.dumps(module.build("custom", "qwen3-vl:4b", sys.argv[2], 64)))
+print(json.dumps(module.build("custom", "qwen3-vl:4b", sys.argv[2], 64, task=sys.argv[3])))
 `;
-  return spawnSync("python3", ["-I", "-c", source, file, baseUrl], {
+  return spawnSync("python3", ["-I", "-c", source, file, baseUrl, task], {
     encoding: "utf8",
     timeout: 5000,
   });
@@ -105,6 +105,16 @@ describe("Hermes managed auxiliary output limit", () => {
 
     expect(request.status, request.stderr).toBe(0);
     expect(JSON.parse(request.stdout)).toEqual({});
+  });
+
+  it("preserves the MoA reference limit on another custom endpoint", () => {
+    const file = fixtureFile();
+    expect(runPatcher(file).status).toBe(0);
+
+    const request = evaluate(file, "https://example.test/v1", "moa_reference");
+
+    expect(request.status, request.stderr).toBe(0);
+    expect(JSON.parse(request.stdout)).toEqual({ max_tokens: 64, model_seen: "qwen3-vl:4b" });
   });
 
   it("accepts one already-patched module without rewriting it", () => {

--- a/test/agents/hermes/hermes-image-build-probes.test.ts
+++ b/test/agents/hermes/hermes-image-build-probes.test.ts
@@ -17,6 +17,7 @@ const a2aNeutralPatch = fs.readFileSync(path.join(root, "agents", "hermes", "a2a
 const probeSource = fs.readFileSync(probes, "utf8");
 const imageProbePath = "/opt/nemoclaw-hermes-config/image-build-probes.py";
 const commands = [
+  "auxiliary-token-limit",
   "cron-backup",
   "cron-create",
   "cron-reopen",

--- a/test/support/connect-flow-test-harness.ts
+++ b/test/support/connect-flow-test-harness.ts
@@ -45,6 +45,7 @@ export type ConnectHarness = {
   connectSandbox: ConnectSandbox;
   ensureOllamaAuthProxySpy: MockInstance;
   findReachableOllamaHostSpy: MockInstance;
+  forwardReachabilitySpy: MockInstance;
   forwardServiceOwnerSpy: MockInstance;
   launchForwardServiceSpy: MockInstance;
   ensureLiveSandboxSpy: MockInstance;
@@ -552,7 +553,9 @@ export function createConnectHarness(options: ConnectHarnessOptions = {}): Conne
   const checkAndRecoverSpy = vi
     .spyOn(processRecovery, "checkAndRecoverSandboxProcesses")
     .mockReturnValue(options.processCheck ?? { checked: true, wasRunning: true, recovered: false });
-  vi.spyOn(forwardHealth, "isLocalForwardReachable").mockReturnValue(true);
+  const forwardReachabilitySpy = vi
+    .spyOn(forwardHealth, "isLocalForwardReachable")
+    .mockReturnValue(true);
   const forwardServiceOwnerSpy = vi
     .spyOn(forwardService, "isForwardServiceListenerOwner")
     .mockReturnValue(false);
@@ -686,6 +689,7 @@ export function createConnectHarness(options: ConnectHarnessOptions = {}): Conne
     connectSandbox: requireDist(connectModulePath).connectSandbox,
     ensureOllamaAuthProxySpy,
     findReachableOllamaHostSpy,
+    forwardReachabilitySpy,
     forwardServiceOwnerSpy,
     launchForwardServiceSpy,
     ensureLiveSandboxSpy,


### PR DESCRIPTION
## Outcome

Hermes Portable restores its receipt-scoped forwards before opening an interactive session, and managed auxiliary requests retain their explicit output-token limits instead of occupying the inference slot until a large default budget is exhausted.

## Reason

Portable stop/start/recreate validation exposed two remaining failures after the lifecycle-lock repairs merged:

- interactive launch could continue before the Hermes forwards required by the TUI were restored;
- Hermes v0.20.6 removes `max_tokens` from auxiliary requests to custom endpoints, which also removed NemoClaw's small session-title limit on `inference.local` and made generation appear to hang.

PR #11427 independently delivered the other two branch fixes discovered during the same validation: exact Hermes dashboard/API forward reuse and skipping OpenClaw state initialization for Hermes. This PR intentionally excludes those superseded local implementations.

## Changes

- Requalify the active Hermes Portable lifecycle authority and restore receipt-scoped forwards before interactive session startup.
- Patch Hermes' auxiliary request construction at image build time so explicit limits are preserved only for NemoClaw managed `inference.local`.
- Integrity-pin the patcher and updated image-build probes.
- Prove that managed requests retain the 64-token title-generation limit while unrelated custom endpoints keep upstream Hermes behavior.

## Related issues

Closes #11567.
Closes #11568.
Parent: #11573.

## Verification

- `npx vitest run --project cli src/lib/actions/sandbox/connect-flow.test.ts` — 57 tests passed.
- `npx vitest run test/agents/hermes/hermes-auxiliary-token-limit.test.ts test/agents/hermes/hermes-image-build-probes.test.ts` — 65 tests passed.
- `npm run build:cli` — passed.
- `npm --prefix nemoclaw run build` — passed after installing the package's isolated dependencies.
- `NODE_OPTIONS=--max-old-space-size=8192 npm run typecheck:cli` — passed.
- `npm run test:changed` — repository growth guardrails passed; no uncommitted changed-test selection remained after the commits were created.
- Pre-commit and pre-push checks passed, including repository checks, secret scanning, codebase growth guardrails, commitlint, and CLI type-checking.
- `git diff --check origin/main...HEAD` — passed.
- Both commits are signed and reported Verified by GitHub.

## Local environment note

The build-context authority suite rejects this seat checkout because its source directories are group-writable. That is an expected fail-closed environmental result, not a product assertion failure. GitHub CI must provide the isolated broad result. `hadolint` is not installed on this seat and remains a CI requirement.

No secrets, API keys, or credentials are included.

---

Signed-off-by: Prekshi Vyas <34834085+prekshivyas@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hermes auxiliary inference requests now preserve token limits for managed inference routes and external MoA reference requests, while omitting them for external title-generation requests.
  * Interactive Hermes Portable setup now verifies lifecycle authority and restores connection forwarding before completing.

* **Quality Improvements**
  * Added build-time validation and automated coverage for token-limit handling, patch safety, and connection forwarding.
  * Verified packaged Hermes images contain the expected changes and exclude temporary patching tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
