### PR TITLE
fix(onboard): accept managed vLLM endpoint for N1x preview

### DIFF
--- a/src/lib/domain/sandbox/n1x-managed-vllm-rebuild.test.ts
+++ b/src/lib/domain/sandbox/n1x-managed-vllm-rebuild.test.ts
@@ -21,7 +21,7 @@ describe("Deferred N1x managed-vLLM acceptance route", () => {
   const accepted = {
     provider: "vllm-local",
     model: "nvidia/Qwen3.6-35B-A3B-NVFP4",
-    endpointUrl: null,
+    endpointUrl: "http://host.openshell.internal:8000/v1",
     endpointSource: null,
     nimContainer: null,
     openshellDriver: "docker",
@@ -29,6 +29,8 @@ describe("Deferred N1x managed-vLLM acceptance route", () => {
 
   it.each([
     ["the exact route", accepted, true],
+    ["a derived legacy endpoint", { ...accepted, endpointUrl: null }, true],
+    ["another provider", { ...accepted, provider: "compatible-endpoint" }, false],
     ["another model", { ...accepted, model: "other" }, false],
     ["a recorded endpoint", { ...accepted, endpointUrl: "http://localhost:8000/v1" }, false],
     ["another endpoint source", { ...accepted, endpointSource: "inference-set" }, false],
@@ -36,6 +38,35 @@ describe("Deferred N1x managed-vLLM acceptance route", () => {
     ["another driver", { ...accepted, openshellDriver: "kubernetes" }, false],
   ])("classifies %s", (_case, route, expected) => {
     expect(isDeferredN1xManagedVllmAcceptanceRoute(route)).toBe(expected);
+  });
+
+  it.each([1024, 8000, 18000, 65535])(
+    "accepts the canonical endpoint on port %s (#11510)",
+    (port) => {
+      expect(
+        isDeferredN1xManagedVllmAcceptanceRoute({
+          ...accepted,
+          endpointUrl: `http://host.openshell.internal:${port}/v1`,
+        }),
+      ).toBe(true);
+    },
+  );
+
+  it.each([
+    undefined,
+    "",
+    "http://host.openshell.internal:1023/v1",
+    "http://host.openshell.internal:65536/v1",
+    "http://host.openshell.internal:08000/v1",
+    "http://host.openshell.internal.example:8000/v1",
+    "http://user:password@host.openshell.internal:8000/v1",
+    "https://host.openshell.internal:8000/v1",
+    "http://host.openshell.internal:8000/v1/",
+    "http://host.openshell.internal:8000/v1?target=other",
+    "http://host.openshell.internal:8000/v1#other",
+    "http://host.openshell.internal:8000/v1\n",
+  ])("rejects noncanonical endpoint %s (#11510)", (endpointUrl) => {
+    expect(isDeferredN1xManagedVllmAcceptanceRoute({ ...accepted, endpointUrl })).toBe(false);
   });
 });
 
@@ -84,15 +115,19 @@ describe("recorded N1x managed-vLLM rebuild eligibility", () => {
     expect(eligible(sandboxEntry)).toBe(true);
   });
 
-  it("accepts normalized N1x Express intent with a derived endpoint (#10959)", () => {
-    expect(
-      eligible({
-        ...n1xExpressEntry,
-        endpointSource: null,
-        deferredN1xManagedVllmAccepted: true,
-      }),
-    ).toBe(true);
-  });
+  it.each([null, "http://host.openshell.internal:8000/v1"])(
+    "accepts recorded N1x preview intent with endpoint %s (#11510)",
+    (endpointUrl) => {
+      expect(
+        eligible({
+          ...n1xExpressEntry,
+          endpointUrl,
+          endpointSource: null,
+          deferredN1xManagedVllmAccepted: true,
+        }),
+      ).toBe(true);
+    },
+  );
 
   it("accepts an explicit preview retry for a normalized legacy record (#10959)", () => {
     expect(
@@ -175,12 +210,11 @@ describe("recorded N1x managed-vLLM rebuild eligibility", () => {
       rebuildSelection: n1xExpressSelection,
     },
     {
-      caseName: "normalized source with a recorded endpoint",
+      caseName: "recorded endpoint without preview provenance",
       sandboxEntry: {
         ...n1xExpressEntry,
         endpointUrl: "http://host.openshell.internal:8000/v1",
         endpointSource: null,
-        deferredN1xManagedVllmAccepted: true,
       },
       rebuildSelection: n1xExpressSelection,
     },

--- a/src/lib/domain/sandbox/n1x-managed-vllm-rebuild.ts
+++ b/src/lib/domain/sandbox/n1x-managed-vllm-rebuild.ts
@@ -45,9 +45,19 @@ export interface DeferredN1xManagedVllmAcceptanceRoute {
 export function isDeferredN1xManagedVllmAcceptanceRoute(
   route: DeferredN1xManagedVllmAcceptanceRoute,
 ): boolean {
+  // Persisted acceptance must remain readable without the original shell's vLLM port setting.
+  const endpointMatch =
+    typeof route.endpointUrl === "string"
+      ? /^http:\/\/host\.openshell\.internal:([1-9][0-9]{3,4})\/v1$/u.exec(route.endpointUrl)
+      : null;
+  const canonicalEndpoint =
+    endpointMatch !== null &&
+    endpointMatch[0] === route.endpointUrl &&
+    Number(endpointMatch[1]) >= 1024 &&
+    Number(endpointMatch[1]) <= 65535;
   return (
     isN1xManagedVllmProviderModel(route.provider, route.model) &&
-    route.endpointUrl === null &&
+    (route.endpointUrl === null || canonicalEndpoint) &&
     route.endpointSource === null &&
     route.nimContainer == null &&
     route.openshellDriver === "docker"
@@ -94,9 +104,8 @@ export function isRecordedN1xManagedVllmRebuildEligible(
   const recordedSourceIsEligible =
     sandboxEntry.endpointSource === "onboard" ||
     (sandboxEntry.endpointSource === null &&
-      sandboxEntry.endpointUrl === null &&
       (sandboxEntry.deferredN1xManagedVllmAccepted === true ||
-        options.explicitPreviewIntent === true));
+        (sandboxEntry.endpointUrl === null && options.explicitPreviewIntent === true)));
   if (
     !isN1xManagedVllmProviderModel(sandboxEntry.provider, sandboxEntry.model) ||
     !recordedEndpointUsesCanonicalLocalRoute ||

--- a/src/lib/onboard/created-sandbox-n1x-finalization.test.ts
+++ b/src/lib/onboard/created-sandbox-n1x-finalization.test.ts
@@ -5,8 +5,10 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
-import { afterEach, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
 
+import { requireValue } from "../core/require-value";
+import { isRecordedN1xManagedVllmRebuildEligible } from "../domain/sandbox/n1x-managed-vllm-rebuild";
 import { createSession, type Session } from "../state/onboard-session";
 import type { SandboxEntry } from "../state/registry";
 import {
@@ -21,6 +23,9 @@ import {
   type InitialOnboardFlowContext,
 } from "./machine/initial-flow-phases";
 import type { SandboxGpuCreateFlowResult } from "./sandbox-gpu-create-flow";
+import { parseHostLocalInferenceReceipt } from "./runtime-provider/host-local-inference";
+import type { SetupNimSelectionState } from "./setup-nim-flow";
+import { createSetupNimVllmHandler } from "./setup-nim-vllm";
 
 const sandboxName = "n1x-preview";
 const model = "nvidia/Qwen3.6-35B-A3B-NVFP4";
@@ -32,18 +37,54 @@ afterEach(async () => {
   vi.resetModules();
   await Promise.all(homes.splice(0).map((home) => fs.rm(home, { recursive: true, force: true })));
 });
-const inferenceSelection = {
+const inferenceSelection: SetupNimSelectionState & {
+  model: string;
+  endpointSource: null;
+  compatibleEndpointReasoning: null;
+  compatibleEndpointReasoningEffort: null;
+} = {
   provider,
   model,
   endpointUrl: null,
   endpointSource: null,
   credentialEnv: null,
   hermesAuthMethod: null,
+  hermesToolGateways: [],
   preferredInferenceApi: "openai-completions",
   compatibleEndpointReasoning: null,
   compatibleEndpointReasoningEffort: null,
   nimContainer: null,
-} as const;
+  allowToolsIncompatible: false,
+};
+
+beforeEach(async () => {
+  inferenceSelection.endpointUrl = null;
+  const handler = createSetupNimVllmHandler({
+    VLLM_PORT: 8000,
+    getLocalProviderBaseUrl: () => "http://host.openshell.internal:8000/v1",
+    getLocalProviderValidationBaseUrl: () => "http://127.0.0.1:8000/v1",
+    getManagedVllmProviderBinding: () => ({
+      baseUrl: "http://host.openshell.internal:8000/v1",
+      validationBaseUrl: "http://127.0.0.1:8000/v1",
+      apiKey: "test-key",
+    }),
+    runCapture: vi.fn(() => {
+      throw new Error("Unexpected unauthenticated vLLM query");
+    }),
+    queryVllmModels: () => JSON.stringify({ data: [{ id: model }] }),
+    isSafeModelId: () => true,
+    requireValue,
+    validateOpenAiLikeSelection: async () => ({ ok: true, api: "openai-completions" }),
+    applyVllmRuntimeContextWindow: vi.fn(),
+    persistConfiguredManagedVllmRuntimeReceipt: async () => ({ ok: true, persisted: true }),
+    exitProcess: (code) => {
+      throw new Error(`Unexpected vLLM setup exit ${code}`);
+    },
+  });
+  expect(await handler(inferenceSelection, { managedInstall: true, sparkHost: false })).toBe(
+    "selected",
+  );
+});
 
 type Gpu = { type: "nvidia"; platform: "n1x" | "spark" };
 type GpuConfig = {
@@ -340,6 +381,15 @@ it.each([
       ...(allow === undefined ? {} : { allowDeferredN1xManagedVllm: allow }),
     });
     const registration = await completeRegistration(flow.createIntent);
+
+    expect(registration.endpointUrl).toBe("http://host.openshell.internal:8000/v1");
+    expect(
+      isRecordedN1xManagedVllmRebuildEligible(
+        registration,
+        { provider, model, pinEndpoint: true, endpointUrl: null },
+        parseHostLocalInferenceReceipt,
+      ),
+    ).toBe(expected);
 
     expect([
       flow.accepted,

--- a/src/lib/state/registry-normalization.test.ts
+++ b/src/lib/state/registry-normalization.test.ts
@@ -245,43 +245,53 @@ describe("sandbox registry normalization", () => {
     );
   });
 
-  it("round-trips only valid Deferred N1x preview acceptance (#10959)", async () => {
-    const registry = await loadRegistryWith({ legacy: { name: "legacy" } });
-    registry.registerSandbox({
-      name: "preview",
-      provider: "vllm-local",
-      model: "nvidia/Qwen3.6-35B-A3B-NVFP4",
-      endpointUrl: null,
-      endpointSource: null,
-      openshellDriver: "docker",
-      deferredN1xManagedVllmAccepted: true,
-    });
-    vi.resetModules();
-    const reloadedRegistry = await import("./registry");
-
-    expect(reloadedRegistry.getSandbox("preview")?.deferredN1xManagedVllmAccepted).toBe(true);
-    const malformed = await loadRegistryWith({
-      malformed: {
-        name: "malformed",
-        deferredN1xManagedVllmAccepted: "true",
-      },
-    });
-    expect(() => malformed.getSandbox("malformed")).toThrow("invalid N1x preview acceptance");
-    const mismatchedRoute = await loadRegistryWith({
-      mismatched: {
-        name: "mismatched",
+  it.each([
+    null,
+    "http://host.openshell.internal:8000/v1",
+    "http://host.openshell.internal:18000/v1",
+  ])(
+    "round-trips valid Deferred N1x preview acceptance with endpoint %s (#11510)",
+    async (endpointUrl) => {
+      const registry = await loadRegistryWith({ legacy: { name: "legacy" } });
+      registry.registerSandbox({
+        name: "preview",
         provider: "vllm-local",
         model: "nvidia/Qwen3.6-35B-A3B-NVFP4",
-        endpointUrl: null,
-        endpointSource: "inference-set",
+        endpointUrl,
+        endpointSource: null,
         openshellDriver: "docker",
         deferredN1xManagedVllmAccepted: true,
-      },
-    });
-    expect(() => mismatchedRoute.getSandbox("mismatched")).toThrow(
-      "invalid N1x preview acceptance",
-    );
-  });
+      });
+      vi.resetModules();
+      const reloadedRegistry = await import("./registry");
+
+      expect(reloadedRegistry.getSandbox("preview")).toMatchObject({
+        endpointUrl,
+        deferredN1xManagedVllmAccepted: true,
+      });
+      const malformed = await loadRegistryWith({
+        malformed: {
+          name: "malformed",
+          deferredN1xManagedVllmAccepted: "true",
+        },
+      });
+      expect(() => malformed.getSandbox("malformed")).toThrow("invalid N1x preview acceptance");
+      const mismatchedRoute = await loadRegistryWith({
+        mismatched: {
+          name: "mismatched",
+          provider: "vllm-local",
+          model: "nvidia/Qwen3.6-35B-A3B-NVFP4",
+          endpointUrl,
+          endpointSource: "inference-set",
+          openshellDriver: "docker",
+          deferredN1xManagedVllmAccepted: true,
+        },
+      });
+      expect(() => mismatchedRoute.getSandbox("mismatched")).toThrow(
+        "invalid N1x preview acceptance",
+      );
+    },
+  );
 
   it("clears Deferred N1x acceptance when route authority changes (#10959)", async () => {
     const registry = await loadRegistryWith({});


### PR DESCRIPTION
## Outcome

Deferred N1x onboarding can register its sandbox after managed vLLM returns `http://host.openshell.internal:8000/v1`, including the default name `my-assistant`. Previously, successful sandbox creation and CUDA proof ended with `Sandbox Deferred N1x preview acceptance failed closed validation.`

## Reason

The vLLM selection handler returns a URL, but preview acceptance required a null endpoint. The existing finalization tests supplied null and missed the mismatch.

### Related issues

Fixes #11510.

## Changes

- Accept the canonical managed vLLM URL or the legacy null endpoint. Keep the exact hostname, HTTP scheme, `/v1` path, unprivileged port, provider/model, source, Docker driver, and NIM checks.
- Preserve preview acceptance through registry reload and rebuild eligibility. Rebuild still checks the configured port and any recorded receipt.
- Exercise the real vLLM selection handler through default-name finalization, persistence, reload, and rebuild. Cover malformed URLs, missing provenance, and custom ports.

The final diff is four files: 140 additions and 34 deletions. Production changes are confined to one existing file, with 12 additions and 3 deletions. Automatic retained-record recovery is outside this reduced scope: an earlier retained failure still needs explicit cleanup through the existing destroy path, with its gateway restored first if unavailable.

## Verification

- Focused CLI regressions: 240 tests passed across 10 files, covering route acceptance, vLLM selection, default-name finalization, registry persistence, registration, onboarding entry, existing retained destroy, and gateway handling.
- Regression check against the original production guard: fresh, resumed, and legacy N1x finalization all reproduced the reported validation error. All pass with this fix.
- `node_modules/.bin/vitest run --project package-contract --coverage=false test/package-contract/onboard/invalid-nvidia-key.test.ts`: all 3 tests passed.
- `npm run build:cli`, changed-file Oxfmt checks, and `git diff --check` passed. Normal commit and publication hooks passed, including the secret scan and CLI TypeScript checks. GitHub verified every published commit.
- Operator-provided N1x retest on 2026-09-14 passed for the reduced candidate. The installer reported `v0.0.123-108-g54e4e328c`, matching PR commit `54e4e328cde3b571ee6f80154997f022cbca3866`. `./install.sh --fresh` completed for default sandbox `my-assistant` in **1193 seconds (19m 53s)**. The operator accepted the license and Deferred N1x preview prompts. An existing registry entry and cached model were present.
- Test environment: native Linux N1x/ARM64, 20 vCPU, 61.6 GiB container-runtime memory, Node.js 22.23.2, npm 10.9.8, Docker 29.2.1, OpenShell 0.0.116, and OpenClaw 2026.7.1. Managed vLLM served `nvidia/Qwen3.6-35B-A3B-NVFP4` on port 8000 using pinned image `nvcr.io/nvidia/vllm@sha256:9204569b17ee4c0eff75194b8e6e458479c8aee18953b5ab9cf359fcdac659e2`.
- The operator's terminal log shows successful sandbox creation after all three GPU proofs, followed by OpenClaw startup, policy application, and deployment verification. The earlier Deferred N1x preview acceptance error did not recur. The agent reviewed this supplied log; it did not execute or independently observe the VM test.

```text
✓ GPU proof passed: nvidia-smi when available
✓ GPU proof passed: /proc/<pid>/task/<tid>/comm write
✓ GPU proof passed: cuInit(0) via libcuda.so.1
✓ Sandbox 'my-assistant' created
✓ OpenClaw gateway launched inside sandbox
✓ Deployment verified — gateway, dashboard, and inference route are healthy.
[INFO]  === Installation complete ===
```

- The run used the standalone gateway after the managed-service 60-second health deadline. The unavailable source-version managed catalog fell back to a local base-image build and the trusted Dockerfile recipe; both completed. These fallbacks were exercised successfully, not counted as managed-service or published-image success.
- The [earlier N1x test at `20510269b`](https://github.com/NVIDIA/NemoClaw/pull/11580#issuecomment-5658307398) remains historical evidence; the retest above covers the reduced candidate.
- Canonical main `bf6e7bb624dcd9b37a62543a0b0bd912d017d5a7` is merged. Validation tooling and resolved executables were compared with that canonical base. No secrets, API keys, or credentials are included.

## Review notes

Self-review of `NVIDIA/NemoClaw` candidate 54e4e328cde3b571ee6f80154997f022cbca3866 covered the complete four-file diff. The sensitive path is `src/lib/onboard/created-sandbox-n1x-finalization.test.ts`. The review checked the actual endpoint producer against registration, reload, and rebuild consumers, plus malformed endpoints and default-name behavior. Existing cleanup and identity safeguards match main.

[Advisor run 34805479300](https://github.com/NVIDIA/NemoClaw/actions/runs/34805479300) completed all nine specialists for this candidate. Findings were grouped and checked:

- The claimed rebuild-test contradiction is a false positive: the case passes `accepted=false`. Its owning suite passed all 15 tests.
- Three custom-port recovery findings request automatic restoration of the original port. This PR preserves the existing requirement that the configured runtime port match the record and receipt. The corresponding test also passes on canonical main and explicitly rejects a mismatch.
- The eligibility wording at `docs/inference/set-up-vllm.mdx:521` needs a docs-only correction. It is deferred to `Docs / Author Post-Merge Catch-Up` under the repository's documentation policy: allow durable preview acceptance with a canonical endpoint; keep one-time explicit recovery limited to legacy null endpoints.
- A native N1x custom-port install-and-rebuild journey remains an E2E evidence gap. No supported selector was identified. The existing operator run covers default-port installation only.

CodeRabbit completed with no new actionable comments. Its docstring-coverage warning is advisory and refers to the earlier broader diff. No independent approval or CI waiver is claimed.

N1x remains a Deferred preview. A completed chat response was not included in the hardware evidence.

---
Signed-off-by: San Dang <sdang@nvidia.com>
