### PR TITLE
perf(test): overlap sandbox recreation cases

### DIFF
--- a/test/onboarding/onboard-sandbox-recreation.test.ts
+++ b/test/onboarding/onboard-sandbox-recreation.test.ts
@@ -2,29 +2,34 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { beforeEach, describe, it, vi } from "vitest";
+import { describe, it } from "vitest";
+import { runOnboardProcessAsync } from "../helpers/onboard-child-process-harness";
 import { writeOkOpenshell } from "../helpers/onboard-openshell-fixture";
 import { type CommandEntry, onboardScriptMocksPath } from "../helpers/onboard-split-context";
 
-beforeEach(() => {
-  vi.stubEnv("NEMOCLAW_TEST_MANAGED_IMAGE_CATALOG", "1");
-  vi.stubEnv("NEMOCLAW_TEST_FORWARD_SERVICE_FIXTURE", "1");
-  vi.stubEnv("NEMOCLAW_SANDBOX_PREBUILD", "1");
-});
+const ONBOARD_TEST_ENV = {
+  NEMOCLAW_SANDBOX_PREBUILD: "1",
+  NEMOCLAW_TEST_FORWARD_SERVICE_FIXTURE: "1",
+  NEMOCLAW_TEST_MANAGED_IMAGE_CATALOG: "1",
+} as const;
 
-describe("onboard helpers", () => {
+function isolatedDashboardPort(tmpDir: string): string {
+  const offset = createHash("sha256").update(tmpDir).digest().readUInt16BE(0) % 10_000;
+  return String(20_000 + offset);
+}
+
+describe.concurrent("onboard helpers", () => {
   it(
     "non-interactive exits with error when existing sandbox is not ready",
     {
       timeout: 60_000,
     },
-    async () => {
+    async (context) => {
       const repoRoot = path.join(import.meta.dirname, "../..");
       const tmpDir = fs.mkdtempSync(
         path.join(os.tmpdir(), "nemoclaw-onboard-noninteractive-notready-"),
@@ -90,15 +95,18 @@ const { createSandbox } = require(${onboardPath});
 
       const env: Record<string, string | undefined> = {
         ...process.env,
+        ...ONBOARD_TEST_ENV,
+        NEMOCLAW_DASHBOARD_PORT: isolatedDashboardPort(tmpDir),
         HOME: tmpDir,
         PATH: `${fakeBin}:${process.env.PATH || ""}`,
         NEMOCLAW_NON_INTERACTIVE: "1",
       };
       delete env["NEMOCLAW_RECREATE_SANDBOX"];
-      const result = spawnSync(process.execPath, [scriptPath], {
+      const result = await runOnboardProcessAsync([scriptPath], {
         cwd: repoRoot,
-        encoding: "utf-8",
         env,
+        timeoutMs: 45_000,
+        context,
       });
 
       assert.notEqual(result.status, 0, "expected non-zero exit for not-ready sandbox");
@@ -114,12 +122,12 @@ const { createSandbox } = require(${onboardPath});
     },
   );
 
-  it.each(["balanced", "restricted"])(
+  it.for(["balanced", "restricted"])(
     "recreate-sandbox uses the requested %s tier without recording it",
     {
       timeout: 60_000,
     },
-    async (policyTier) => {
+    async (policyTier, context) => {
       const repoRoot = path.join(import.meta.dirname, "../..");
       const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-recreate-flag-"));
       const fakeBin = path.join(tmpDir, "bin");
@@ -227,16 +235,19 @@ const { createSandbox } = require(${onboardPath});
 `;
       fs.writeFileSync(scriptPath, script);
 
-      const result = spawnSync(process.execPath, [scriptPath], {
+      const result = await runOnboardProcessAsync([scriptPath], {
         cwd: repoRoot,
-        encoding: "utf-8",
         env: {
           ...process.env,
+          ...ONBOARD_TEST_ENV,
+          NEMOCLAW_DASHBOARD_PORT: isolatedDashboardPort(tmpDir),
           HOME: tmpDir,
           PATH: `${fakeBin}:${process.env.PATH || ""}`,
           NEMOCLAW_NON_INTERACTIVE: "1",
           NEMOCLAW_POLICY_TIER: policyTier,
         },
+        timeoutMs: 45_000,
+        context,
       });
 
       assert.equal(result.status, 0, result.stderr);
@@ -288,7 +299,7 @@ const { createSandbox } = require(${onboardPath});
     {
       timeout: 60_000,
     },
-    async () => {
+    async (context) => {
       const repoRoot = path.join(import.meta.dirname, "../..");
       const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-recreate-backup-"));
       const fakeBin = path.join(tmpDir, "bin");
@@ -413,15 +424,18 @@ const { createSandbox } = require(${onboardPath});
 `;
       fs.writeFileSync(scriptPath, script);
 
-      const result = spawnSync(process.execPath, [scriptPath], {
+      const result = await runOnboardProcessAsync([scriptPath], {
         cwd: repoRoot,
-        encoding: "utf-8",
         env: {
           ...process.env,
+          ...ONBOARD_TEST_ENV,
+          NEMOCLAW_DASHBOARD_PORT: isolatedDashboardPort(tmpDir),
           HOME: tmpDir,
           PATH: `${fakeBin}:${process.env.PATH || ""}`,
           NEMOCLAW_NON_INTERACTIVE: "1",
         },
+        timeoutMs: 45_000,
+        context,
       });
 
       assert.equal(result.status, 0, result.stderr);
@@ -471,7 +485,7 @@ const { createSandbox } = require(${onboardPath});
     {
       timeout: 60_000,
     },
-    async () => {
+    async (context) => {
       const repoRoot = path.join(import.meta.dirname, "../..");
       const tmpDir = fs.mkdtempSync(
         path.join(os.tmpdir(), "nemoclaw-onboard-recreate-skip-backup-"),
@@ -583,15 +597,18 @@ const { createSandbox } = require(${onboardPath});
 `;
       fs.writeFileSync(scriptPath, script);
 
-      const result = spawnSync(process.execPath, [scriptPath], {
+      const result = await runOnboardProcessAsync([scriptPath], {
         cwd: repoRoot,
-        encoding: "utf-8",
         env: {
           ...process.env,
+          ...ONBOARD_TEST_ENV,
+          NEMOCLAW_DASHBOARD_PORT: isolatedDashboardPort(tmpDir),
           HOME: tmpDir,
           PATH: `${fakeBin}:${process.env.PATH || ""}`,
           NEMOCLAW_NON_INTERACTIVE: "1",
         },
+        timeoutMs: 45_000,
+        context,
       });
 
       assert.equal(result.status, 0, result.stderr);
@@ -620,7 +637,7 @@ const { createSandbox } = require(${onboardPath});
     {
       timeout: 60_000,
     },
-    async () => {
+    async (context) => {
       const repoRoot = path.join(import.meta.dirname, "../..");
       const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-recreate-notready-"));
       const fakeBin = path.join(tmpDir, "bin");
@@ -751,15 +768,18 @@ const { createSandbox } = require(${onboardPath});
 `;
       fs.writeFileSync(scriptPath, script);
 
-      const result = spawnSync(process.execPath, [scriptPath], {
+      const result = await runOnboardProcessAsync([scriptPath], {
         cwd: repoRoot,
-        encoding: "utf-8",
         env: {
           ...process.env,
+          ...ONBOARD_TEST_ENV,
+          NEMOCLAW_DASHBOARD_PORT: isolatedDashboardPort(tmpDir),
           HOME: tmpDir,
           PATH: `${fakeBin}:${process.env.PATH || ""}`,
           NEMOCLAW_NON_INTERACTIVE: "1",
         },
+        timeoutMs: 45_000,
+        context,
       });
 
       assert.equal(result.status, 0, result.stderr);
@@ -795,7 +815,7 @@ const { createSandbox } = require(${onboardPath});
     {
       timeout: 60_000,
     },
-    async () => {
+    async (context) => {
       const repoRoot = path.join(import.meta.dirname, "../..");
       const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-interactive-reuse-"));
       const fakeBin = path.join(tmpDir, "bin");
@@ -901,15 +921,18 @@ const { createSandbox } = require(${onboardPath});
       // Run WITHOUT NEMOCLAW_NON_INTERACTIVE to exercise interactive path
       const env: Record<string, string | undefined> = {
         ...process.env,
+        ...ONBOARD_TEST_ENV,
+        NEMOCLAW_DASHBOARD_PORT: isolatedDashboardPort(tmpDir),
         HOME: tmpDir,
         PATH: `${fakeBin}:${process.env.PATH || ""}`,
       };
       delete env["NEMOCLAW_NON_INTERACTIVE"];
       delete env["NEMOCLAW_RECREATE_SANDBOX"];
-      const result = spawnSync(process.execPath, [scriptPath], {
+      const result = await runOnboardProcessAsync([scriptPath], {
         cwd: repoRoot,
-        encoding: "utf-8",
         env,
+        timeoutMs: 45_000,
+        context,
       });
 
       assert.equal(result.status, 0, result.stderr);
@@ -943,7 +966,7 @@ const { createSandbox } = require(${onboardPath});
     {
       timeout: 60_000,
     },
-    async () => {
+    async (context) => {
       const repoRoot = path.join(import.meta.dirname, "../..");
       const tmpDir = fs.mkdtempSync(
         path.join(os.tmpdir(), "nemoclaw-onboard-interactive-decline-"),
@@ -1072,16 +1095,19 @@ const { createSandbox } = require(${onboardPath});
       // Run WITHOUT NEMOCLAW_NON_INTERACTIVE to exercise interactive path
       const env: Record<string, string | undefined> = {
         ...process.env,
+        ...ONBOARD_TEST_ENV,
+        NEMOCLAW_DASHBOARD_PORT: isolatedDashboardPort(tmpDir),
         HOME: tmpDir,
         PATH: `${fakeBin}:${process.env.PATH || ""}`,
         NEMOCLAW_RECREATE_WITHOUT_BACKUP: "1",
       };
       delete env["NEMOCLAW_NON_INTERACTIVE"];
       delete env["NEMOCLAW_RECREATE_SANDBOX"];
-      const result = spawnSync(process.execPath, [scriptPath], {
+      const result = await runOnboardProcessAsync([scriptPath], {
         cwd: repoRoot,
-        encoding: "utf-8",
         env,
+        timeoutMs: 45_000,
+        context,
       });
 
       assert.equal(result.status, 0, result.stderr);
@@ -1118,7 +1144,7 @@ const { createSandbox } = require(${onboardPath});
     {
       timeout: 60_000,
     },
-    async () => {
+    async (context) => {
       const repoRoot = path.join(import.meta.dirname, "../..");
       const tmpDir = fs.mkdtempSync(
         path.join(os.tmpdir(), "nemoclaw-onboard-interactive-notready-"),
@@ -1246,16 +1272,19 @@ const { createSandbox } = require(${onboardPath});
       // Run WITHOUT NEMOCLAW_NON_INTERACTIVE to exercise interactive path
       const env: Record<string, string | undefined> = {
         ...process.env,
+        ...ONBOARD_TEST_ENV,
+        NEMOCLAW_DASHBOARD_PORT: isolatedDashboardPort(tmpDir),
         HOME: tmpDir,
         PATH: `${fakeBin}:${process.env.PATH || ""}`,
         NEMOCLAW_RECREATE_WITHOUT_BACKUP: "1",
       };
       delete env["NEMOCLAW_NON_INTERACTIVE"];
       delete env["NEMOCLAW_RECREATE_SANDBOX"];
-      const result = spawnSync(process.execPath, [scriptPath], {
+      const result = await runOnboardProcessAsync([scriptPath], {
         cwd: repoRoot,
-        encoding: "utf-8",
         env,
+        timeoutMs: 45_000,
+        context,
       });
 
       assert.equal(result.status, 0, result.stderr);


### PR DESCRIPTION
## Outcome

Runs the nine isolated sandbox-recreation process fixtures concurrently. GitHub CI measured the suite at 16.44 seconds versus 45.72 seconds on the baseline runner profile (64% faster). On the same local machine, suite time dropped from 46.08 seconds on current main to 11.20 seconds on this branch (76% faster); a shuffled repeat completed in 10.74 seconds. This changes test infrastructure only.

## Reason

Each fixture has its own temporary home and fake binaries, but synchronous child-process calls forced the independent cases to wait on one another.

### Related issues

Part of #6237.

## Changes

- run the sandbox-recreation suite concurrently
- use the shared lifecycle-safe async child-process harness with a 45-second hard timeout
- give each fixture a deterministic isolated dashboard port so concurrent cases cannot contend
- use `it.for` for the policy-tier cases so each case retains Vitest lifecycle context

## Verification

- focused sandbox-recreation suite — 9/9 passed in 11.20 seconds
- shuffled sandbox-recreation repeat with seed 11583 — 9/9 passed in 10.74 seconds
- current-main warm comparison — 9/9 passed in 46.08 seconds
- GitHub Linux runner comparison — 45.72 seconds baseline, 16.44 seconds on this branch
- optimized exact-head CI shard — passed
- codebase growth guardrails — 7/7 passed
- `NODE_OPTIONS=--max-old-space-size=8192 npm run check:diff` — passed
- GitHub commit verification — commit `14f6315c3d4f796949d47e97e9d9c1f96e755e8c` is Verified
- documentation review — no user-facing docs changes needed
- secret review — test infrastructure only; no secrets, API keys, or credentials added

## Review notes

Exact-head core CI passed after one `gh` retry of an unrelated `launch-agent-turn` shard flake that also passed locally in isolation. All nine PR Review Advisor specialists failed before review because the OpenShell exec relay returned `The service is currently unavailable`; one cooldown and failed-job retry reproduced the same external outage, with no findings or artifacts. No product-code change is justified. The first concurrent run exposed a shared dashboard-port race; the published version isolates the real port reservation per fixture and keeps child cleanup owned by Vitest.

---

Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved onboarding test execution by running scenarios concurrently with isolated contexts and dashboard ports.
  - Preserved coverage for sandbox readiness, recreation, backup and restore, policy tiers, interactive reuse, and drift handling.
  - Maintained existing test scenarios and assertions while improving consistency and execution efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->