### PR TITLE
fix(advisor): bypass sandbox login profiles

### DIFF
--- a/test/automation/pull-requests/pr-review-advisor-openshell.test.ts
+++ b/test/automation/pull-requests/pr-review-advisor-openshell.test.ts
@@ -1140,6 +1140,7 @@ describe("PR review advisor OpenShell wrapper", () => {
         "exec",
         "--name",
         "pr-advisor-test",
+        "--no-login-shell",
         "--timeout",
         "2100",
         "--workdir",

--- a/tools/openshell-agent/runtime.mts
+++ b/tools/openshell-agent/runtime.mts
@@ -434,6 +434,7 @@ function openShellSandboxExecArguments(input: ExecOpenShellSandboxOptions): stri
     "exec",
     "--name",
     input.name,
+    "--no-login-shell",
     ...timeoutArgs,
     ...workdirArgs,
     ...environmentArgs,


### PR DESCRIPTION
## Outcome

Managed workflow agents now run OpenShell sandbox commands without loading sandbox-user startup files. PR Review Advisor specialists no longer abort when the OpenShell 0.0.116 non-root sandbox user cannot read `/sandbox/.profile`.

## Reason

The OpenShell 0.0.116 cutover exposed a login-shell startup failure in the shared managed-agent runtime. OpenShell already provides `sandbox exec --no-login-shell` for this case, but NemoClaw's shared helper did not pass it.

### Related issues

Relates to NVIDIA/OpenShell#2668 and NVIDIA/OpenShell#2852. No NemoClaw issue is required for this localized CI regression.

## Changes

- Pass `--no-login-shell` through the shared managed OpenShell sandbox exec helper.
- Protect the PR Review Advisor invocation contract with an argv assertion.

## Verification

- `npm exec -- vitest run --project integration test/automation/pull-requests/pr-review-advisor-openshell.test.ts test/automation/pull-requests/pr-merge-conflict-fixer.test.ts` — 61 tests passed.
- `npm exec -- vitest run --project integration test/generation/post-merge-docs.test.ts --testNamePattern='preserves the previous draft|produces and accepts an exact release target above the safe-integer range' --testTimeout=60000` — 3 tests passed.
- `NODE_OPTIONS=--max-old-space-size=8192 npm run validate:pr` — passed on the rebased commit.
- Reviewed the final diff; it contains no secrets, API keys, or credentials.

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sandbox command execution now runs without a login shell, improving consistency and reliability for automated tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->