### PR TITLE
fix(advisor): restore stable OpenShell exec

### DIFF
--- a/test/automation/pull-requests/pr-review-advisor-openshell.test.ts
+++ b/test/automation/pull-requests/pr-review-advisor-openshell.test.ts
@@ -6,6 +6,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import YAML from "yaml";
 
 import {
   ADVISOR_OPENAI_COMPATIBLE_BASE_URL,
@@ -524,6 +525,31 @@ describe("PR review advisor specialist lifecycle", () => {
 });
 
 describe("PR review advisor OpenShell wrapper", () => {
+  it("permits only the pinned image login files required by stable OpenShell exec", () => {
+    const policy = YAML.parse(
+      fs.readFileSync("tools/pr-review-advisor/openshell-policy.yaml", "utf8"),
+    ) as {
+      filesystem_policy: { read_only: string[]; read_write: string[] };
+    };
+
+    expect(policy.filesystem_policy).toEqual({
+      include_workdir: false,
+      read_only: [
+        "/usr/bin",
+        "/usr/lib",
+        "/usr/share/git-core",
+        "/etc",
+        "/sandbox/.bashrc",
+        "/sandbox/.profile",
+        "/advisor",
+        "/pr-workdir",
+        "/pr-review-advisor-context",
+        "/pr-review-advisor-tools",
+      ],
+      read_write: ["/dev", "/sandbox/pr-review-advisor-runtime"],
+    });
+  });
+
   it("dispatches sandbox runtime initialization", () => {
     const initialize = vi.fn();
 
@@ -1134,13 +1160,13 @@ describe("PR review advisor OpenShell wrapper", () => {
     expect(calls.some(([, args]) => args.slice(0, 2).join(" ") === "policy set")).toBe(false);
 
     const runArgs = vi.mocked(tools.runAsync).mock.calls[0]?.[1] ?? [];
+    expect(runArgs).not.toContain("--no-login-shell");
     expect(runArgs).toEqual(
       expect.arrayContaining([
         "sandbox",
         "exec",
         "--name",
         "pr-advisor-test",
-        "--no-login-shell",
         "--timeout",
         "2100",
         "--workdir",

--- a/tools/openshell-agent/runtime.mts
+++ b/tools/openshell-agent/runtime.mts
@@ -434,7 +434,6 @@ function openShellSandboxExecArguments(input: ExecOpenShellSandboxOptions): stri
     "exec",
     "--name",
     input.name,
-    "--no-login-shell",
     ...timeoutArgs,
     ...workdirArgs,
     ...environmentArgs,

--- a/tools/pr-review-advisor/openshell-policy.yaml
+++ b/tools/pr-review-advisor/openshell-policy.yaml
@@ -10,6 +10,8 @@ filesystem_policy:
     - /usr/lib
     - /usr/share/git-core
     - /etc
+    - /sandbox/.bashrc
+    - /sandbox/.profile
     - /advisor
     - /pr-workdir
     - /pr-review-advisor-context


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

PR Review Advisor specialists can start on the repository-pinned OpenShell v0.0.116 release again. Stable OpenShell may read the pinned image's login files, while the Advisor sandbox keeps them read-only and retains its existing write boundary.

## Reason

The runtime passed `--no-login-shell`, an option available on unreleased OpenShell main but absent from pinned v0.0.116. Stable OpenShell treated it as the sandbox command and failed every specialist with `/bin/bash: --: invalid option` before review began.

### Related issues

Part of #10791

## Changes

- Remove the unsupported `--no-login-shell` argument from sandbox execution.
- Permit only `/sandbox/.profile` and `/sandbox/.bashrc` as additional read-only policy paths required by stable OpenShell login execution.
- Add focused assertions for the stable CLI argument and filesystem-policy contracts.

## Verification

- `npx vitest run --project integration test/automation/pull-requests/pr-review-advisor-openshell.test.ts test/generation/post-merge-docs.test.ts` — 108/108 passed on current main.
- `npx prek run --hook-stage pre-commit --all-files` — passed.
- `NODE_OPTIONS=--max-old-space-size=8192 npm run validate:pr` — passed, including CLI typecheck.
- Documentation-writer review — no documentation change required because supported user-facing behavior and security guarantees are unchanged.
- GitHub verification — both published commits are Verified.
- Diff review — no secrets, API keys, or credentials added.
- Live E2E — not run locally; exact-head GitHub Advisor validation is required before readiness.

## Review notes

This touches the Advisor sandbox policy. The two added paths are pinned-image login files and remain read-only; no broader `/sandbox` read or write permission is granted.

---
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * OpenShell sandbox sessions now support the standard shell startup configuration without forcing the no-login-shell option.
  * Sandbox access to `.bashrc` and `.profile` is now read-only, helping protect shell configuration while preserving access to these files.

* **Tests**
  * Added coverage to verify the sandbox’s exact filesystem permissions and execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->