### PR TITLE
test(onboard): serialize dashboard port fixture

### DIFF
--- a/test/onboarding/onboard-messaging.test.ts
+++ b/test/onboarding/onboard-messaging.test.ts
@@ -1238,7 +1238,7 @@ const { createSandbox } = require(${onboardPath});
     },
   );
 
-  it(
+  it.sequential(
     "reuses sandbox without refreshing unselected ambient messaging providers (#10277)",
     {
       timeout: 60_000,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

Keeps the dashboard-port-owning onboard-messaging fixture out of sibling overlap, preventing the repeated port collision seen in sharded CI. The other 13 fixtures remain concurrent, preserving nearly all of the suite speedup from #11581.

## Reason

The merged parallelization made all 14 child-process fixtures concurrent, but this one case still exercises the real shared dashboard-port allocator. It failed twice on clean GitHub runners because a sibling fixture held the same default port.

## Changes

- Mark only `reuses sandbox without refreshing unselected ambient messaging providers` as sequential inside the concurrent suite.

## Verification

- `npx vitest run --project integration test/onboarding/onboard-messaging.test.ts --sequence.shuffle --sequence.seed=11598` — 14/14 passed in 28.52s test time.
- `npx vitest run --project integration test/automation/pull-requests/growth-guardrails.test.ts` — 7/7 passed.
- `npm run build:cli` — passed.
- `npm --prefix nemoclaw run build` — passed.
- `NODE_OPTIONS=--max-old-space-size=8192 npm run check:diff` — passed, including formatting, lint, secret scan, source-shape budget, repository checks, and CLI type-check.
- Hosted CI on exact head `cb41cdcb40ab77ddd084bf371366012cc175adf1` — all 12 CLI shards and all aggregate checks passed; shard 9 passed in 8m46s.
- GitHub commit verification — `cb41cdcb40ab77ddd084bf371366012cc175adf1` is Verified.
- Documentation review — no user-facing documentation change is needed.
- Secret review — no secrets, API keys, or credentials added.

## Review notes

Primary evidence: the same untouched fixture failed on [the original shard](https://github.com/NVIDIA/NemoClaw/actions/runs/34651247023/job/103434104655) and its [clean retry](https://github.com/NVIDIA/NemoClaw/actions/runs/34651247023/job/103436996681). Both failures were default dashboard-port collisions after #11581 made the suite concurrent.

---
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the sandbox-reuse messaging-provider test to run sequentially for more consistent test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->