### PR TITLE
fix(advisor): retain sandbox entrypoint

### DIFF
--- a/test/automation/pull-requests/pr-review-advisor-openshell.test.ts
+++ b/test/automation/pull-requests/pr-review-advisor-openshell.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { execFileSync, spawnSync } from "node:child_process";
+import { EventEmitter } from "node:events";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -30,6 +31,7 @@ import {
   prepareAdvisorSandboxInputs,
   runAdvisorSandboxAsync,
   runOpenShellAdvisorCommand,
+  waitForAdvisorSandboxTermination,
   verifyAdvisorGitWorktree,
 } from "../../../tools/pr-review-advisor/openshell.mts";
 import {
@@ -525,6 +527,27 @@ describe("PR review advisor specialist lifecycle", () => {
 });
 
 describe("PR review advisor OpenShell wrapper", () => {
+  it("initializes and keeps the sandbox entrypoint alive until OpenShell terminates it (#10791)", async () => {
+    const signals = new EventEmitter();
+    const initialize = vi.fn();
+    let settled = false;
+    const waiting = runOpenShellAdvisorCommand("initialize", initialize, () =>
+      waitForAdvisorSandboxTermination(signals),
+    ).then(() => {
+      settled = true;
+    });
+
+    await Promise.resolve();
+    expect(initialize).toHaveBeenCalledOnce();
+    expect(settled).toBe(false);
+
+    signals.emit("SIGTERM");
+    await waiting;
+    expect(settled).toBe(true);
+    expect(signals.listenerCount("SIGTERM")).toBe(0);
+    expect(signals.listenerCount("SIGINT")).toBe(0);
+  });
+
   it("permits only the pinned image login files required by stable OpenShell exec", () => {
     const policy = YAML.parse(
       fs.readFileSync("tools/pr-review-advisor/openshell-policy.yaml", "utf8"),
@@ -550,14 +573,6 @@ describe("PR review advisor OpenShell wrapper", () => {
     });
   });
 
-  it("dispatches sandbox runtime initialization", () => {
-    const initialize = vi.fn();
-
-    runOpenShellAdvisorCommand("initialize", initialize);
-
-    expect(initialize).toHaveBeenCalledOnce();
-  });
-
   it.each([
     [undefined, "openshell command is required"],
     ["prepare", "Unsupported OpenShell advisor command: prepare"],
@@ -569,10 +584,10 @@ describe("PR review advisor OpenShell wrapper", () => {
     ["delete", "Unsupported OpenShell advisor command: delete"],
     ["check", "Unsupported OpenShell advisor command: check"],
     ["unknown", "Unsupported OpenShell advisor command: unknown"],
-  ])("rejects unsupported OpenShell command %s", (command, message) => {
+  ])("rejects unsupported OpenShell command %s", async (command, message) => {
     const initialize = vi.fn();
 
-    expect(() => runOpenShellAdvisorCommand(command, initialize)).toThrow(message);
+    await expect(runOpenShellAdvisorCommand(command, initialize)).rejects.toThrow(message);
     expect(initialize).not.toHaveBeenCalled();
   });
 

--- a/test/automation/pull-requests/pr-review-advisor-openshell.test.ts
+++ b/test/automation/pull-requests/pr-review-advisor-openshell.test.ts
@@ -527,26 +527,29 @@ describe("PR review advisor specialist lifecycle", () => {
 });
 
 describe("PR review advisor OpenShell wrapper", () => {
-  it("initializes and keeps the sandbox entrypoint alive until OpenShell terminates it (#10791)", async () => {
-    const signals = new EventEmitter();
-    const initialize = vi.fn();
-    let settled = false;
-    const waiting = runOpenShellAdvisorCommand("initialize", initialize, () =>
-      waitForAdvisorSandboxTermination(signals),
-    ).then(() => {
-      settled = true;
-    });
+  it.each(["SIGTERM", "SIGINT"] as const)(
+    "initializes and keeps the sandbox entrypoint alive until OpenShell sends %s (#10791)",
+    async (signal) => {
+      const signals = new EventEmitter();
+      const initialize = vi.fn();
+      let settled = false;
+      const waiting = runOpenShellAdvisorCommand("initialize", initialize, () =>
+        waitForAdvisorSandboxTermination(signals),
+      ).then(() => {
+        settled = true;
+      });
 
-    await Promise.resolve();
-    expect(initialize).toHaveBeenCalledOnce();
-    expect(settled).toBe(false);
+      await Promise.resolve();
+      expect(initialize).toHaveBeenCalledOnce();
+      expect(settled).toBe(false);
 
-    signals.emit("SIGTERM");
-    await waiting;
-    expect(settled).toBe(true);
-    expect(signals.listenerCount("SIGTERM")).toBe(0);
-    expect(signals.listenerCount("SIGINT")).toBe(0);
-  });
+      signals.emit(signal);
+      await waiting;
+      expect(settled).toBe(true);
+      expect(signals.listenerCount("SIGTERM")).toBe(0);
+      expect(signals.listenerCount("SIGINT")).toBe(0);
+    },
+  );
 
   it("permits only the pinned image login files required by stable OpenShell exec", () => {
     const policy = YAML.parse(

--- a/tools/pr-review-advisor/openshell.mts
+++ b/tools/pr-review-advisor/openshell.mts
@@ -564,19 +564,40 @@ export function initializeAdvisorSandboxRuntime(): void {
   checkAdvisorSandboxRuntime();
 }
 
-export function runOpenShellAdvisorCommand(
+export async function runOpenShellAdvisorCommand(
   command: string | undefined,
   initialize: () => void = initializeAdvisorSandboxRuntime,
-): void {
+  waitForTermination: () => Promise<void> = waitForAdvisorSandboxTermination,
+): Promise<void> {
   const requiredCommand = required(command, "openshell command");
   if (requiredCommand !== "initialize") {
     throw new Error(`Unsupported OpenShell advisor command: ${requiredCommand}`);
   }
   initialize();
+  await waitForTermination();
+}
+
+type AdvisorSandboxSignals = {
+  once(event: "SIGINT" | "SIGTERM", listener: () => void): unknown;
+  removeListener(event: "SIGINT" | "SIGTERM", listener: () => void): unknown;
+};
+
+export function waitForAdvisorSandboxTermination(
+  signals: AdvisorSandboxSignals = process,
+): Promise<void> {
+  return new Promise((resolve) => {
+    const finish = () => {
+      signals.removeListener("SIGTERM", finish);
+      signals.removeListener("SIGINT", finish);
+      resolve();
+    };
+    signals.once("SIGTERM", finish);
+    signals.once("SIGINT", finish);
+  });
 }
 
 async function main(): Promise<void> {
-  runOpenShellAdvisorCommand(process.argv[2]);
+  await runOpenShellAdvisorCommand(process.argv[2]);
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {


### PR DESCRIPTION
## Outcome

PR Review Advisor sandboxes keep their trusted entrypoint alive until OpenShell terminates the sandbox, so the supervisor exec relay remains available for the specialist session.

## Reason

OpenShell v0.0.116 tears down the supervisor session when the configured entrypoint exits. The Advisor entrypoint initialized its runtime and returned immediately, racing every later `sandbox exec` and causing repeated 0/9 specialist failures before review began.

### Related issues

Part of #10791

## Changes

- Wait for `SIGTERM` or `SIGINT` after sandbox runtime initialization instead of exiting the entrypoint.
- Remove both signal listeners during shutdown.
- Add focused regressions proving initialization completes while the entrypoint remains alive until either supported OpenShell termination signal.

## Verification

- `npx vitest run test/automation/pull-requests/pr-review-advisor-openshell.test.ts` — 46/46 passed
- `NODE_OPTIONS=--max-old-space-size=8192 npm run validate:pr` — passed after merging current main
- Exact-head CI run `34655855329` — passed
- CodeRabbit incremental review — passed; its SIGINT coverage thread is fixed and resolved
- Documentation-writer review — no documentation change required because commands, configuration, review semantics, and the security boundary are unchanged
- GitHub commit verification — all branch commits through `21840fbb575aeab6f746b54b96a1fab1c1d498ef` are Verified
- Diff inspection — no secrets, API keys, or credentials

## Review notes

The local `prek` executable was unavailable, so commit and push hooks could not execute directly. The focused regression and repository `validate:pr` gate were run manually and passed before publication.

Advisor run `34656803483` cannot self-host this repair: by design it executes the trusted Advisor runtime from base commit `49fea6a4dcdd9c008398a69f88eabb3d35847690`, not the PR head. All nine jobs therefore reproduced the base runtime's `exec relay closed` failure before specialists ran and uploaded no artifacts. After independent merge, downstream lifecycle PR #11047 will provide the current-main 9/9 live proof.

---
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>
