### PR TITLE
docs(hermes): fix Hindsight version check

### DIFF
--- a/docs/manage-sandboxes/install-plugins-hermes.mdx
+++ b/docs/manage-sandboxes/install-plugins-hermes.mdx
@@ -83,7 +83,7 @@ Verify the provider and dependency after the restart:
 
 ```bash
 nemohermes <name> exec -- hermes memory status
-nemohermes <name> exec -- python -c 'import os, sys; sys.path.insert(0, os.environ["HERMES_LAZY_INSTALL_TARGET"]); import hindsight_client; print(hindsight_client.__version__)'
+nemohermes <name> exec -- python -c 'import os, sys; sys.path.insert(0, os.environ["HERMES_LAZY_INSTALL_TARGET"]); import hindsight_client; from importlib.metadata import version; print(version("hindsight-client"))'
 nemohermes <name> status
 ```
 


### PR DESCRIPTION
## Summary

The supported Hindsight package does not expose `hindsight_client.__version__`. This reads the installed package metadata so the version check prints `0.6.1` instead of raising `AttributeError`.

## Related Issue

Fixes #11509

## Changes

- Read the installed version with `importlib.metadata`, retaining the import check and lazy-package lookup.

## Type of Change

- [x] Doc only (includes code sample changes)

## Quality Gates

- [x] Original command fails and corrected command passes with the supported package
- [x] Documentation updated for the reported behavior
- [x] Independent documentation writer review completed with no findings
- [x] Hermes-only scope, routes, and lazy-package lookup unchanged

## Verification

- Tested the supported `hindsight-client==0.6.1` wheel in Docker: the original expression fails; the corrected expression prints `0.6.1`.
- `npm run docs` — passed with five warnings in unchanged pages/configuration and the authenticated redirect check.
- `npm run validate:pr` — passed.
- Normal commit and push hooks passed; the push required an 8 GiB Node heap.
- DCO sign-off included and commit verified by GitHub.
- Independent documentation review — no findings. Hermes-only scope and routes are unchanged.
- The diff contains no secrets, API keys, or credentials.

---
Signed-off-by: latenighthackathon <latenighthackathon@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency verification by using the installed Hindsight client version, providing more reliable version checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
