### PR TITLE
fix(advisor): keep sandbox entrypoint process alive

### DIFF
--- a/test/automation/pull-requests/pr-review-advisor-openshell.test.ts
+++ b/test/automation/pull-requests/pr-review-advisor-openshell.test.ts
@@ -551,6 +551,26 @@ describe("PR review advisor OpenShell wrapper", () => {
     },
   );
 
+  it("keeps a real Node entrypoint alive while it waits for OpenShell termination (#10791)", () => {
+    const moduleUrl = new URL("../../../tools/pr-review-advisor/openshell.mts", import.meta.url)
+      .href;
+    const child = spawnSync(
+      process.execPath,
+      [
+        "--no-warnings",
+        "--input-type=module",
+        "--eval",
+        `import { waitForAdvisorSandboxTermination } from ${JSON.stringify(moduleUrl)}; await waitForAdvisorSandboxTermination();`,
+      ],
+      { encoding: "utf8", killSignal: "SIGTERM", timeout: 1_000 },
+    );
+
+    expect(child.error).toMatchObject({ code: "ETIMEDOUT" });
+    expect(child.status).toBe(0);
+    expect(child.signal).toBeNull();
+    expect(child.stderr).toBe("");
+  });
+
   it("permits only the pinned image login files required by stable OpenShell exec", () => {
     const policy = YAML.parse(
       fs.readFileSync("tools/pr-review-advisor/openshell-policy.yaml", "utf8"),

--- a/tools/pr-review-advisor/openshell.mts
+++ b/tools/pr-review-advisor/openshell.mts
@@ -586,7 +586,11 @@ export function waitForAdvisorSandboxTermination(
   signals: AdvisorSandboxSignals = process,
 ): Promise<void> {
   return new Promise((resolve) => {
+    // Signal listeners and an unresolved promise do not keep Node running when
+    // no active handles remain. Own one handle until OpenShell terminates PID 1.
+    const keepAlive = setInterval(() => undefined, 60_000);
     const finish = () => {
+      clearInterval(keepAlive);
       signals.removeListener("SIGTERM", finish);
       signals.removeListener("SIGINT", finish);
       resolve();


### PR DESCRIPTION
## Outcome

The Advisor sandbox initializer keeps its real Node process alive until OpenShell sends `SIGTERM` or `SIGINT`. The supervisor relay no longer closes merely because no active event-loop handle remains after initialization.

## Reason

Post-merge Advisor run 34658298309 used the #11599 code from current `main`, but all nine specialists still stopped before review with `exec relay closed before the command reported an exit status`. An unresolved promise plus signal listeners does not keep a Node process alive when no active handles remain, so the initializer still exited immediately.

### Related issues

Part of #10791

## Changes

- Hold one active timer handle for the initializer lifetime and release it when OpenShell terminates the process.
- Add a real subprocess regression that fails when Node exits with an unsettled termination promise and passes only when the entrypoint remains alive through `SIGTERM`.

## Verification

- `npx vitest run test/automation/pull-requests/pr-review-advisor-openshell.test.ts --testTimeout=60000` — 47 tests passed after formatting.
- Pre-commit hooks — passed.
- `NODE_OPTIONS=--max-old-space-size=8192` pre-push TypeScript checks — passed after building the plugin artifact required by the local checkout.
- GitHub commit verification — commit `566e6be05dc4e17f11d92bae035878b1e48886f0` is Verified.
- Diff inspection — no secrets, API keys, or credentials.

## Review notes

This fixes the entrypoint-lifetime defect exposed after #11599 merged. PR #11596 separately owns the pinned OpenShell 0.0.116 `sandbox exec` command compatibility change; the two root causes remain separate.

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sandbox termination handling so the process remains active while waiting for OpenShell to stop the sandbox.
  - Added cleanup when termination signals are received, allowing shutdown to complete without lingering activity or errors.

- **Tests**
  - Added integration coverage verifying timeout-based termination behavior in a real Node.js process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->