### PR TITLE
perf(test): overlap auto-pair slow-mode cases

### DIFF
--- a/ci/test-file-size-budget.json
+++ b/ci/test-file-size-budget.json
@@ -7,7 +7,7 @@
     "src/lib/onboard/preflight.test.ts": 1875,
     "test/generation/generate-openclaw-config.test.ts": 1898,
     "test/installer-integration/install-preflight.test.ts": 3025,
-    "test/agents/openclaw/runtime/nemoclaw-start.test.ts": 4352,
+    "test/agents/openclaw/runtime/nemoclaw-start.test.ts": 4348,
     "test/onboarding/onboard-messaging.test.ts": 1963,
     "test/onboarding/onboard-selection.test.ts": 4133
   }

--- a/test/agents/openclaw/runtime/nemoclaw-start.test.ts
+++ b/test/agents/openclaw/runtime/nemoclaw-start.test.ts
@@ -42,7 +42,7 @@ const JSON5_MODULE = path.join(
   "node_modules",
   "json5",
 );
-const execFileAsync = promisify(execFile);
+const runCommand = promisify(execFile);
 
 // Concurrent process fixtures are independent, but keep their host load bounded.
 vi.setConfig({ maxConcurrency: 4 });
@@ -1183,7 +1183,7 @@ describe.concurrent("nemoclaw-start auto-pair slow-mode keepalive (#4263)", () =
       "nemoclaw-auto-pair-slow-",
     );
     try {
-      const run = await execFileAsync("python3", ["-c", buildAutoPairScript()], {
+      const run = await runCommand("python3", ["-c", buildAutoPairScript()], {
         encoding: "utf-8",
         env: {
           ...process.env,
@@ -1271,7 +1271,7 @@ exit 2
     );
 
     try {
-      const run = await execFileAsync("python3", ["-c", buildAutoPairScript()], {
+      const run = await runCommand("python3", ["-c", buildAutoPairScript()], {
         encoding: "utf-8",
         env: {
           ...process.env,
@@ -1329,7 +1329,7 @@ exit 2
     );
 
     try {
-      const run = await execFileAsync("python3", ["-c", buildAutoPairScript()], {
+      const run = await runCommand("python3", ["-c", buildAutoPairScript()], {
         encoding: "utf-8",
         env: {
           ...process.env,
@@ -1398,7 +1398,7 @@ exit 2
     );
 
     try {
-      const run = await execFileAsync("python3", ["-c", buildAutoPairScript()], {
+      const run = await runCommand("python3", ["-c", buildAutoPairScript()], {
         encoding: "utf-8",
         env: {
           ...process.env,
@@ -1445,7 +1445,7 @@ exit 2
     );
 
     try {
-      const run = await execFileAsync("python3", ["-c", buildAutoPairScript()], {
+      const run = await runCommand("python3", ["-c", buildAutoPairScript()], {
         encoding: "utf-8",
         env: {
           ...process.env,
@@ -1501,7 +1501,7 @@ exit 2
     );
 
     try {
-      const run = await execFileAsync("python3", ["-c", buildAutoPairScript()], {
+      const run = await runCommand("python3", ["-c", buildAutoPairScript()], {
         encoding: "utf-8",
         env: {
           ...process.env,
@@ -1541,7 +1541,7 @@ exit 0
       // semantics so subprocess.run(..., timeout=...) actually fires.
       const watcherSrc = localApprovalPolicyPythonScript(fs.readFileSync(START_SCRIPT, "utf-8"));
       const start = Date.now();
-      const run = await execFileAsync("python3", ["-c", watcherSrc], {
+      const run = await runCommand("python3", ["-c", watcherSrc], {
         encoding: "utf-8",
         env: {
           ...process.env,
@@ -1619,7 +1619,7 @@ exit 2
 
     try {
       const watcherSrc = localApprovalPolicyPythonScript(fs.readFileSync(START_SCRIPT, "utf-8"));
-      const run = await execFileAsync("python3", ["-c", watcherSrc], {
+      const run = await runCommand("python3", ["-c", watcherSrc], {
         encoding: "utf-8",
         env: {
           ...process.env,
@@ -1689,7 +1689,7 @@ exit 2
     );
 
     try {
-      const run = await execFileAsync("python3", ["-c", buildAutoPairScript()], {
+      const run = await runCommand("python3", ["-c", buildAutoPairScript()], {
         encoding: "utf-8",
         env: {
           ...process.env,

--- a/test/agents/openclaw/runtime/nemoclaw-start.test.ts
+++ b/test/agents/openclaw/runtime/nemoclaw-start.test.ts
@@ -2,12 +2,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { spawnSync } from "node:child_process";
+import { execFile, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { promisify } from "node:util";
 import * as ts from "typescript";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { extractShellFunctionFromSource } from "../../../helpers/shell-source";
 import { createCanonicalCliFixture, setupLateCliFixture } from "./auto-pair-settlement-fixture";
 
@@ -41,6 +42,10 @@ const JSON5_MODULE = path.join(
   "node_modules",
   "json5",
 );
+const execFileAsync = promisify(execFile);
+
+// Concurrent process fixtures are independent, but keep their host load bounded.
+vi.setConfig({ maxConcurrency: 4 });
 
 function commandPath(name: string): string {
   const result = spawnSync("/bin/sh", ["-c", `command -v ${name}`], { encoding: "utf-8" });
@@ -1166,19 +1171,19 @@ exit 2
     }
   }, 40_000);
 });
-describe("nemoclaw-start auto-pair slow-mode keepalive (#4263)", () => {
+describe.concurrent("nemoclaw-start auto-pair slow-mode keepalive (#4263)", () => {
   const src = fs.readFileSync(START_SCRIPT, "utf-8");
 
   function buildAutoPairScript(): string {
     return autoPairPythonScript(src);
   }
 
-  it("stays fast through browser pairing and slows only after the canonical CLI baseline", () => {
+  it("stays fast through browser pairing and slows only after the canonical CLI baseline", async () => {
     const { tmpDir, fakeOpenclaw, approveLog, stateDir } = setupLateCliFixture(
       "nemoclaw-auto-pair-slow-",
     );
     try {
-      const run = spawnSync("python3", ["-c", buildAutoPairScript()], {
+      const run = await execFileAsync("python3", ["-c", buildAutoPairScript()], {
         encoding: "utf-8",
         env: {
           ...process.env,
@@ -1192,7 +1197,6 @@ describe("nemoclaw-start auto-pair slow-mode keepalive (#4263)", () => {
         },
         timeout: 30_000,
       });
-      expect(run.status).toBe(0);
       expect(run.stdout).toContain(
         "[auto-pair] approved request=browser-pair client=openclaw-control-ui mode=webchat",
       );
@@ -1218,7 +1222,7 @@ describe("nemoclaw-start auto-pair slow-mode keepalive (#4263)", () => {
     }
   }, 40_000);
 
-  it("rejects unknown clients in slow-mode keepalive", () => {
+  it("rejects unknown clients in slow-mode keepalive", async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-auto-pair-slow-evil-"));
     const fakeOpenclaw = path.join(tmpDir, "openclaw");
     const stateDir = path.join(tmpDir, "state");
@@ -1267,7 +1271,7 @@ exit 2
     );
 
     try {
-      const run = spawnSync("python3", ["-c", buildAutoPairScript()], {
+      const run = await execFileAsync("python3", ["-c", buildAutoPairScript()], {
         encoding: "utf-8",
         env: {
           ...process.env,
@@ -1278,7 +1282,6 @@ exit 2
         },
         timeout: 30_000,
       });
-      expect(run.status).toBe(0);
       expect(run.stdout).toContain(
         "[auto-pair] canonical CLI baseline settled; entering slow-mode approvals=0",
       );
@@ -1290,7 +1293,7 @@ exit 2
     }
   }, 40_000);
 
-  it("rejects malformed CLI scope request payloads", () => {
+  it("rejects malformed CLI scope request payloads", async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-auto-pair-malformed-"));
     const fakeOpenclaw = path.join(tmpDir, "openclaw");
     const approveLog = path.join(tmpDir, "approvals.log");
@@ -1326,7 +1329,7 @@ exit 2
     );
 
     try {
-      const run = spawnSync("python3", ["-c", buildAutoPairScript()], {
+      const run = await execFileAsync("python3", ["-c", buildAutoPairScript()], {
         encoding: "utf-8",
         env: {
           ...process.env,
@@ -1336,7 +1339,6 @@ exit 2
         },
         timeout: 20_000,
       });
-      expect(run.status).toBe(0);
       expect(run.stdout).toContain(
         "[auto-pair] rejected malformed scopes client=openclaw-cli mode=cli",
       );
@@ -1347,7 +1349,7 @@ exit 2
     }
   }, 30_000);
 
-  it("rejects disallowed CLI admin scope requests", () => {
+  it("rejects disallowed CLI admin scope requests", async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-auto-pair-admin-"));
     const fakeOpenclaw = path.join(tmpDir, "openclaw");
     const maliciousPolicyDir = path.join(tmpDir, "malicious-policy");
@@ -1396,7 +1398,7 @@ exit 2
     );
 
     try {
-      const run = spawnSync("python3", ["-c", buildAutoPairScript()], {
+      const run = await execFileAsync("python3", ["-c", buildAutoPairScript()], {
         encoding: "utf-8",
         env: {
           ...process.env,
@@ -1407,7 +1409,6 @@ exit 2
         },
         timeout: 20_000,
       });
-      expect(run.status).toBe(0);
       expect(run.stdout).toContain(
         "[auto-pair] rejected disallowed scopes=['operator.admin'] client=openclaw-cli mode=cli",
       );
@@ -1418,7 +1419,7 @@ exit 2
     }
   }, 30_000);
 
-  it("keeps fast polling when no canonical CLI baseline appears (#10269)", () => {
+  it("keeps fast polling when no canonical CLI baseline appears (#10269)", async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-auto-pair-slow-fastdl-"));
     const fakeOpenclaw = path.join(tmpDir, "openclaw");
     const approveLog = path.join(tmpDir, "approvals.log");
@@ -1444,7 +1445,7 @@ exit 2
     );
 
     try {
-      const run = spawnSync("python3", ["-c", buildAutoPairScript()], {
+      const run = await execFileAsync("python3", ["-c", buildAutoPairScript()], {
         encoding: "utf-8",
         env: {
           ...process.env,
@@ -1454,7 +1455,6 @@ exit 2
         },
         timeout: 20_000,
       });
-      expect(run.status).toBe(0);
       expect(run.stdout).not.toContain("entering slow-mode");
       expect(run.stdout).toContain(
         '[auto-pair-status] {"schemaVersion":1,"state":"request-not-produced"}',
@@ -1466,7 +1466,7 @@ exit 2
     }
   }, 30_000);
 
-  it("keeps a rejected sticky request in fast mode without approving it (#10269)", () => {
+  it("keeps a rejected sticky request in fast mode without approving it (#10269)", async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-auto-pair-sticky-"));
     const fakeOpenclaw = path.join(tmpDir, "openclaw");
     const approveLog = path.join(tmpDir, "approvals.log");
@@ -1501,7 +1501,7 @@ exit 2
     );
 
     try {
-      const run = spawnSync("python3", ["-c", buildAutoPairScript()], {
+      const run = await execFileAsync("python3", ["-c", buildAutoPairScript()], {
         encoding: "utf-8",
         env: {
           ...process.env,
@@ -1511,7 +1511,6 @@ exit 2
         },
         timeout: 20_000,
       });
-      expect(run.status).toBe(0);
       expect(run.stdout).not.toContain("entering slow-mode");
       expect(run.stdout).toContain("[auto-pair] rejected unknown client=evil-client mode=unknown");
       expect(run.stdout).toContain("watcher deadline reached approvals=0");
@@ -1522,7 +1521,7 @@ exit 2
     }
   }, 30_000);
 
-  it("bounds the openclaw CLI invocation so a wedged child cannot pin the watcher", () => {
+  it("bounds the openclaw CLI invocation so a wedged child cannot pin the watcher", async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-auto-pair-runto-"));
     const fakeOpenclaw = path.join(tmpDir, "openclaw");
 
@@ -1542,7 +1541,7 @@ exit 0
       // semantics so subprocess.run(..., timeout=...) actually fires.
       const watcherSrc = localApprovalPolicyPythonScript(fs.readFileSync(START_SCRIPT, "utf-8"));
       const start = Date.now();
-      const run = spawnSync("python3", ["-c", watcherSrc], {
+      const run = await execFileAsync("python3", ["-c", watcherSrc], {
         encoding: "utf-8",
         env: {
           ...process.env,
@@ -1556,7 +1555,6 @@ exit 0
         timeout: 20_000,
       });
       const elapsedMs = Date.now() - start;
-      expect(run.status).toBe(0);
       // The watcher exited via DEADLINE, not via a wedged subprocess.
       expect(run.stdout).toContain("watcher deadline reached approvals=0");
       // Timeout log was emitted for at least one stuck `devices list`.
@@ -1569,7 +1567,7 @@ exit 0
     }
   }, 30_000);
 
-  it("retries a transient approve timeout instead of permanently handling the requestId", () => {
+  it("retries a transient approve timeout instead of permanently handling the requestId", async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-auto-pair-aretry-"));
     const fakeOpenclaw = path.join(tmpDir, "openclaw");
     const stateFile = path.join(tmpDir, "approve-count");
@@ -1621,7 +1619,7 @@ exit 2
 
     try {
       const watcherSrc = localApprovalPolicyPythonScript(fs.readFileSync(START_SCRIPT, "utf-8"));
-      const run = spawnSync("python3", ["-c", watcherSrc], {
+      const run = await execFileAsync("python3", ["-c", watcherSrc], {
         encoding: "utf-8",
         env: {
           ...process.env,
@@ -1632,7 +1630,6 @@ exit 2
         },
         timeout: 30_000,
       });
-      expect(run.status).toBe(0);
       // Timeout was logged for the first attempt.
       expect(run.stdout).toContain("[auto-pair] timeout calling devices approve");
       // Retry succeeded on the second attempt.
@@ -1647,7 +1644,7 @@ exit 2
     }
   }, 40_000);
 
-  it("retries a non-zero approve failure without counting it as approved or re-arming fast-reentry", () => {
+  it("retries a non-zero approve failure without counting it as approved or re-arming fast-reentry", async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-auto-pair-afail-"));
     const fakeOpenclaw = path.join(tmpDir, "openclaw");
     const stateFile = path.join(tmpDir, "approve-count");
@@ -1692,7 +1689,7 @@ exit 2
     );
 
     try {
-      const run = spawnSync("python3", ["-c", buildAutoPairScript()], {
+      const run = await execFileAsync("python3", ["-c", buildAutoPairScript()], {
         encoding: "utf-8",
         env: {
           ...process.env,
@@ -1704,7 +1701,6 @@ exit 2
         },
         timeout: 20_000,
       });
-      expect(run.status).toBe(0);
       expect(run.stdout).toContain(
         "[auto-pair] approve failed request=retry-cli: temporary approve failure",
       );

--- a/test/agents/openclaw/runtime/nemoclaw-start.test.ts
+++ b/test/agents/openclaw/runtime/nemoclaw-start.test.ts
@@ -1567,7 +1567,7 @@ exit 0
     }
   }, 30_000);
 
-  it("retries a transient approve timeout instead of permanently handling the requestId", async () => {
+  it.sequential("retries a transient approve timeout instead of permanently handling the requestId", async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-auto-pair-aretry-"));
     const fakeOpenclaw = path.join(tmpDir, "openclaw");
     const stateFile = path.join(tmpDir, "approve-count");

--- a/test/agents/openclaw/runtime/nemoclaw-start.test.ts
+++ b/test/agents/openclaw/runtime/nemoclaw-start.test.ts
@@ -1178,7 +1178,7 @@ describe.concurrent("nemoclaw-start auto-pair slow-mode keepalive (#4263)", () =
     return autoPairPythonScript(src);
   }
 
-  it("stays fast through browser pairing and slows only after the canonical CLI baseline", async () => {
+  it("stays fast through browser pairing and slows only after the canonical CLI baseline", async (t) => {
     const { tmpDir, fakeOpenclaw, approveLog, stateDir } = setupLateCliFixture(
       "nemoclaw-auto-pair-slow-",
     );
@@ -1197,22 +1197,22 @@ describe.concurrent("nemoclaw-start auto-pair slow-mode keepalive (#4263)", () =
         },
         timeout: 30_000,
       });
-      expect(run.stdout).toContain(
+      t.expect(run.stdout).toContain(
         "[auto-pair] approved request=browser-pair client=openclaw-control-ui mode=webchat",
       );
-      expect(run.stdout).not.toContain("browser pairing converged");
+      t.expect(run.stdout).not.toContain("browser pairing converged");
       // Concurrent late wave is handled before the fast-to-slow transition.
-      expect(run.stdout).toContain("[auto-pair] approved request=late-cli client=cli mode=cli");
-      expect(run.stdout).toContain("[auto-pair] approved request=late-cli-b client=cli mode=cli");
-      expect(run.stdout).toContain("watcher deadline reached approvals=3");
-      expect(run.stdout).toContain(
+      t.expect(run.stdout).toContain("[auto-pair] approved request=late-cli client=cli mode=cli");
+      t.expect(run.stdout).toContain("[auto-pair] approved request=late-cli-b client=cli mode=cli");
+      t.expect(run.stdout).toContain("watcher deadline reached approvals=3");
+      t.expect(run.stdout).toContain(
         "[auto-pair] canonical CLI baseline settled; entering slow-mode approvals=3",
       );
-      expect(run.stdout).toContain("[auto-pair] fast-reentry bumped polls=3 approved=3 mode=fast");
+      t.expect(run.stdout).toContain("[auto-pair] fast-reentry bumped polls=3 approved=3 mode=fast");
       const approvedAt = run.stdout.indexOf("approved request=late-cli-b");
       const settledAt = run.stdout.indexOf("canonical CLI baseline settled");
-      expect(settledAt).toBeGreaterThan(approvedAt);
-      expect(fs.readFileSync(approveLog, "utf-8").trim().split("\n")).toEqual([
+      t.expect(settledAt).toBeGreaterThan(approvedAt);
+      t.expect(fs.readFileSync(approveLog, "utf-8").trim().split("\n")).toEqual([
         "browser-pair",
         "late-cli",
         "late-cli-b",
@@ -1222,7 +1222,7 @@ describe.concurrent("nemoclaw-start auto-pair slow-mode keepalive (#4263)", () =
     }
   }, 40_000);
 
-  it("rejects unknown clients in slow-mode keepalive", async () => {
+  it("rejects unknown clients in slow-mode keepalive", async (t) => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-auto-pair-slow-evil-"));
     const fakeOpenclaw = path.join(tmpDir, "openclaw");
     const stateDir = path.join(tmpDir, "state");
@@ -1282,18 +1282,18 @@ exit 2
         },
         timeout: 30_000,
       });
-      expect(run.stdout).toContain(
+      t.expect(run.stdout).toContain(
         "[auto-pair] canonical CLI baseline settled; entering slow-mode approvals=0",
       );
-      expect(run.stdout).toContain("[auto-pair] rejected unknown client=evil-client mode=unknown");
+      t.expect(run.stdout).toContain("[auto-pair] rejected unknown client=evil-client mode=unknown");
       // Critical: never approved.
-      expect(fs.existsSync(approveLog)).toBe(false);
+      t.expect(fs.existsSync(approveLog)).toBe(false);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   }, 40_000);
 
-  it("rejects malformed CLI scope request payloads", async () => {
+  it("rejects malformed CLI scope request payloads", async (t) => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-auto-pair-malformed-"));
     const fakeOpenclaw = path.join(tmpDir, "openclaw");
     const approveLog = path.join(tmpDir, "approvals.log");
@@ -1339,17 +1339,17 @@ exit 2
         },
         timeout: 20_000,
       });
-      expect(run.stdout).toContain(
+      t.expect(run.stdout).toContain(
         "[auto-pair] rejected malformed scopes client=openclaw-cli mode=cli",
       );
-      expect(run.stdout).toContain("watcher deadline reached approvals=0");
-      expect(fs.existsSync(approveLog)).toBe(false);
+      t.expect(run.stdout).toContain("watcher deadline reached approvals=0");
+      t.expect(fs.existsSync(approveLog)).toBe(false);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   }, 30_000);
 
-  it("rejects disallowed CLI admin scope requests", async () => {
+  it("rejects disallowed CLI admin scope requests", async (t) => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-auto-pair-admin-"));
     const fakeOpenclaw = path.join(tmpDir, "openclaw");
     const maliciousPolicyDir = path.join(tmpDir, "malicious-policy");
@@ -1409,17 +1409,17 @@ exit 2
         },
         timeout: 20_000,
       });
-      expect(run.stdout).toContain(
+      t.expect(run.stdout).toContain(
         "[auto-pair] rejected disallowed scopes=['operator.admin'] client=openclaw-cli mode=cli",
       );
-      expect(run.stdout).toContain("watcher deadline reached approvals=0");
-      expect(fs.existsSync(approveLog)).toBe(false);
+      t.expect(run.stdout).toContain("watcher deadline reached approvals=0");
+      t.expect(fs.existsSync(approveLog)).toBe(false);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   }, 30_000);
 
-  it("keeps fast polling when no canonical CLI baseline appears (#10269)", async () => {
+  it("keeps fast polling when no canonical CLI baseline appears (#10269)", async (t) => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-auto-pair-slow-fastdl-"));
     const fakeOpenclaw = path.join(tmpDir, "openclaw");
     const approveLog = path.join(tmpDir, "approvals.log");
@@ -1455,18 +1455,18 @@ exit 2
         },
         timeout: 20_000,
       });
-      expect(run.stdout).not.toContain("entering slow-mode");
-      expect(run.stdout).toContain(
+      t.expect(run.stdout).not.toContain("entering slow-mode");
+      t.expect(run.stdout).toContain(
         '[auto-pair-status] {"schemaVersion":1,"state":"request-not-produced"}',
       );
-      expect(run.stdout).toContain("watcher deadline reached approvals=0");
-      expect(fs.existsSync(approveLog)).toBe(false);
+      t.expect(run.stdout).toContain("watcher deadline reached approvals=0");
+      t.expect(fs.existsSync(approveLog)).toBe(false);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   }, 30_000);
 
-  it("keeps a rejected sticky request in fast mode without approving it (#10269)", async () => {
+  it("keeps a rejected sticky request in fast mode without approving it (#10269)", async (t) => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-auto-pair-sticky-"));
     const fakeOpenclaw = path.join(tmpDir, "openclaw");
     const approveLog = path.join(tmpDir, "approvals.log");
@@ -1511,17 +1511,17 @@ exit 2
         },
         timeout: 20_000,
       });
-      expect(run.stdout).not.toContain("entering slow-mode");
-      expect(run.stdout).toContain("[auto-pair] rejected unknown client=evil-client mode=unknown");
-      expect(run.stdout).toContain("watcher deadline reached approvals=0");
+      t.expect(run.stdout).not.toContain("entering slow-mode");
+      t.expect(run.stdout).toContain("[auto-pair] rejected unknown client=evil-client mode=unknown");
+      t.expect(run.stdout).toContain("watcher deadline reached approvals=0");
       // Unknown client was never approved.
-      expect(fs.existsSync(approveLog)).toBe(false);
+      t.expect(fs.existsSync(approveLog)).toBe(false);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   }, 30_000);
 
-  it("bounds the openclaw CLI invocation so a wedged child cannot pin the watcher", async () => {
+  it("bounds the openclaw CLI invocation so a wedged child cannot pin the watcher", async (t) => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-auto-pair-runto-"));
     const fakeOpenclaw = path.join(tmpDir, "openclaw");
 
@@ -1556,18 +1556,18 @@ exit 0
       });
       const elapsedMs = Date.now() - start;
       // The watcher exited via DEADLINE, not via a wedged subprocess.
-      expect(run.stdout).toContain("watcher deadline reached approvals=0");
+      t.expect(run.stdout).toContain("watcher deadline reached approvals=0");
       // Timeout log was emitted for at least one stuck `devices list`.
-      expect(run.stdout).toContain("[auto-pair] timeout calling devices list");
+      t.expect(run.stdout).toContain("[auto-pair] timeout calling devices list");
       // Sanity: if the timeout didn't fire, the first `sleep 2` would
       // already exceed this cap before the watcher could reach its deadline.
-      expect(elapsedMs).toBeLessThan(1_800);
+      t.expect(elapsedMs).toBeLessThan(1_800);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   }, 30_000);
 
-  it.sequential("retries a transient approve timeout instead of permanently handling the requestId", async () => {
+  it.sequential("retries a transient approve timeout instead of permanently handling the requestId", async (t) => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-auto-pair-aretry-"));
     const fakeOpenclaw = path.join(tmpDir, "openclaw");
     const stateFile = path.join(tmpDir, "approve-count");
@@ -1631,20 +1631,20 @@ exit 2
         timeout: 30_000,
       });
       // Timeout was logged for the first attempt.
-      expect(run.stdout).toContain("[auto-pair] timeout calling devices approve");
+      t.expect(run.stdout).toContain("[auto-pair] timeout calling devices approve");
       // Retry succeeded on the second attempt.
-      expect(run.stdout).toContain(
+      t.expect(run.stdout).toContain(
         "[auto-pair] approved request=flaky-cli client=openclaw-cli mode=cli",
       );
       // The approve log records exactly one successful approval (the
       // retry, not the hung first attempt).
-      expect(fs.readFileSync(approveLog, "utf-8").trim().split("\n")).toEqual(["flaky-cli"]);
+      t.expect(fs.readFileSync(approveLog, "utf-8").trim().split("\n")).toEqual(["flaky-cli"]);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   }, 40_000);
 
-  it("retries a non-zero approve failure without counting it as approved or re-arming fast-reentry", async () => {
+  it("retries a non-zero approve failure without counting it as approved or re-arming fast-reentry", async (t) => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-auto-pair-afail-"));
     const fakeOpenclaw = path.join(tmpDir, "openclaw");
     const stateFile = path.join(tmpDir, "approve-count");
@@ -1701,18 +1701,18 @@ exit 2
         },
         timeout: 20_000,
       });
-      expect(run.stdout).toContain(
+      t.expect(run.stdout).toContain(
         "[auto-pair] approve failed request=retry-cli: temporary approve failure",
       );
-      expect(run.stdout).toContain(
+      t.expect(run.stdout).toContain(
         "[auto-pair] approved request=retry-cli client=openclaw-cli mode=cli",
       );
-      expect(run.stdout).toContain("watcher deadline reached approvals=1");
-      expect(fs.readFileSync(stateFile, "utf-8").trim()).toBe("2");
-      expect(fs.readFileSync(approveLog, "utf-8").trim().split("\n")).toEqual(["retry-cli"]);
+      t.expect(run.stdout).toContain("watcher deadline reached approvals=1");
+      t.expect(fs.readFileSync(stateFile, "utf-8").trim()).toBe("2");
+      t.expect(fs.readFileSync(approveLog, "utf-8").trim().split("\n")).toEqual(["retry-cli"]);
       const markerRe = /fast-reentry bumped polls=3 /g;
-      expect(run.stdout.match(markerRe)?.length).toBe(1);
-      expect(run.stdout).toContain("[auto-pair] fast-reentry bumped polls=3 approved=0 mode=fast");
+      t.expect(run.stdout.match(markerRe)?.length).toBe(1);
+      t.expect(run.stdout).toContain("[auto-pair] fast-reentry bumped polls=3 approved=0 mode=fast");
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }

--- a/test/agents/openclaw/runtime/nemoclaw-start.test.ts
+++ b/test/agents/openclaw/runtime/nemoclaw-start.test.ts
@@ -1178,7 +1178,9 @@ describe.concurrent("nemoclaw-start auto-pair slow-mode keepalive (#4263)", () =
     return autoPairPythonScript(src);
   }
 
-  it("stays fast through browser pairing and slows only after the canonical CLI baseline", async (t) => {
+  it("stays fast through browser pairing and slows only after the canonical CLI baseline", async ({
+    expect,
+  }) => {
     const { tmpDir, fakeOpenclaw, approveLog, stateDir } = setupLateCliFixture(
       "nemoclaw-auto-pair-slow-",
     );
@@ -1197,22 +1199,22 @@ describe.concurrent("nemoclaw-start auto-pair slow-mode keepalive (#4263)", () =
         },
         timeout: 30_000,
       });
-      t.expect(run.stdout).toContain(
+      expect(run.stdout).toContain(
         "[auto-pair] approved request=browser-pair client=openclaw-control-ui mode=webchat",
       );
-      t.expect(run.stdout).not.toContain("browser pairing converged");
+      expect(run.stdout).not.toContain("browser pairing converged");
       // Concurrent late wave is handled before the fast-to-slow transition.
-      t.expect(run.stdout).toContain("[auto-pair] approved request=late-cli client=cli mode=cli");
-      t.expect(run.stdout).toContain("[auto-pair] approved request=late-cli-b client=cli mode=cli");
-      t.expect(run.stdout).toContain("watcher deadline reached approvals=3");
-      t.expect(run.stdout).toContain(
+      expect(run.stdout).toContain("[auto-pair] approved request=late-cli client=cli mode=cli");
+      expect(run.stdout).toContain("[auto-pair] approved request=late-cli-b client=cli mode=cli");
+      expect(run.stdout).toContain("watcher deadline reached approvals=3");
+      expect(run.stdout).toContain(
         "[auto-pair] canonical CLI baseline settled; entering slow-mode approvals=3",
       );
-      t.expect(run.stdout).toContain("[auto-pair] fast-reentry bumped polls=3 approved=3 mode=fast");
+      expect(run.stdout).toContain("[auto-pair] fast-reentry bumped polls=3 approved=3 mode=fast");
       const approvedAt = run.stdout.indexOf("approved request=late-cli-b");
       const settledAt = run.stdout.indexOf("canonical CLI baseline settled");
-      t.expect(settledAt).toBeGreaterThan(approvedAt);
-      t.expect(fs.readFileSync(approveLog, "utf-8").trim().split("\n")).toEqual([
+      expect(settledAt).toBeGreaterThan(approvedAt);
+      expect(fs.readFileSync(approveLog, "utf-8").trim().split("\n")).toEqual([
         "browser-pair",
         "late-cli",
         "late-cli-b",
@@ -1222,7 +1224,7 @@ describe.concurrent("nemoclaw-start auto-pair slow-mode keepalive (#4263)", () =
     }
   }, 40_000);
 
-  it("rejects unknown clients in slow-mode keepalive", async (t) => {
+  it("rejects unknown clients in slow-mode keepalive", async ({ expect }) => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-auto-pair-slow-evil-"));
     const fakeOpenclaw = path.join(tmpDir, "openclaw");
     const stateDir = path.join(tmpDir, "state");
@@ -1282,18 +1284,17 @@ exit 2
         },
         timeout: 30_000,
       });
-      t.expect(run.stdout).toContain(
+      expect(run.stdout).toContain(
         "[auto-pair] canonical CLI baseline settled; entering slow-mode approvals=0",
       );
-      t.expect(run.stdout).toContain("[auto-pair] rejected unknown client=evil-client mode=unknown");
-      // Critical: never approved.
-      t.expect(fs.existsSync(approveLog)).toBe(false);
+      expect(run.stdout).toContain("[auto-pair] rejected unknown client=evil-client mode=unknown");
+      expect(fs.existsSync(approveLog)).toBe(false);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   }, 40_000);
 
-  it("rejects malformed CLI scope request payloads", async (t) => {
+  it("rejects malformed CLI scope request payloads", async ({ expect }) => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-auto-pair-malformed-"));
     const fakeOpenclaw = path.join(tmpDir, "openclaw");
     const approveLog = path.join(tmpDir, "approvals.log");
@@ -1339,17 +1340,17 @@ exit 2
         },
         timeout: 20_000,
       });
-      t.expect(run.stdout).toContain(
+      expect(run.stdout).toContain(
         "[auto-pair] rejected malformed scopes client=openclaw-cli mode=cli",
       );
-      t.expect(run.stdout).toContain("watcher deadline reached approvals=0");
-      t.expect(fs.existsSync(approveLog)).toBe(false);
+      expect(run.stdout).toContain("watcher deadline reached approvals=0");
+      expect(fs.existsSync(approveLog)).toBe(false);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   }, 30_000);
 
-  it("rejects disallowed CLI admin scope requests", async (t) => {
+  it("rejects disallowed CLI admin scope requests", async ({ expect }) => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-auto-pair-admin-"));
     const fakeOpenclaw = path.join(tmpDir, "openclaw");
     const maliciousPolicyDir = path.join(tmpDir, "malicious-policy");
@@ -1409,17 +1410,17 @@ exit 2
         },
         timeout: 20_000,
       });
-      t.expect(run.stdout).toContain(
+      expect(run.stdout).toContain(
         "[auto-pair] rejected disallowed scopes=['operator.admin'] client=openclaw-cli mode=cli",
       );
-      t.expect(run.stdout).toContain("watcher deadline reached approvals=0");
-      t.expect(fs.existsSync(approveLog)).toBe(false);
+      expect(run.stdout).toContain("watcher deadline reached approvals=0");
+      expect(fs.existsSync(approveLog)).toBe(false);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   }, 30_000);
 
-  it("keeps fast polling when no canonical CLI baseline appears (#10269)", async (t) => {
+  it("keeps fast polling when no canonical CLI baseline appears (#10269)", async ({ expect }) => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-auto-pair-slow-fastdl-"));
     const fakeOpenclaw = path.join(tmpDir, "openclaw");
     const approveLog = path.join(tmpDir, "approvals.log");
@@ -1455,18 +1456,20 @@ exit 2
         },
         timeout: 20_000,
       });
-      t.expect(run.stdout).not.toContain("entering slow-mode");
-      t.expect(run.stdout).toContain(
+      expect(run.stdout).not.toContain("entering slow-mode");
+      expect(run.stdout).toContain(
         '[auto-pair-status] {"schemaVersion":1,"state":"request-not-produced"}',
       );
-      t.expect(run.stdout).toContain("watcher deadline reached approvals=0");
-      t.expect(fs.existsSync(approveLog)).toBe(false);
+      expect(run.stdout).toContain("watcher deadline reached approvals=0");
+      expect(fs.existsSync(approveLog)).toBe(false);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   }, 30_000);
 
-  it("keeps a rejected sticky request in fast mode without approving it (#10269)", async (t) => {
+  it("keeps a rejected sticky request in fast mode without approving it (#10269)", async ({
+    expect,
+  }) => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-auto-pair-sticky-"));
     const fakeOpenclaw = path.join(tmpDir, "openclaw");
     const approveLog = path.join(tmpDir, "approvals.log");
@@ -1511,17 +1514,18 @@ exit 2
         },
         timeout: 20_000,
       });
-      t.expect(run.stdout).not.toContain("entering slow-mode");
-      t.expect(run.stdout).toContain("[auto-pair] rejected unknown client=evil-client mode=unknown");
-      t.expect(run.stdout).toContain("watcher deadline reached approvals=0");
-      // Unknown client was never approved.
-      t.expect(fs.existsSync(approveLog)).toBe(false);
+      expect(run.stdout).not.toContain("entering slow-mode");
+      expect(run.stdout).toContain("[auto-pair] rejected unknown client=evil-client mode=unknown");
+      expect(run.stdout).toContain("watcher deadline reached approvals=0");
+      expect(fs.existsSync(approveLog)).toBe(false);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   }, 30_000);
 
-  it("bounds the openclaw CLI invocation so a wedged child cannot pin the watcher", async (t) => {
+  it("bounds the openclaw CLI invocation so a wedged child cannot pin the watcher", async ({
+    expect,
+  }) => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-auto-pair-runto-"));
     const fakeOpenclaw = path.join(tmpDir, "openclaw");
 
@@ -1555,19 +1559,17 @@ exit 0
         timeout: 20_000,
       });
       const elapsedMs = Date.now() - start;
-      // The watcher exited via DEADLINE, not via a wedged subprocess.
-      t.expect(run.stdout).toContain("watcher deadline reached approvals=0");
-      // Timeout log was emitted for at least one stuck `devices list`.
-      t.expect(run.stdout).toContain("[auto-pair] timeout calling devices list");
-      // Sanity: if the timeout didn't fire, the first `sleep 2` would
-      // already exceed this cap before the watcher could reach its deadline.
-      t.expect(elapsedMs).toBeLessThan(1_800);
+      expect(run.stdout).toContain("watcher deadline reached approvals=0");
+      expect(run.stdout).toContain("[auto-pair] timeout calling devices list");
+      expect(elapsedMs).toBeLessThan(1_800);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   }, 30_000);
 
-  it.sequential("retries a transient approve timeout instead of permanently handling the requestId", async (t) => {
+  it.sequential("retries a transient approve timeout instead of permanently handling the requestId", async ({
+    expect,
+  }) => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-auto-pair-aretry-"));
     const fakeOpenclaw = path.join(tmpDir, "openclaw");
     const stateFile = path.join(tmpDir, "approve-count");
@@ -1630,21 +1632,19 @@ exit 2
         },
         timeout: 30_000,
       });
-      // Timeout was logged for the first attempt.
-      t.expect(run.stdout).toContain("[auto-pair] timeout calling devices approve");
-      // Retry succeeded on the second attempt.
-      t.expect(run.stdout).toContain(
+      expect(run.stdout).toContain("[auto-pair] timeout calling devices approve");
+      expect(run.stdout).toContain(
         "[auto-pair] approved request=flaky-cli client=openclaw-cli mode=cli",
       );
-      // The approve log records exactly one successful approval (the
-      // retry, not the hung first attempt).
-      t.expect(fs.readFileSync(approveLog, "utf-8").trim().split("\n")).toEqual(["flaky-cli"]);
+      expect(fs.readFileSync(approveLog, "utf-8").trim().split("\n")).toEqual(["flaky-cli"]);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   }, 40_000);
 
-  it("retries a non-zero approve failure without counting it as approved or re-arming fast-reentry", async (t) => {
+  it("retries a non-zero approve failure without counting it as approved or re-arming fast-reentry", async ({
+    expect,
+  }) => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-auto-pair-afail-"));
     const fakeOpenclaw = path.join(tmpDir, "openclaw");
     const stateFile = path.join(tmpDir, "approve-count");
@@ -1701,18 +1701,18 @@ exit 2
         },
         timeout: 20_000,
       });
-      t.expect(run.stdout).toContain(
+      expect(run.stdout).toContain(
         "[auto-pair] approve failed request=retry-cli: temporary approve failure",
       );
-      t.expect(run.stdout).toContain(
+      expect(run.stdout).toContain(
         "[auto-pair] approved request=retry-cli client=openclaw-cli mode=cli",
       );
-      t.expect(run.stdout).toContain("watcher deadline reached approvals=1");
-      t.expect(fs.readFileSync(stateFile, "utf-8").trim()).toBe("2");
-      t.expect(fs.readFileSync(approveLog, "utf-8").trim().split("\n")).toEqual(["retry-cli"]);
+      expect(run.stdout).toContain("watcher deadline reached approvals=1");
+      expect(fs.readFileSync(stateFile, "utf-8").trim()).toBe("2");
+      expect(fs.readFileSync(approveLog, "utf-8").trim().split("\n")).toEqual(["retry-cli"]);
       const markerRe = /fast-reentry bumped polls=3 /g;
-      t.expect(run.stdout.match(markerRe)?.length).toBe(1);
-      t.expect(run.stdout).toContain("[auto-pair] fast-reentry bumped polls=3 approved=0 mode=fast");
+      expect(run.stdout.match(markerRe)?.length).toBe(1);
+      expect(run.stdout).toContain("[auto-pair] fast-reentry bumped polls=3 approved=0 mode=fast");
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

Reduces the focused `nemoclaw-start auto-pair slow-mode keepalive` suite from 8.98s to 6.27s locally (30% faster) while preserving all nine cases. This changes test scheduling only; production behavior is unchanged.

## Reason

Eight independent child-process fixtures spent most of their wall time waiting but ran serially. Bounded overlap removes avoidable idle time while the one timeout-sensitive retry fixture stays serial for deterministic timing.

## Changes

- Run the independent slow-mode cases concurrently with a file-local concurrency cap of four.
- Use the async child-process API so Vitest can overlap the fixtures without changing their commands or assertions.
- Keep the transient approve-timeout retry case sequential after stress testing exposed host-load sensitivity.
- Lower the test file's line-count budget from 4,352 to 4,348.

## Verification

- `npx vitest run --project integration test/agents/openclaw/runtime/nemoclaw-start.test.ts -t "nemoclaw-start auto-pair slow-mode keepalive" --sequence.shuffle --sequence.seed=11601` on `origin/main` — 9/9 passed; 8.98s test time.
- The same command on this branch — 9/9 passed; 6.27s test time (30% faster).
- The same focused run with seeds `11602` and `11603` — 9/9 passed in both runs; 6.18s and 6.03s test time.
- `npx vitest run --project integration test/agents/openclaw/runtime/nemoclaw-start.test.ts` — 122/122 passed.
- `npm --prefix nemoclaw run build` — passed.
- `npm run build:cli` — passed.
- `NODE_OPTIONS=--max-old-space-size=8192 npm run check:diff` — passed, including formatting, repository checks, source-shape and growth guards, CLI typecheck, and secret scan.
- GitHub commit verification — all commits are Verified.
- Documentation review — no documentation changes needed because only internal test scheduling changes.
- Diff review — no secrets, API keys, or credentials added.

---
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Updated concurrent auto-pair tests to use test-local assertion context.
  - Preserved sequential retry coverage and existing test behavior.
  - Updated the test file size budget to reflect the current test suite.
  - Removed redundant explanatory comments from test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->