### PR TITLE
fix(e2e): default protected images to sandbox user

### DIFF
--- a/scripts/checks/build-protected-managed-images.sh
+++ b/scripts/checks/build-protected-managed-images.sh
@@ -20,7 +20,7 @@ source_root="$PWD"
 cache_to=""
 cache_from=""
 audit_evidence_from=""
-runtime_user="root"
+runtime_user="sandbox"
 while (($# > 0)); do
   case "$1" in
     --audit-evidence-from)

--- a/test/platform/images/protected-managed-image-build-script.test.ts
+++ b/test/platform/images/protected-managed-image-build-script.test.ts
@@ -305,7 +305,7 @@ beforeEach(() => {
   registryLog = path.join(testRoot, "registry.log");
   registryStatus = "404";
   teeFailureMode = "";
-  imageUser = "root";
+  imageUser = "sandbox";
   mkdirSync(stubBin);
   writeExecutable(
     "docker",
@@ -353,28 +353,33 @@ describe("protected managed-image source-root boundary", () => {
 });
 
 describe("protected managed-image build-cache boundary", () => {
-  it("keeps the legacy root runtime contract unless a reviewed transition selects sandbox", () => {
+  it.each(["linux/amd64", "linux/arm64"])(
+    "builds every agent as sandbox by default on %s",
+    (platform) => {
+      stubBuildInvocation();
+
+      const result = runBuild(REPO_ROOT, [], platform);
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(recordedBuildInvocations()).toHaveLength(3);
+      expect(
+        recordedBuildInvocations().every((invocation) =>
+          invocation.includes("--build-arg NEMOCLAW_MANAGED_IMAGE_RUNTIME_USER=sandbox"),
+        ),
+      ).toBe(true);
+    },
+  );
+
+  it("preserves an explicitly selected runtime user", () => {
     stubBuildInvocation();
+    imageUser = "root";
+    const result = runBuild(REPO_ROOT, ["--runtime-user", "root"]);
 
-    const legacy = runBuild(REPO_ROOT);
-
-    expect(legacy.status, legacy.stderr).toBe(0);
+    expect(result.status, result.stderr).toBe(0);
     expect(recordedBuildInvocations()).toHaveLength(3);
     expect(
       recordedBuildInvocations().every((invocation) =>
         invocation.includes("--build-arg NEMOCLAW_MANAGED_IMAGE_RUNTIME_USER=root"),
-      ),
-    ).toBe(true);
-
-    writeFileSync(dockerLog, "", "utf8");
-    imageUser = "sandbox";
-    const transitioned = runBuild(REPO_ROOT, ["--runtime-user", "sandbox"]);
-
-    expect(transitioned.status, transitioned.stderr).toBe(0);
-    expect(recordedBuildInvocations()).toHaveLength(3);
-    expect(
-      recordedBuildInvocations().every((invocation) =>
-        invocation.includes("--build-arg NEMOCLAW_MANAGED_IMAGE_RUNTIME_USER=sandbox"),
       ),
     ).toBe(true);
   });
@@ -383,7 +388,7 @@ describe("protected managed-image build-cache boundary", () => {
     stubBuildInvocation();
     imageUser = "root";
 
-    const result = runBuild(REPO_ROOT, ["--runtime-user", "sandbox"]);
+    const result = runBuild(REPO_ROOT);
 
     expect(result.status, result.stderr).toBe(1);
     expect(recordedBuildInvocations()).toHaveLength(1);
@@ -411,12 +416,12 @@ describe("protected managed-image build-cache boundary", () => {
     expect(recordedBuildInvocation("openclaw")).toContain("--platform linux/arm64");
     expect(recordedBuildInvocation("openclaw")).toContain("--build-arg TARGETARCH=arm64");
     expect(recordedBuildInvocation("openclaw")).toContain(
-      "--build-arg NEMOCLAW_MANAGED_IMAGE_RUNTIME_USER=root",
+      "--build-arg NEMOCLAW_MANAGED_IMAGE_RUNTIME_USER=sandbox",
     );
     expect(recordedBuildInvocation("hermes")).toContain("--platform linux/arm64");
     expect(recordedBuildInvocation("hermes")).toContain("--build-arg TARGETARCH=arm64");
     expect(recordedBuildInvocation("hermes")).toContain(
-      "--build-arg NEMOCLAW_MANAGED_IMAGE_RUNTIME_USER=root",
+      "--build-arg NEMOCLAW_MANAGED_IMAGE_RUNTIME_USER=sandbox",
     );
     expect(recordedBuildInvocation("langchain-deepagents-code")).toContain(
       "--platform linux/arm64",
@@ -425,7 +430,7 @@ describe("protected managed-image build-cache boundary", () => {
       "--build-arg TARGETARCH=arm64",
     );
     expect(recordedBuildInvocation("langchain-deepagents-code")).toContain(
-      "--build-arg NEMOCLAW_MANAGED_IMAGE_RUNTIME_USER=root",
+      "--build-arg NEMOCLAW_MANAGED_IMAGE_RUNTIME_USER=sandbox",
     );
   });
 


### PR DESCRIPTION
## Outcome

Protected managed-image builds select the non-root `sandbox` user when the caller omits `--runtime-user`. Both startup architectures can now reach Hermes qualification without violating its Dockerfile's non-root requirement.

## Reason

The shared builder still defaulted to `root` after the managed runtime contract moved to `sandbox`. The multiarch startup workflow omitted the option, while GPU qualification already selected `sandbox` explicitly.

The same Hermes build failure occurred on both architectures in [PR #11487 E2E](https://github.com/NVIDIA/NemoClaw/actions/runs/34666235561) and [main E2E at bb6800b8](https://github.com/NVIDIA/NemoClaw/actions/runs/34670833866). This dependency unblocks #11487. Missing `contracts.json` was a consequence of the failed build, not a separate cause.

## Changes

- Change the shared builder's default to `sandbox`; preserve explicit selection and final image-user validation.
- Exercise the default for all three agents on AMD64 and ARM64. Reject an image reporting `root` under the default contract.
- Preserve cache, retry, digest, cohort, credential, and cleanup controls. GPU qualification already passes the same user explicitly. No new mechanism or supported runtime is introduced.

## Verification

- `npx --no-install vitest run --project integration test/platform/images/protected-managed-image-build-script.test.ts` — 37 tests passed.
- `npm run build:cli` and `npm --prefix nemoclaw run build` — passed.
- Normal pre-commit and commit-msg hooks — passed, including ShellCheck and secret scanning.
- Normal pre-push publication validation and CLI, plugin, and JavaScript-config TypeScript checks — passed with the canonical base `bb6800b8fbb15b962822a1ef92a460dd1eab0229`.
- `git diff --check` — passed. The diff contains no secrets, API keys, or credentials.
- The deterministic risk plan selects `managed-image-multiarch-startup`; live candidate evidence is pending.

## Review notes

NVIDIA/NemoClaw commit `14391108763ea81e30c6e8da094e67a0161a95cd` changes the sensitive path `scripts/checks/build-protected-managed-images.sh`. Full-diff self-review found no actionable correctness or security findings. The change preserves Hermes' non-root check and rejects a mismatched final image user. This is not independent review or maintainer approval.

Local Advisor could not start its first specialist: OpenShell reported `sandbox is not ready` during creation of `pr-adv-5f1e35416ea5`. Cleanup deleted that sandbox. No specialist review completed. The authorized alternative review path is in use; independent automated review, CI, and selected E2E remain pending. The contributor doctor also hit the default Node heap limit; publication validation uses its recommended 8 GiB heap. Both missing build outputs were subsequently built. Global CLI exposure was not changed.

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Protected managed-image builds now use `sandbox` as the default runtime user.
  * Explicit runtime-user selections, including `root`, remain supported.
  * Image user validation and architecture-specific runtime checks remain enforced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->