### PR TITLE
fix(automation): separate OpenShell uploads from startup commands

### DIFF
--- a/test/automation/pull-requests/pr-merge-conflict-fixer.test.ts
+++ b/test/automation/pull-requests/pr-merge-conflict-fixer.test.ts
@@ -676,7 +676,7 @@ describe("PR merge conflict fixer", () => {
 
   it("runs sandbox phases without host credentials (#7542)", () => {
     const env = resolverEnvironment();
-    const tools = resolverTools(["", "", "", "", "sandbox-test\n", ""]);
+    const tools = resolverTools(["", "", "", "", "", "sandbox-test\n", ""]);
 
     createResolutionSandbox(env, tools);
     runResolutionTask(env, tools);
@@ -684,7 +684,7 @@ describe("PR merge conflict fixer", () => {
     deleteResolutionSandbox(env, tools);
 
     const calls = vi.mocked(tools.run).mock.calls;
-    expect(calls).toHaveLength(6);
+    expect(calls).toHaveLength(7);
     expect(required(calls[0], "missing sandbox create call")[1]).toEqual(
       expect.arrayContaining([
         "sandbox",
@@ -700,7 +700,20 @@ describe("PR merge conflict fixer", () => {
         "--no-git-ignore",
       ]),
     );
-    expect(required(calls[1], "missing Pi task call")[1]).toEqual(
+    expect(required(calls[0], "missing sandbox create call")[1]).not.toContain("--");
+    expect(required(calls[1], "missing startup check call")[1]).toEqual([
+      "sandbox",
+      "exec",
+      "--name",
+      "sandbox-test",
+      "--",
+      "/usr/bin/git",
+      "-C",
+      "/sandbox/repo",
+      "status",
+      "--short",
+    ]);
+    expect(required(calls[2], "missing Pi task call")[1]).toEqual(
       expect.arrayContaining([
         "sandbox",
         "exec",
@@ -714,7 +727,7 @@ describe("PR merge conflict fixer", () => {
         "--offline",
       ]),
     );
-    const exportArgs = required(calls[2], "missing patch export call")[1];
+    const exportArgs = required(calls[3], "missing patch export call")[1];
     expect(exportArgs).toEqual(
       expect.arrayContaining([
         "sandbox",
@@ -726,15 +739,15 @@ describe("PR merge conflict fixer", () => {
     );
     expect(exportArgs.join("\n")).toContain("git ls-files -u");
     expect(exportArgs.join("\n")).toContain("git diff --binary");
-    expect(required(calls[3], "missing patch download call")[1]).toEqual([
+    expect(required(calls[4], "missing patch download call")[1]).toEqual([
       "sandbox",
       "download",
       "sandbox-test",
       "/sandbox/resolution.patch",
       `${required(env.ARTIFACT_DIR, "ARTIFACT_DIR")}/`,
     ]);
-    expect(required(calls[4], "missing sandbox list call")[2].capture).toBe(true);
-    expect(required(calls[5], "missing sandbox delete call")[1]).toEqual([
+    expect(required(calls[5], "missing sandbox list call")[2].capture).toBe(true);
+    expect(required(calls[6], "missing sandbox delete call")[1]).toEqual([
       "sandbox",
       "delete",
       "sandbox-test",

--- a/test/generation/post-merge-docs.test.ts
+++ b/test/generation/post-merge-docs.test.ts
@@ -350,7 +350,7 @@ const credentials =
   "GH_TOKEN GITHUB_TOKEN NVIDIA_API_KEY OPENAI_API_KEY POST_MERGE_DOCS_API_KEY PR_REVIEW_ADVISOR_API_KEY".split(
     " ",
   );
-type RunnerStage = "create" | "agent" | "export" | "download";
+type RunnerStage = "create" | "bootstrap" | "agent" | "export" | "download";
 function runnerFixture(phase: "author" | "review", startTag = rangeStartTag) {
   const { mainSha, source } = sourceFixture();
   fs.writeFileSync(path.join(source, "docs/guide.mdx"), "later\n");
@@ -396,10 +396,14 @@ function runnerTools(
     author: (repository: string) =>
       fs.writeFileSync(path.join(repository, "docs/guide.mdx"), "authored\n"),
     agentArgs: [] as readonly string[],
+    bootstrapArgs: [] as readonly string[],
     createArgs: [] as readonly string[],
     deleted: false,
   };
   const handlers: Record<string, (args: readonly string[]) => unknown> = {
+    bootstrap: (args) => {
+      state.bootstrapArgs = args;
+    },
     create: (args) => {
       state.createArgs = args;
       fs.cpSync(path.join(root, "work/repo"), sandbox, { recursive: true });
@@ -441,11 +445,11 @@ function runnerTools(
       state.deleted = true;
     },
   };
-  const commands: Record<string, string> = { bash: "export", node: "agent" };
+  const commands: Record<string, string> = { bash: "export", git: "bootstrap", node: "agent" };
   const run: OpenShellTools["run"] = (_command, args, options) => {
     for (const name of credentials) expect(options.env).not.toHaveProperty(name);
     const executable = path.basename(args[args.indexOf("--") + 1] ?? "");
-    const stage = commands[executable] ?? args[1];
+    const stage = args[1] === "create" ? "create" : (commands[executable] ?? args[1]);
     expect(stage).not.toBe(failure);
     return String(handlers[stage](args) ?? "");
   };
@@ -1029,6 +1033,19 @@ describe("post-merge documentation runner", () => {
     );
     expect(state.createArgs.filter((argument) => argument === "--upload")).toHaveLength(3);
     expect(state.createArgs).not.toContain("--driver-config-json");
+    expect(state.createArgs).not.toContain("--");
+    expect(state.bootstrapArgs).toEqual([
+      "sandbox",
+      "exec",
+      "--name",
+      "docs-author",
+      "--",
+      "/usr/bin/git",
+      "-C",
+      "/sandbox/repo",
+      "status",
+      "--short",
+    ]);
     expect(state.agentArgs.join("\n")).not.toContain("GIT_DIR=");
     expect(state.deleted).toBe(true);
   });
@@ -1137,7 +1154,7 @@ describe("post-merge documentation runner", () => {
     expect(() => executePostMergeDocs(input.env, tools)).toThrow("bounded regular file");
     expect(state.deleted).toBe(true);
   });
-  it.each<RunnerStage>(["create", "agent", "export", "download"])(
+  it.each<RunnerStage>(["create", "bootstrap", "agent", "export", "download"])(
     "deletes the sandbox after %s fails",
     (stage) => {
       const input = runnerFixture("author");
@@ -1151,6 +1168,7 @@ describe("post-merge documentation runner", () => {
     const { run, tools } = runnerTools(input);
     tools.run = vi
       .fn<OpenShellTools["run"]>()
+      .mockImplementationOnce(run)
       .mockImplementationOnce(run)
       .mockImplementationOnce(run)
       .mockImplementationOnce(run)
@@ -1171,6 +1189,7 @@ describe("post-merge documentation runner", () => {
     const { run, tools } = runnerTools(input);
     tools.run = vi
       .fn<OpenShellTools["run"]>()
+      .mockImplementationOnce(run)
       .mockImplementationOnce(run)
       .mockImplementationOnce(() => {
         throw new Error("agent failed");

--- a/tools/openshell-agent/runtime.mts
+++ b/tools/openshell-agent/runtime.mts
@@ -399,6 +399,7 @@ export function createOpenShellSandbox(
   const driverConfigArgs = input.driverConfig
     ? ["--driver-config-json", JSON.stringify(input.driverConfig)]
     : [];
+  const commandArgs = input.command.length > 0 ? ["--", ...input.command] : [];
   tools.run(
     "openshell",
     [
@@ -413,8 +414,7 @@ export function createOpenShellSandbox(
       input.policyPath,
       ...uploadOptions,
       "--no-tty",
-      "--",
-      ...input.command,
+      ...commandArgs,
     ],
     { env: credentialFreeEnvironment(env) },
   );

--- a/tools/post-merge-docs/run.mts
+++ b/tools/post-merge-docs/run.mts
@@ -10,6 +10,7 @@ import { pathToFileURL } from "node:url";
 
 import {
   configureOpenShellInference,
+  credentialFreeEnvironment,
   createOpenShellSandbox,
   defaultOpenShellTools,
   deleteOpenShellSandbox,
@@ -223,6 +224,16 @@ function create(env: NodeJS.ProcessEnv, tools: OpenShellTools): void {
   const work = required(env.POST_MERGE_DOCS_WORKDIR, "POST_MERGE_DOCS_WORKDIR");
   const config = required(env.POST_MERGE_DOCS_CONFIG_DIR, "POST_MERGE_DOCS_CONFIG_DIR");
   const review = current === "review";
+  const sandboxName = required(env.SANDBOX_NAME, "SANDBOX_NAME");
+  const startupCommand = review
+    ? [
+        "/usr/bin/git",
+        "--git-dir=/sandbox/repo/.git",
+        "--work-tree=/sandbox/repo",
+        "status",
+        "--short",
+      ]
+    : ["/usr/bin/git", "-C", "/sandbox/repo", "status", "--short"];
   const policy =
     current === "author"
       ? "pr-merge-conflict-fixer/policy.yaml"
@@ -230,17 +241,9 @@ function create(env: NodeJS.ProcessEnv, tools: OpenShellTools): void {
   createOpenShellSandbox(
     env,
     {
-      command: review
-        ? [
-            "/usr/bin/git",
-            "--git-dir=/sandbox/repo/.git",
-            "--work-tree=/sandbox/repo",
-            "status",
-            "--short",
-          ]
-        : ["/usr/bin/git", "-C", "/sandbox/repo", "status", "--short"],
+      command: review ? startupCommand : [],
       image: required(env.PI_IMAGE, "PI_IMAGE"),
-      name: required(env.SANDBOX_NAME, "SANDBOX_NAME"),
+      name: sandboxName,
       policyPath: path.join(required(env.TRUSTED_CHECKOUT, "TRUSTED_CHECKOUT"), "tools", policy),
       driverConfig: review
         ? {
@@ -272,6 +275,13 @@ function create(env: NodeJS.ProcessEnv, tools: OpenShellTools): void {
     },
     tools,
   );
+  if (!review) {
+    execOpenShellSandbox(
+      credentialFreeEnvironment(env),
+      { command: startupCommand, name: sandboxName },
+      tools,
+    );
+  }
 }
 
 function run(env: NodeJS.ProcessEnv, tools: OpenShellTools): void {

--- a/tools/pr-merge-conflict-fixer/resolve.mts
+++ b/tools/pr-merge-conflict-fixer/resolve.mts
@@ -8,6 +8,7 @@ import { pathToFileURL } from "node:url";
 
 import {
   configureOpenShellInference as configureSharedOpenShellInference,
+  credentialFreeEnvironment,
   createOpenShellSandbox,
   defaultOpenShellTools,
   deleteOpenShellSandbox,
@@ -151,10 +152,12 @@ export function createResolutionSandbox(
   env: NodeJS.ProcessEnv,
   tools: ResolverTools = defaultOpenShellTools,
 ): void {
+  const sandboxName = required(env.SANDBOX_NAME, "SANDBOX_NAME");
+  const startupCommand = ["/usr/bin/git", "-C", "/sandbox/repo", "status", "--short"];
   createOpenShellSandbox(
     env,
     {
-      name: required(env.SANDBOX_NAME, "SANDBOX_NAME"),
+      name: sandboxName,
       image: required(env.PI_IMAGE, "PI_IMAGE"),
       policyPath: path.join(
         required(env.TRUSTED_CHECKOUT, "TRUSTED_CHECKOUT"),
@@ -172,8 +175,13 @@ export function createResolutionSandbox(
           destination: "/sandbox",
         },
       ],
-      command: ["/usr/bin/git", "-C", "/sandbox/repo", "status", "--short"],
+      command: [],
     },
+    tools,
+  );
+  execOpenShellSandbox(
+    credentialFreeEnvironment(env),
+    { command: startupCommand, name: sandboxName },
     tools,
   );
 }


### PR DESCRIPTION
## Outcome

OpenShell upload-backed automation now creates each sandbox before running its startup Git check. Post-merge documentation and merge-conflict repair no longer fail before candidate work when OpenShell rejects uploads combined with an inline command.

## Reason

OpenShell v0.0.116 rejects `sandbox create` when `--upload` and a trailing command are used together. The post-merge documentation author and merge-conflict resolver still used that removed command shape after the OpenShell migration.

### Related issues

Refs #10947

## Changes

- Make the shared OpenShell runtime omit the command separator when sandbox creation has no startup command.
- Create upload-backed author and conflict-resolution sandboxes without a command, then run the existing Git status check through a credential-free sandbox exec.
- Extend the existing automation tests to protect the two-step lifecycle and cleanup after a failed startup check.

## Verification

- `npx vitest run test/generation/post-merge-docs.test.ts test/automation/pull-requests/pr-merge-conflict-fixer.test.ts` — 81 tests passed.
- Repository pre-commit, commit-message, and pre-push hooks — passed.
- Reviewed the candidate diff — no secrets, API keys, or credentials.

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sandbox creation when no startup command is provided, avoiding unnecessary command separators.
  - Sandbox status checks now run separately with a credential-free environment.
  - Standardized startup behavior across review and author sandboxes.
  - Improved sandbox name handling during startup and cleanup workflows.

- **Tests**
  - Expanded coverage for sandbox startup checks, bootstrap execution, command arguments, patch retrieval, listing, and cleanup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->