### PR TITLE
fix(onboard): detect WSL Docker credential isolation from the caller's Docker selection

### DIFF
--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -193,12 +193,14 @@ The `docker_desktop_credential_store_headless` advisory means that the Docker cl
 
 Onboarding preflight prints this warning before the first image pull and then continues, on both fresh and resumed onboarding. NemoClaw reads the config from `$DOCKER_CONFIG/config.json` when `DOCKER_CONFIG` is set, and from `~/.docker/config.json` otherwise. On WSL, NemoClaw probes the credential helper with a read-only `list` call instead of relying on session markers, because WSLg can set `DISPLAY` in every WSL shell.
 
-On WSL, NemoClaw automatically uses a temporary credential-free Docker configuration for public managed image pulls, generated image builds, GPU probes, and local-inference probe images when all of these conditions apply:
+On WSL, NemoClaw automatically uses a temporary credential-free Docker configuration for the Docker commands that it runs itself: public managed image pre-pulls, generated image builds, GPU probes, and local-inference probe images. It does so when all of these conditions apply:
 
 - `DOCKER_HOST` is unset and the Docker context is `default`. NemoClaw reads `DOCKER_HOST`, `DOCKER_CONTEXT`, and `DOCKER_CONFIG` from the environment of the `$$nemoclaw` command. When `DOCKER_CONTEXT` is unset, it runs `docker context show`.
 - The client configuration named above selects the Docker Desktop credential helper.
 - The read-only helper probe fails.
 - The operation does not require registry credentials.
+
+The OpenShell gateway pulls the sandbox image through its own Docker socket and does not read the Docker client configuration.
 
 NemoClaw does not modify your Docker client configuration.
 It removes the temporary directory after the Docker operation.

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -195,8 +195,8 @@ Onboarding preflight prints this warning before the first image pull and then co
 
 On WSL, NemoClaw automatically uses a temporary credential-free Docker configuration for public managed image pulls, generated image builds, GPU probes, and local-inference probe images when all of these conditions apply:
 
-- The current Docker context is `default` and `DOCKER_HOST` is unset.
-- The client configuration selects the Docker Desktop credential helper.
+- `DOCKER_HOST` is unset and the Docker context is `default`. NemoClaw reads `DOCKER_HOST`, `DOCKER_CONTEXT`, and `DOCKER_CONFIG` from the environment of the `$$nemoclaw` command. When `DOCKER_CONTEXT` is unset, it runs `docker context show`.
+- The client configuration named above selects the Docker Desktop credential helper.
 - The read-only helper probe fails.
 - The operation does not require registry credentials.
 
@@ -204,7 +204,14 @@ NemoClaw does not modify your Docker client configuration.
 It removes the temporary directory after the Docker operation.
 If cleanup fails, the warning prints the exact credential-free directory; wait for Docker to finish using it, then remove that directory.
 
-An explicit Docker host, a non-default context, a responsive helper, a custom Dockerfile, and an operation that might require private-registry credentials continue to use the configured Docker client state.
+These cases continue to use the configured Docker client state:
+
+- An explicit Docker host.
+- A non-default context selected with `DOCKER_CONTEXT` or persisted by `docker context use`.
+- A responsive helper.
+- A custom Dockerfile.
+- An operation that might require private-registry credentials.
+
 Restore the Docker Desktop session or helper access for those operations.
 
 For a public-image-only retry outside the automatic WSL path, resume onboarding with a temporary isolated configuration:

--- a/src/lib/adapters/docker/client-isolation.ts
+++ b/src/lib/adapters/docker/client-isolation.ts
@@ -8,7 +8,7 @@ import path from "node:path";
 
 import { DOCKER_DESKTOP_CREDENTIAL_STORE_NAMES } from "../../domain/docker-host";
 import { isWsl } from "../../platform";
-import { buildSubprocessEnv } from "../../subprocess-env";
+import { buildDockerSubprocessEnv, buildSubprocessEnv } from "../../subprocess-env";
 import {
   dockerDesktopCredentialHelperResponds,
   readDockerCredentialStore,
@@ -52,6 +52,23 @@ export function createCredentialFreeDockerConfig(purpose: "portable" | "wsl-buil
     mode: 0o600,
   });
   return directory;
+}
+
+/**
+ * Docker client selection for the Docker commands NemoClaw runs during a
+ * sandbox create. The subprocess env forwards only DOCKER_HOST, while the
+ * Docker runner also honours the caller's DOCKER_CONTEXT and DOCKER_CONFIG, so
+ * credential isolation must detect against that selection.
+ */
+export function dockerClientSelectionEnv(
+  subprocessEnv: NodeJS.ProcessEnv,
+  hostEnv: NodeJS.ProcessEnv,
+): Record<string, string> {
+  const extra: Record<string, string> = {};
+  for (const [key, value] of Object.entries(subprocessEnv)) {
+    if (value !== undefined) extra[key] = value;
+  }
+  return buildDockerSubprocessEnv(hostEnv, extra.DOCKER_HOST ?? hostEnv.DOCKER_HOST, extra);
 }
 
 /** Restrict the host Docker build to environment values used by Docker itself. */

--- a/src/lib/onboard/__test-helpers__/sandbox-gpu-create-flow.ts
+++ b/src/lib/onboard/__test-helpers__/sandbox-gpu-create-flow.ts
@@ -228,51 +228,30 @@ export function createGpuFlowTestHarness(mocks: Record<string, ReturnType<typeof
     WSL_DISTRO_NAME: "Ubuntu",
   } as const;
   const remoteDockerHost = "tcp://remote-builder.example:2376";
-  const managedDockerConfigPreservationCases: readonly {
+  const managedDockerClientSelectionCases: readonly {
     readonly title: string;
-    readonly helperResponds: boolean;
     /** Docker selection in the caller environment of the nemoclaw command. */
     readonly callerSelection: { readonly DOCKER_HOST?: string; readonly DOCKER_CONTEXT?: string };
     /** The allowlisted part of that selection that reaches the sandbox create env. */
     readonly sandboxSelection: { readonly DOCKER_HOST?: string };
-    readonly contextStdout: string;
-    readonly contextShowCalls: number;
     readonly clientConfigForwarded: boolean;
   }[] = [
     {
-      title: "the Desktop helper responds",
-      helperResponds: true,
+      title: "the default context selects an unavailable Docker Desktop helper",
       callerSelection: {},
       sandboxSelection: {},
-      contextStdout: "default\n",
-      contextShowCalls: 1,
-      clientConfigForwarded: true,
-    },
-    {
-      title: "the persisted Docker context is not default",
-      helperResponds: false,
-      callerSelection: {},
-      sandboxSelection: {},
-      contextStdout: "remote-builder\n",
-      contextShowCalls: 1,
       clientConfigForwarded: true,
     },
     {
       title: "the caller selects a non-default DOCKER_CONTEXT",
-      helperResponds: false,
       callerSelection: { DOCKER_CONTEXT: "qa-explicit-host" },
       sandboxSelection: {},
-      contextStdout: "default\n",
-      contextShowCalls: 0,
       clientConfigForwarded: true,
     },
     {
       title: "an explicit remote Docker host is selected",
-      helperResponds: false,
       callerSelection: { DOCKER_HOST: remoteDockerHost },
       sandboxSelection: { DOCKER_HOST: remoteDockerHost },
-      contextStdout: "default\n",
-      contextShowCalls: 0,
       clientConfigForwarded: false,
     },
   ];
@@ -404,14 +383,10 @@ export function createGpuFlowTestHarness(mocks: Record<string, ReturnType<typeof
     return { createLifecycle };
   }
 
-  function captureCreateEnv(): {
-    env: NodeJS.ProcessEnv;
-    configExisted: boolean;
-  } {
-    const captured = { env: {} as NodeJS.ProcessEnv, configExisted: false };
+  function captureCreateEnv(): { env: NodeJS.ProcessEnv } {
+    const captured = { env: {} as NodeJS.ProcessEnv };
     mocks.streamSandboxCreate.mockImplementation((_exe, _args, env: NodeJS.ProcessEnv) => {
       captured.env = env;
-      captured.configExisted = fs.existsSync(String(env.DOCKER_CONFIG));
       return Promise.resolve({
         status: 0,
         output: "Created sandbox: alpha",
@@ -450,7 +425,7 @@ export function createGpuFlowTestHarness(mocks: Record<string, ReturnType<typeof
     DEFAULT_RUNTIME_SNAPSHOT: defaultRuntimeSnapshot,
     PORTABLE_RUNTIME_AUTHORITY: portableRuntimeAuthority,
     MANAGED_CREATE_SANDBOX_ENV: managedCreateSandboxEnv,
-    managedDockerConfigPreservationCases,
+    managedDockerClientSelectionCases,
     readySandboxGetResult,
     createSequencedOpenShellRunner,
     failNativeCreate,

--- a/src/lib/onboard/__test-helpers__/sandbox-gpu-create-flow.ts
+++ b/src/lib/onboard/__test-helpers__/sandbox-gpu-create-flow.ts
@@ -222,24 +222,58 @@ export function createGpuFlowTestHarness(mocks: Record<string, ReturnType<typeof
     runtimeDir: "/run/user/1001",
     socketPath: "/run/user/1001/podman/podman.sock",
   };
-  const managedDockerConfigPreservationCases = [
+  const managedCreateSandboxEnv = {
+    PATH: "/usr/bin",
+    OPENSHELL_GATEWAY: "1",
+    WSL_DISTRO_NAME: "Ubuntu",
+  } as const;
+  const remoteDockerHost = "tcp://remote-builder.example:2376";
+  const managedDockerConfigPreservationCases: readonly {
+    readonly title: string;
+    readonly helperResponds: boolean;
+    /** Docker selection in the caller environment of the nemoclaw command. */
+    readonly callerSelection: { readonly DOCKER_HOST?: string; readonly DOCKER_CONTEXT?: string };
+    /** The allowlisted part of that selection that reaches the sandbox create env. */
+    readonly sandboxSelection: { readonly DOCKER_HOST?: string };
+    readonly contextStdout: string;
+    readonly contextShowCalls: number;
+    readonly clientConfigForwarded: boolean;
+  }[] = [
     {
       title: "the Desktop helper responds",
       helperResponds: true,
-      dockerHost: "unix:///var/run/docker.sock",
+      callerSelection: {},
+      sandboxSelection: {},
       contextStdout: "default\n",
+      contextShowCalls: 1,
+      clientConfigForwarded: true,
     },
     {
-      title: "the Docker context is not default",
+      title: "the persisted Docker context is not default",
       helperResponds: false,
-      dockerHost: undefined,
+      callerSelection: {},
+      sandboxSelection: {},
       contextStdout: "remote-builder\n",
+      contextShowCalls: 1,
+      clientConfigForwarded: true,
+    },
+    {
+      title: "the caller selects a non-default DOCKER_CONTEXT",
+      helperResponds: false,
+      callerSelection: { DOCKER_CONTEXT: "qa-explicit-host" },
+      sandboxSelection: {},
+      contextStdout: "default\n",
+      contextShowCalls: 0,
+      clientConfigForwarded: true,
     },
     {
       title: "an explicit remote Docker host is selected",
       helperResponds: false,
-      dockerHost: "tcp://remote-builder.example:2376",
+      callerSelection: { DOCKER_HOST: remoteDockerHost },
+      sandboxSelection: { DOCKER_HOST: remoteDockerHost },
       contextStdout: "default\n",
+      contextShowCalls: 0,
+      clientConfigForwarded: false,
     },
   ];
   const temporaryDirectories: string[] = [];
@@ -327,7 +361,7 @@ export function createGpuFlowTestHarness(mocks: Record<string, ReturnType<typeof
     return dockerConfig;
   }
 
-  function attachManagedBootstrap(input: SandboxGpuCreateFlowInput): void {
+  function attachManagedBootstrap(input: SandboxGpuCreateFlowInput) {
     input.sandboxGpuConfig = {
       mode: "0",
       hostGpuDetected: false,
@@ -338,6 +372,24 @@ export function createGpuFlowTestHarness(mocks: Record<string, ReturnType<typeof
     };
     input.gpuRoutePlan = "none";
     input.initialGpuRoute = "none";
+    const createLifecycle = vi.fn((options: ManagedBootstrapRuntimeCreateLifecycleInput) => ({
+      launchArgv: options.launchArgv,
+      patch: createGpuPatchFixture(),
+      recoverUnfinished: async () => null,
+      prepareNetwork: async () => undefined,
+      runCreate: async <T>(
+        start: (held: {
+          readonly heldWorkloadArgv: readonly string[];
+          readonly bootstrapIdentity: string;
+        }) => Promise<{ readonly value: T }>,
+      ): Promise<T> =>
+        (
+          await start({
+            heldWorkloadArgv: options.heldWorkloadArgv,
+            bootstrapIdentity: options.bootstrapIdentity,
+          })
+        ).value,
+    }));
     input.managedBootstrap = {
       bootstrapIdentity: "e".repeat(64),
       stateRoot: "/tmp/nemoclaw-managed-bootstrap",
@@ -345,27 +397,11 @@ export function createGpuFlowTestHarness(mocks: Record<string, ReturnType<typeof
         identity: { id: "mxc" },
         bootstrap: {
           createOnboardRouting: () => ({ nativeFallbackHasCleanBaseline: false }),
-          createLifecycle: (options: ManagedBootstrapRuntimeCreateLifecycleInput) => ({
-            launchArgv: options.launchArgv,
-            patch: createGpuPatchFixture(),
-            recoverUnfinished: async () => null,
-            prepareNetwork: async () => undefined,
-            runCreate: async <T>(
-              start: (held: {
-                readonly heldWorkloadArgv: readonly string[];
-                readonly bootstrapIdentity: string;
-              }) => Promise<{ readonly value: T }>,
-            ): Promise<T> =>
-              (
-                await start({
-                  heldWorkloadArgv: options.heldWorkloadArgv,
-                  bootstrapIdentity: options.bootstrapIdentity,
-                })
-              ).value,
-          }),
+          createLifecycle,
         },
       },
     } as unknown as NonNullable<SandboxGpuCreateFlowInput["managedBootstrap"]>;
+    return { createLifecycle };
   }
 
   function captureCreateEnv(): {
@@ -413,6 +449,7 @@ export function createGpuFlowTestHarness(mocks: Record<string, ReturnType<typeof
     NVIDIA_SMI_FAILED_PROOF: nvidiaSmiFailedProof,
     DEFAULT_RUNTIME_SNAPSHOT: defaultRuntimeSnapshot,
     PORTABLE_RUNTIME_AUTHORITY: portableRuntimeAuthority,
+    MANAGED_CREATE_SANDBOX_ENV: managedCreateSandboxEnv,
     managedDockerConfigPreservationCases,
     readySandboxGetResult,
     createSequencedOpenShellRunner,

--- a/src/lib/onboard/managed-bootstrap/docker-runtime.test.ts
+++ b/src/lib/onboard/managed-bootstrap/docker-runtime.test.ts
@@ -473,6 +473,39 @@ describe("Docker managed-bootstrap GPU probe image", () => {
     );
   });
 
+  it("keeps the caller Docker configuration for the WSL pre-pull when a non-default DOCKER_CONTEXT selects a Docker Desktop credential store (#11533)", async () => {
+    const { dependencies, dockerRun } = gpuModeDependencies();
+    const seed = authority("openclaw");
+    const dockerConfig = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-docker-runtime-config-"));
+    temporaryStateRoots.push(dockerConfig);
+    fs.writeFileSync(
+      path.join(dockerConfig, "config.json"),
+      JSON.stringify({ credsStore: "desktop.exe" }),
+    );
+    const input: ManagedBootstrapRuntimeCreateLifecycleInput = {
+      ...compatibilityLifecycleInput(seed, dependencies),
+      dockerClientEnv: {
+        DOCKER_CONFIG: dockerConfig,
+        DOCKER_CONTEXT: "qa-explicit-host",
+        WSL_DISTRO_NAME: "Ubuntu",
+      },
+    };
+    sandboxCreateMocks.isDockerDesktopWslRuntime.mockReturnValue(true);
+    dockerAdapterMocks.imageInspect.mockReturnValue({ status: 1 });
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await runCompatibilityCreate(input, seed);
+
+    const pullEnv = dockerAdapterMocks.pullWithProgressWatchdog.mock.calls[0]?.[1]?.env;
+    expect(pullEnv?.DOCKER_CONFIG).toBe(dockerConfig);
+    expect(pullEnv?.DOCKER_CONTEXT).toBe("qa-explicit-host");
+    expect(pullEnv).not.toHaveProperty("DOCKER_HOST");
+    expect(dockerRun.mock.calls[0]?.[1]?.env).toEqual(
+      expect.objectContaining({ DOCKER_CONFIG: dockerConfig, DOCKER_CONTEXT: "qa-explicit-host" }),
+    );
+    expect(log.mock.calls.flat().join("\n")).not.toContain("credential-free");
+  });
+
   it("skips the pull when the exact WSL sandbox image is already local", async () => {
     const { dependencies, dockerRun } = gpuModeDependencies();
     const seed = authority("openclaw");

--- a/src/lib/onboard/sandbox-gpu-create-flow.test.ts
+++ b/src/lib/onboard/sandbox-gpu-create-flow.test.ts
@@ -67,12 +67,6 @@ vi.mock("../adapters/docker/exec", async (importOriginal) => ({
   dockerSpawnSync: mocks.dockerSpawnSync,
 }));
 
-vi.mock("../platform", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("../platform")>()),
-  isWsl: (opts: { env?: NodeJS.ProcessEnv; isWsl?: boolean } = {}) =>
-    typeof opts.isWsl === "boolean" ? opts.isWsl : Boolean(opts.env?.WSL_DISTRO_NAME),
-}));
-
 import {
   createGpuFlowDeps as createDeps,
   createGpuFlowInput as createInput,
@@ -110,7 +104,7 @@ const {
   DEFAULT_RUNTIME_SNAPSHOT,
   PORTABLE_RUNTIME_AUTHORITY,
   MANAGED_CREATE_SANDBOX_ENV,
-  managedDockerConfigPreservationCases,
+  managedDockerClientSelectionCases,
   readySandboxGetResult,
   createSequencedOpenShellRunner,
   failNativeCreate,
@@ -133,44 +127,10 @@ beforeEach(setupHarness);
 afterEach(resetHarness);
 
 describe("runSandboxGpuCreateFlow provider-owned managed create", () => {
-  it("isolates an unavailable WSL Docker Desktop helper during managed create (#10349)", async () => {
-    const dockerConfig = writeDesktopCredsStore();
-    const input = createInput();
-    attachManagedBootstrap(input);
-    input.hostEnv = { PATH: "/usr/bin", DOCKER_CONFIG: dockerConfig };
-    input.sandboxEnv = { ...MANAGED_CREATE_SANDBOX_ENV };
-    const captured = captureCreateEnv();
-    const deps = createDeps();
-    vi.mocked(deps.runCaptureOpenshell).mockImplementation((args) =>
-      args[1] === "get" ? "ID: alpha-sandbox-id\nState: Ready\n" : "alpha Ready",
-    );
-
-    await runSandboxGpuCreateFlow(input, deps);
-
-    expect(captured.env.DOCKER_CONFIG).toContain("nemoclaw-wsl-buildkit-docker-config-");
-    expect(captured.env.PATH).toBe("/usr/bin");
-    expect(captured.env.OPENSHELL_GATEWAY).toBe("1");
-    expect(captured.env).not.toHaveProperty("DOCKER_CONTEXT");
-    expect(captured.configExisted).toBe(true);
-    expect(fs.existsSync(String(captured.env.DOCKER_CONFIG))).toBe(false);
-    const contextShowEnv = mocks.dockerSpawnSync.mock.calls[0]?.[1]?.env;
-    expect(contextShowEnv?.DOCKER_CONFIG).toBe(dockerConfig);
-    expect(contextShowEnv).not.toHaveProperty("DOCKER_CONTEXT");
-    expect(contextShowEnv).not.toHaveProperty("DOCKER_HOST");
-    expect(mocks.streamSandboxCreate).toHaveBeenCalledOnce();
-  });
-
-  it.each(managedDockerConfigPreservationCases)(
-    "keeps the caller Docker config when $title (#10349)",
+  it.each(managedDockerClientSelectionCases)(
+    "hands the managed lifecycle the caller Docker selection when $title and leaves the create environment unchanged (#11533)",
     async (row) => {
       const dockerConfig = writeDesktopCredsStore();
-      mocks.helperResponds.mockReturnValue(row.helperResponds);
-      mocks.dockerSpawnSync.mockReturnValue({
-        status: 0,
-        error: undefined,
-        stdout: row.contextStdout,
-        stderr: "",
-      });
       const input = createInput();
       const { createLifecycle } = attachManagedBootstrap(input);
       input.hostEnv = { PATH: "/usr/bin", DOCKER_CONFIG: dockerConfig, ...row.callerSelection };
@@ -183,18 +143,18 @@ describe("runSandboxGpuCreateFlow provider-owned managed create", () => {
 
       await runSandboxGpuCreateFlow(input, deps);
 
-      expect(captured.env).not.toHaveProperty("DOCKER_CONFIG");
-      expect(captured.env).not.toHaveProperty("DOCKER_CONTEXT");
-      expect(captured.env.PATH).toBe("/usr/bin");
-      expect(captured.env.OPENSHELL_GATEWAY).toBe("1");
+      expect(captured.env).toEqual({ ...MANAGED_CREATE_SANDBOX_ENV, ...row.sandboxSelection });
+      expect(mocks.streamSandboxCreate).toHaveBeenCalledOnce();
+      expect(mocks.dockerSpawnSync).not.toHaveBeenCalled();
+      expect(mocks.helperResponds).not.toHaveBeenCalled();
       expect(fs.existsSync(dockerConfig)).toBe(true);
-      expect(mocks.dockerSpawnSync).toHaveBeenCalledTimes(row.contextShowCalls);
       const dockerClientEnv = createLifecycle.mock.calls[0]?.[0]?.dockerClientEnv ?? {};
       expect(dockerClientEnv.DOCKER_HOST).toBe(row.callerSelection.DOCKER_HOST);
       expect(dockerClientEnv.DOCKER_CONTEXT).toBe(row.callerSelection.DOCKER_CONTEXT);
       expect(dockerClientEnv.DOCKER_CONFIG).toBe(
         row.clientConfigForwarded ? dockerConfig : undefined,
       );
+      expect(dockerClientEnv.WSL_DISTRO_NAME).toBe(MANAGED_CREATE_SANDBOX_ENV.WSL_DISTRO_NAME);
     },
   );
 

--- a/src/lib/onboard/sandbox-gpu-create-flow.test.ts
+++ b/src/lib/onboard/sandbox-gpu-create-flow.test.ts
@@ -109,6 +109,7 @@ const {
   NVIDIA_SMI_FAILED_PROOF,
   DEFAULT_RUNTIME_SNAPSHOT,
   PORTABLE_RUNTIME_AUTHORITY,
+  MANAGED_CREATE_SANDBOX_ENV,
   managedDockerConfigPreservationCases,
   readySandboxGetResult,
   createSequencedOpenShellRunner,
@@ -133,17 +134,11 @@ afterEach(resetHarness);
 
 describe("runSandboxGpuCreateFlow provider-owned managed create", () => {
   it("isolates an unavailable WSL Docker Desktop helper during managed create (#10349)", async () => {
-    vi.stubEnv("DOCKER_CONTEXT", "ambient-remote-context");
-    vi.stubEnv("DOCKER_HOST", "tcp://ambient-remote.example:2376");
     const dockerConfig = writeDesktopCredsStore();
     const input = createInput();
     attachManagedBootstrap(input);
-    input.sandboxEnv = {
-      PATH: "/usr/bin",
-      OPENSHELL_GATEWAY: "1",
-      WSL_DISTRO_NAME: "Ubuntu",
-      DOCKER_CONFIG: dockerConfig,
-    };
+    input.hostEnv = { PATH: "/usr/bin", DOCKER_CONFIG: dockerConfig };
+    input.sandboxEnv = { ...MANAGED_CREATE_SANDBOX_ENV };
     const captured = captureCreateEnv();
     const deps = createDeps();
     vi.mocked(deps.runCaptureOpenshell).mockImplementation((args) =>
@@ -153,13 +148,15 @@ describe("runSandboxGpuCreateFlow provider-owned managed create", () => {
     await runSandboxGpuCreateFlow(input, deps);
 
     expect(captured.env.DOCKER_CONFIG).toContain("nemoclaw-wsl-buildkit-docker-config-");
-    expect(captured.env.DOCKER_CONFIG).not.toBe(dockerConfig);
     expect(captured.env.PATH).toBe("/usr/bin");
     expect(captured.env.OPENSHELL_GATEWAY).toBe("1");
+    expect(captured.env).not.toHaveProperty("DOCKER_CONTEXT");
     expect(captured.configExisted).toBe(true);
     expect(fs.existsSync(String(captured.env.DOCKER_CONFIG))).toBe(false);
-    expect(mocks.dockerSpawnSync.mock.calls[0]?.[1]?.env).not.toHaveProperty("DOCKER_CONTEXT");
-    expect(mocks.dockerSpawnSync.mock.calls[0]?.[1]?.env).not.toHaveProperty("DOCKER_HOST");
+    const contextShowEnv = mocks.dockerSpawnSync.mock.calls[0]?.[1]?.env;
+    expect(contextShowEnv?.DOCKER_CONFIG).toBe(dockerConfig);
+    expect(contextShowEnv).not.toHaveProperty("DOCKER_CONTEXT");
+    expect(contextShowEnv).not.toHaveProperty("DOCKER_HOST");
     expect(mocks.streamSandboxCreate).toHaveBeenCalledOnce();
   });
 
@@ -175,14 +172,9 @@ describe("runSandboxGpuCreateFlow provider-owned managed create", () => {
         stderr: "",
       });
       const input = createInput();
-      attachManagedBootstrap(input);
-      input.sandboxEnv = {
-        PATH: "/usr/bin",
-        OPENSHELL_GATEWAY: "1",
-        WSL_DISTRO_NAME: "Ubuntu",
-        DOCKER_CONFIG: dockerConfig,
-        ...(row.dockerHost === undefined ? {} : { DOCKER_HOST: row.dockerHost }),
-      };
+      const { createLifecycle } = attachManagedBootstrap(input);
+      input.hostEnv = { PATH: "/usr/bin", DOCKER_CONFIG: dockerConfig, ...row.callerSelection };
+      input.sandboxEnv = { ...MANAGED_CREATE_SANDBOX_ENV, ...row.sandboxSelection };
       const captured = captureCreateEnv();
       const deps = createDeps();
       vi.mocked(deps.runCaptureOpenshell).mockImplementation((args) =>
@@ -191,11 +183,18 @@ describe("runSandboxGpuCreateFlow provider-owned managed create", () => {
 
       await runSandboxGpuCreateFlow(input, deps);
 
-      expect(captured.env.DOCKER_CONFIG).toBe(dockerConfig);
+      expect(captured.env).not.toHaveProperty("DOCKER_CONFIG");
+      expect(captured.env).not.toHaveProperty("DOCKER_CONTEXT");
       expect(captured.env.PATH).toBe("/usr/bin");
       expect(captured.env.OPENSHELL_GATEWAY).toBe("1");
-      expect(captured.configExisted).toBe(true);
       expect(fs.existsSync(dockerConfig)).toBe(true);
+      expect(mocks.dockerSpawnSync).toHaveBeenCalledTimes(row.contextShowCalls);
+      const dockerClientEnv = createLifecycle.mock.calls[0]?.[0]?.dockerClientEnv ?? {};
+      expect(dockerClientEnv.DOCKER_HOST).toBe(row.callerSelection.DOCKER_HOST);
+      expect(dockerClientEnv.DOCKER_CONTEXT).toBe(row.callerSelection.DOCKER_CONTEXT);
+      expect(dockerClientEnv.DOCKER_CONFIG).toBe(
+        row.clientConfigForwarded ? dockerConfig : undefined,
+      );
     },
   );
 

--- a/src/lib/onboard/sandbox-gpu-create-flow.ts
+++ b/src/lib/onboard/sandbox-gpu-create-flow.ts
@@ -245,7 +245,7 @@ export interface SandboxGpuCreateFlowInput {
   createArgv: string[];
   /** Exact schema-5 build context consumed by the OpenShell create child. */
   createWorkingDirectory?: string;
-  /** Host-side runtime environment used only by the selected lifecycle provider. */
+  /** Host-side environment for the selected lifecycle provider and for NemoClaw's own Docker commands. */
   hostEnv?: NodeJS.ProcessEnv;
   portableLifecycle?: boolean;
   hermesPortableLifecycle?: boolean;

--- a/src/lib/onboard/sandbox-gpu-create-run-attempt.ts
+++ b/src/lib/onboard/sandbox-gpu-create-run-attempt.ts
@@ -4,6 +4,7 @@
 import { randomBytes } from "node:crypto";
 
 import {
+  dockerClientSelectionEnv,
   mergeIsolatedDockerClientEnv,
   prepareDockerBuildEnvironment,
   warnIfDockerBuildEnvironmentCleanupFailed,
@@ -83,14 +84,15 @@ async function streamSandboxCreateWithPublicImageCredentialIsolation(
   isolate: boolean,
   sandboxName: string,
   sandboxEnv: NodeJS.ProcessEnv,
+  dockerClientEnv: NodeJS.ProcessEnv,
   run: (env: NodeJS.ProcessEnv) => Promise<StreamSandboxCreateResult>,
 ): Promise<StreamSandboxCreateResult> {
   if (!isolate) return run(sandboxEnv);
-  // Detect against the same environment the create command runs with. The
-  // sandbox env drops DOCKER_CONFIG and DOCKER_CONTEXT, so process.env can
-  // report a credential store or a context the create never uses.
+  // The create env itself cannot serve as the detection source: it carries
+  // no DOCKER_CONTEXT and no DOCKER_CONFIG, so it reports the default context
+  // and the ambient credential store even when the caller selected others.
   const prepared = prepareDockerBuildEnvironment({
-    env: sandboxEnv,
+    env: dockerClientEnv,
     allowCredentialIsolation: true,
   });
   try {
@@ -579,6 +581,10 @@ export function createSandboxGpuCreateAttemptRunner(
     }
     const hasRequiredUlimits = (input.requiredUlimits?.length ?? 0) > 0;
     const managedBootstrap = input.managedBootstrap ?? null;
+    const dockerClientEnv = dockerClientSelectionEnv(
+      input.sandboxEnv,
+      input.hostEnv ?? process.env,
+    );
     const unboundAttemptArgv = state.compatibilityArgv ?? input.createArgv;
     if (input.requirePolicylessCreate) assertPolicylessSandboxCreateArgv(unboundAttemptArgv);
     const createAttemptNonce = resolveCreateAttemptNonce(input, deferPostCreateEffects);
@@ -678,7 +684,7 @@ export function createSandboxGpuCreateAttemptRunner(
           sandboxGpuConfig: input.sandboxGpuConfig,
           requiredLimits: input.requiredUlimits ?? [],
           timeoutSecs: input.sandboxReadyTimeoutSecs,
-          dockerClientEnv: input.sandboxEnv,
+          dockerClientEnv,
           network: {
             inferenceProvider: input.provider,
             gatewayUsesContainerBridge: input.dockerDriverGateway,
@@ -770,6 +776,7 @@ export function createSandboxGpuCreateAttemptRunner(
         managedBootstrap != null,
         input.sandboxName,
         input.sandboxEnv,
+        dockerClientEnv,
         (createEnv) =>
           streamSandboxCreate(createExecutable, createExecutableArgs, createEnv, {
             ...(input.createWorkingDirectory ? { cwd: input.createWorkingDirectory } : {}),

--- a/src/lib/onboard/sandbox-gpu-create-run-attempt.ts
+++ b/src/lib/onboard/sandbox-gpu-create-run-attempt.ts
@@ -3,12 +3,7 @@
 
 import { randomBytes } from "node:crypto";
 
-import {
-  dockerClientSelectionEnv,
-  mergeIsolatedDockerClientEnv,
-  prepareDockerBuildEnvironment,
-  warnIfDockerBuildEnvironmentCleanupFailed,
-} from "../adapters/docker/client-isolation";
+import { dockerClientSelectionEnv } from "../adapters/docker/client-isolation";
 import {
   NEMOCLAW_CREATE_ATTEMPT_LABEL,
   NEMOCLAW_CREATE_ATTEMPT_NONCE_HEX_LENGTH,
@@ -20,7 +15,7 @@ import {
 } from "../adapters/openshell/sandbox-identity";
 import { namedOpenShellGateway } from "../adapters/openshell/sandbox-observer";
 import { printSandboxCreateRecoveryHints } from "../build-context";
-import { streamSandboxCreate, type StreamSandboxCreateResult } from "../sandbox/create-stream";
+import { streamSandboxCreate } from "../sandbox/create-stream";
 import { getReadyCheckOutputPatternsForAgent } from "../sandbox/create-stream-ready-gate";
 import type { SandboxGpuProofResult } from "../state/registry";
 import { classifySandboxCreateFailure } from "../validation";
@@ -79,36 +74,6 @@ export type SandboxGpuCreateAttemptState = {
 const REPLACEMENT_STABLE_READY_POLLS = 2;
 const SANDBOX_READY_PROBE_TIMEOUT_MS = 5_000;
 const CREATED_SANDBOX_PUBLICATION_POLL_INTERVAL_SECONDS = 1;
-
-async function streamSandboxCreateWithPublicImageCredentialIsolation(
-  isolate: boolean,
-  sandboxName: string,
-  sandboxEnv: NodeJS.ProcessEnv,
-  dockerClientEnv: NodeJS.ProcessEnv,
-  run: (env: NodeJS.ProcessEnv) => Promise<StreamSandboxCreateResult>,
-): Promise<StreamSandboxCreateResult> {
-  if (!isolate) return run(sandboxEnv);
-  // The create env itself cannot serve as the detection source: it carries
-  // no DOCKER_CONTEXT and no DOCKER_CONFIG, so it reports the default context
-  // and the ambient credential store even when the caller selected others.
-  const prepared = prepareDockerBuildEnvironment({
-    env: dockerClientEnv,
-    allowCredentialIsolation: true,
-  });
-  try {
-    if (prepared.isolatedCredentialConfig) {
-      console.log(
-        "  Docker Desktop credential helper is unavailable in this WSL session; using an isolated credential-free config for the managed sandbox image pull.",
-      );
-    }
-    return await run(mergeIsolatedDockerClientEnv(sandboxEnv, prepared));
-  } finally {
-    warnIfDockerBuildEnvironmentCleanupFailed(
-      prepared.cleanup(),
-      `managed sandbox create '${sandboxName}'`,
-    );
-  }
-}
 
 const ANSI_RE = /\x1B(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1B\\)|[@-_])/gu;
 const OPENSHELL_SANDBOX_NOT_READY =
@@ -772,70 +737,68 @@ export function createSandboxGpuCreateAttemptRunner(
       return sandboxId;
     };
     const streamCreate = async () => {
-      const createResult = await streamSandboxCreateWithPublicImageCredentialIsolation(
-        managedBootstrap != null,
-        input.sandboxName,
+      const createResult = await streamSandboxCreate(
+        createExecutable,
+        createExecutableArgs,
         input.sandboxEnv,
-        dockerClientEnv,
-        (createEnv) =>
-          streamSandboxCreate(createExecutable, createExecutableArgs, createEnv, {
-            ...(input.createWorkingDirectory ? { cwd: input.createWorkingDirectory } : {}),
-            readyCheck: () => {
-              const list = deps.runCaptureOpenshell(["sandbox", "list", "-g", input.gatewayName], {
-                ignoreError: true,
-                killProcessTreeOnTimeout: true,
-                timeout: SANDBOX_READY_PROBE_TIMEOUT_MS,
-              });
-              const ready = sandboxGpuCreateAttempt.isSandboxReady(list, input.sandboxName);
-              if (!ready || !createAttemptNonce) return ready;
-              const observation = observeCreatedOpenShellSandboxId(
-                {
-                  sandboxName: input.sandboxName,
-                  gatewayName: input.gatewayName,
-                  createAttemptNonce,
-                  runCaptureOpenshell: captureSandboxReadiness,
+        {
+          ...(input.createWorkingDirectory ? { cwd: input.createWorkingDirectory } : {}),
+          readyCheck: () => {
+            const list = deps.runCaptureOpenshell(["sandbox", "list", "-g", input.gatewayName], {
+              ignoreError: true,
+              killProcessTreeOnTimeout: true,
+              timeout: SANDBOX_READY_PROBE_TIMEOUT_MS,
+            });
+            const ready = sandboxGpuCreateAttempt.isSandboxReady(list, input.sandboxName);
+            if (!ready || !createAttemptNonce) return ready;
+            const observation = observeCreatedOpenShellSandboxId(
+              {
+                sandboxName: input.sandboxName,
+                gatewayName: input.gatewayName,
+                createAttemptNonce,
+                runCaptureOpenshell: captureSandboxReadiness,
+              },
+              SANDBOX_READY_PROBE_TIMEOUT_MS,
+            );
+            if (observation.state === "invalid") {
+              return failReadyCheckCreatedIdentity(observation.diagnostic);
+            }
+            if (observation.sandboxId === null) {
+              return readyCheckCreatedSandboxId
+                ? failReadyCheckCreatedIdentity("selector-identity-disappeared")
+                : false;
+            }
+            if (
+              readyCheckCreatedSandboxId &&
+              observation.sandboxId !== readyCheckCreatedSandboxId
+            ) {
+              return failReadyCheckCreatedIdentity("selector-identity-changed");
+            }
+            readyCheckCreatedSandboxId = observation.sandboxId;
+            // End only the create-client handoff. Strict metadata settlement still
+            // runs before any post-create effect.
+            return true;
+          },
+          ...(deferPostCreateEffects
+            ? {}
+            : {
+                onPoll: () => {
+                  if (!deferRestartSafeCutover) void runtimePatch.maybeApplyDuringCreate();
                 },
-                SANDBOX_READY_PROBE_TIMEOUT_MS,
-              );
-              if (observation.state === "invalid") {
-                return failReadyCheckCreatedIdentity(observation.diagnostic);
-              }
-              if (observation.sandboxId === null) {
-                return readyCheckCreatedSandboxId
-                  ? failReadyCheckCreatedIdentity("selector-identity-disappeared")
-                  : false;
-              }
-              if (
-                readyCheckCreatedSandboxId &&
-                observation.sandboxId !== readyCheckCreatedSandboxId
-              ) {
-                return failReadyCheckCreatedIdentity("selector-identity-changed");
-              }
-              readyCheckCreatedSandboxId = observation.sandboxId;
-              // End only the create-client handoff. Strict metadata settlement still
-              // runs before any post-create effect.
-              return true;
-            },
-            ...(deferPostCreateEffects
-              ? {}
-              : {
-                  onPoll: () => {
-                    if (!deferRestartSafeCutover) void runtimePatch.maybeApplyDuringCreate();
-                  },
-                }),
-            readyCheckOutputPatterns: getReadyCheckOutputPatternsForAgent({
-              isTerminalAgent: input.terminalAgent,
-              startupRunsDuringCreate: managedLifecycle === null,
-              env: createEnv,
-            }),
-            failureCheck: runtimePatch.createFailureMessage,
-            traceEvent: addTraceEvent,
-            waitForReadyTermination: deferRestartSafeCutover || deferPostCreateEffects,
-            initialPhase:
-              compatibility && (input.prebuild.imageRef || state.compatibilityArgv)
-                ? "create"
-                : undefined,
+              }),
+          readyCheckOutputPatterns: getReadyCheckOutputPatternsForAgent({
+            isTerminalAgent: input.terminalAgent,
+            startupRunsDuringCreate: managedLifecycle === null,
+            env: input.sandboxEnv,
           }),
+          failureCheck: runtimePatch.createFailureMessage,
+          traceEvent: addTraceEvent,
+          waitForReadyTermination: deferRestartSafeCutover || deferPostCreateEffects,
+          initialPhase:
+            compatibility && (input.prebuild.imageRef || state.compatibilityArgv)
+              ? "create"
+              : undefined,
+        },
       );
       if (createResult.readyTerminationTimedOut) {
         if (createAttemptNonce) {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome
On WSL, the credential-free Docker configuration for a managed sandbox create follows the Docker client selection of the `nemoclaw` command, and only the Docker commands that NemoClaw runs itself use it. Before, the create step evaluated the bypass against the reduced environment handed to `openshell sandbox create`, so it printed `Docker Desktop credential helper is unavailable in this WSL session` and applied the credential-free configuration even when the caller selected a non-default `DOCKER_CONTEXT` or a `DOCKER_CONFIG` without the Docker Desktop helper; the configuration it placed on the `openshell sandbox create` environment had no effect. After, the create step evaluates nothing and prints nothing about credentials. The managed-bootstrap lifecycle receives the caller selection and evaluates the bypass for its own GPU-probe image pre-pull and GPU probes: an explicit `DOCKER_HOST`, a non-default `DOCKER_CONTEXT`, or a custom `DOCKER_CONFIG` keeps the configured Docker client state, as the troubleshooting page states. Callers without these variables see no change beyond the removed create-step message.

## Reason
The managed create path evaluated the bypass against the environment handed to `openshell sandbox create`. That environment forwards only `DOCKER_HOST`, so the check always saw the default context and the ambient `~/.docker/config.json`, while the Docker commands that NemoClaw runs during bootstrap receive the caller's `DOCKER_CONTEXT` and `DOCKER_CONFIG` from the Docker runner. Detection and execution disagreed, and a named context could reach a GPU probe together with an isolated `DOCKER_CONFIG` that cannot resolve it.

The overlay on the create environment was also inert. `openshell sandbox create` is a gRPC client of the OpenShell gateway; the gateway's Docker driver pulls the sandbox image through its own Docker socket with an anonymous `create_image` call and reads no `DOCKER_CONFIG` or `DOCKER_CONTEXT`, in the pinned OpenShell 0.0.106 and on its `main`. Keeping one Docker client selection for the managed create, consumed only by the Docker commands NemoClaw runs, removes the second authority and the misleading message.

### Related issues
Fixes #11533

## Changes
- `src/lib/adapters/docker/client-isolation.ts`: add `dockerClientSelectionEnv`, which extends a sandbox subprocess env with the caller's Docker selection under the Docker runner rules: an explicit `DOCKER_HOST` drops context and configuration, otherwise `DOCKER_CONTEXT` and `DOCKER_CONFIG` are forwarded. The managed create path is its only consumer; the existing `buildDockerSubprocessEnv` cannot be called there directly without a new dependency edge.
- `src/lib/onboard/sandbox-gpu-create-run-attempt.ts`: hand that selection to the managed-bootstrap lifecycle as `dockerClientEnv`, so the GPU pre-pull and GPU probes detect credential isolation against it. Remove the create-step detection and the credential-free `DOCKER_CONFIG` overlay on the `openshell sandbox create` environment; the create runs with the allowlisted sandbox environment as it did before the overlay existed.
- `src/lib/onboard/sandbox-gpu-create-flow.ts`: describe the wider role of `hostEnv`.
- `src/lib/onboard/sandbox-gpu-create-flow.test.ts`, `src/lib/onboard/__test-helpers__/sandbox-gpu-create-flow.ts`: one table asserts, for a default context with an unavailable Docker Desktop helper, an explicit non-default `DOCKER_CONTEXT`, and an explicit remote `DOCKER_HOST`, that the `openshell sandbox create` environment equals the sandbox environment, that no `docker context show` or helper probe runs at the create step, and that the lifecycle `dockerClientEnv` carries the caller selection. The pre-fix run of the first row failed because the create environment received the credential-free directory.
- `src/lib/onboard/managed-bootstrap/docker-runtime.test.ts`: run the real detection for a non-default `DOCKER_CONTEXT` that selects a Docker Desktop credential store and assert that the WSL pre-pull and the GPU probes keep the caller `DOCKER_CONFIG` and `DOCKER_CONTEXT` without a credential-free message.
- `docs/reference/troubleshooting.mdx`: name the environment the bypass conditions are read from, state that the temporary configuration applies to the Docker commands NemoClaw runs itself, note that the OpenShell gateway pulls the sandbox image through its own Docker socket without reading the Docker client configuration, and list the cases that keep the configured Docker client state.

## Verification
- `npx vitest run --project cli src/lib/onboard/sandbox-gpu-create-flow.test.ts src/lib/onboard/sandbox-prebuild.test.ts src/lib/onboard/managed-bootstrap/docker-runtime.test.ts src/lib/onboard/sandbox-gpu-create-flow-hermes-portable.test.ts src/lib/onboard/sandbox-create-step.test.ts src/lib/onboard/sandbox-create-launch.test.ts` — 6 files, 169 tests passed
- New flow table on the previous source — 1 of 3 rows failed: the create environment received `nemoclaw-wsl-buildkit-docker-config-*`; with the change applied — 3 of 3 passed
- `npm run test:changed` — growth guardrails passed; 135 tests passed
- `NODE_OPTIONS=--max-old-space-size=8192 npx tsc -p tsconfig.cli.json` — passed
- `npm run lint` — passed: oxlint 0 warnings and 0 errors, `oxfmt --check`, repository checks
- `npm run docs` — 0 errors, 5 pre-existing warnings
- Independent documentation writer review of the staged tree — Verdict: PASS, Result: docs-updated; its clarification of which Docker commands use the temporary configuration is applied in this commit
- Not run: a live WSL2 Docker Desktop onboarding; no such host is available here
- The diff contains no secrets, API keys, or credentials

## Review notes
Sensitive path: onboarding and the Docker credential-isolation control. The `openshell sandbox create` environment is the allowlisted sandbox environment without any credential-free overlay; the isolated configuration remains credential-free for the Docker commands NemoClaw runs, with the same creation and cleanup path. Evidence that the removed overlay was inert comes from the OpenShell source: the Docker compute driver resolves its socket from the gateway configuration or `DOCKER_HOST` and pulls with `create_image` without credentials, and no OpenShell crate reads `DOCKER_CONFIG` or `DOCKER_CONTEXT`. The change reverses one earlier test assertion that an ambient `DOCKER_CONTEXT` or `DOCKER_HOST` must not suppress isolation; the Docker commands the isolation protects run under that ambient selection, so suppression is the documented behavior. The OpenShell gateway keeps its own Docker daemon authority, an absolute `unix://` `DOCKER_HOST` or the default socket; the caller's Docker context selects the daemon only for the Docker commands NemoClaw runs, which is the existing runner contract.


## Maintainer follow-up

- Signed maintainer repair `c9a58c2f1` gives an explicit caller `DOCKER_CONTEXT` precedence when the reduced sandbox-create environment also carries `DOCKER_HOST`; the caller context and `DOCKER_CONFIG` remain the authority for NemoClaw-owned Docker commands. The caller-path matrix now protects this simultaneous-selection case.
- Exact repair validation: 170/170 focused tests, all 19 repository checks, CLI build and typecheck, plugin build, and `npm run validate:pr` passed.
- `npm run review:local` reached specialist configuration, but the temporary OpenShell gateway refused connections, so no local Advisor report was produced. Fresh exact-head CI, CodeRabbit, and hosted Advisor review are required.

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker configuration handling for WSL environments, including non-default contexts and credential stores.
  * Preserved caller Docker settings during managed sandbox and GPU creation.
  * Prevented unnecessary Docker client configuration from being forwarded to launched sandboxes.
  * Ensured sandbox image pulls use the OpenShell gateway’s Docker connection rather than NemoClaw’s client configuration.

* **Documentation**
  * Clarified which Docker operations use temporary credential-free settings and which retain configured Docker credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
