### PR TITLE
fix(inference): admit OEM-chassis RTX Spark N1x to Ollama model ranking

### DIFF
--- a/docs/get-started/windows-preparation.mdx
+++ b/docs/get-started/windows-preparation.mdx
@@ -204,7 +204,8 @@ Do not set Windows `OLLAMA_HOST` to `0.0.0.0:11434`; the wildcard listener is un
 Do not run both the Windows and WSL Ollama instances on port `11434` at the same time.
 Use one instance, or move one of them to a different port before running `$$nemoclaw onboard`.
 On a WSL RTX Spark N1x, NemoClaw ranks installed Ollama models with capacity from the selected Docker or Podman provider's CUDA proof.
-The proof-backed GPU identity qualifies the host; a Windows chassis model that reports `RTX Spark N1X` also qualifies it.
+The proof-backed GPU identity or a Windows chassis model that reports `RTX Spark N1X` qualifies the host for this ranking.
+The chassis model does not establish N1x WSL identity.
 Both providers run the same pinned CUDA workload and capacity query; their provider implementation owns the GPU injection arguments.
 When `qwen3.6:35b` is installed and that proof reports at least 30,000 MiB available, NemoClaw selects it before `qwen3.5:9b`.
 Other Windows on Arm GPUs remain compute-constrained and select `qwen3.5:9b` instead of the 30B and 35B starter models.

--- a/docs/get-started/windows-preparation.mdx
+++ b/docs/get-started/windows-preparation.mdx
@@ -172,7 +172,7 @@ The Podman path does not enable the Docker-specific managed llama.cpp or Windows
 If the installer offers Express on WSL, a qualifying N1x WSL host uses managed llama.cpp with Qwen 3.6 35B-A3B.
 The installer leaves inference selection to onboarding.
 Onboarding requires Linux ARM64 WSL, one GPU whose normalized identity is either `NVIDIA RTX Spark N1X` or `NVIDIA RTX Spark N1X (6144-core Blackwell RTX GPU)`, the default local Docker context, at least 48,000 MiB of Docker and GPU memory, driver version `580.65.06` or later, Docker storage and runtime readiness, NVIDIA GPU integration, and a successful Docker Desktop GPU passthrough proof.
-The Windows chassis model does not participate in selection.
+The Windows chassis model does not participate in managed llama.cpp selection.
 If N1x readiness does not match before managed selection starts, Windows Express selects WSL-local Ollama.
 If a required check fails after managed selection starts, onboarding stops before installation.
 Other WSL hosts also use WSL-local Ollama for Express installation.
@@ -203,7 +203,8 @@ A direct request from WSL can fail because Docker Desktop defines this hostname 
 Do not set Windows `OLLAMA_HOST` to `0.0.0.0:11434`; the wildcard listener is unauthenticated and disables the loopback-only HTTP `Host` validation that NemoClaw requires.
 Do not run both the Windows and WSL Ollama instances on port `11434` at the same time.
 Use one instance, or move one of them to a different port before running `$$nemoclaw onboard`.
-A WSL host whose Windows product reports RTX Spark N1x uses capacity from the selected Docker or Podman provider's CUDA proof to rank installed Ollama models.
+On a WSL RTX Spark N1x, NemoClaw ranks installed Ollama models with capacity from the selected Docker or Podman provider's CUDA proof.
+The proof-backed GPU identity qualifies the host; a Windows chassis model that reports `RTX Spark N1X` also qualifies it.
 Both providers run the same pinned CUDA workload and capacity query; their provider implementation owns the GPU injection arguments.
 When `qwen3.6:35b` is installed and that proof reports at least 30,000 MiB available, NemoClaw selects it before `qwen3.5:9b`.
 Other Windows on Arm GPUs remain compute-constrained and select `qwen3.5:9b` instead of the 30B and 35B starter models.

--- a/docs/inference/set-up-ollama.mdx
+++ b/docs/inference/set-up-ollama.mdx
@@ -366,7 +366,7 @@ After a model fails validation, NemoClaw excludes it from the next installed-mod
 
 On Windows on Arm N1X systems with a Snapdragon X processor, automatic selection omits the 30B and 35B starter models and selects `qwen3.5:9b`.
 On a WSL RTX Spark N1x, NemoClaw can select an installed `qwen3.6:35b` only when the selected Docker or Podman provider's CUDA proof reports at least 30,000 MiB available.
-The proof must validate exactly one GPU.
+NemoClaw runs the proof only when `nvidia-smi` reports exactly one GPU row.
 NemoClaw treats the host as N1x when that GPU's normalized identity is `NVIDIA RTX Spark N1X` or `NVIDIA RTX Spark N1X (6144-core Blackwell RTX GPU)`, or when the Windows chassis model reports `RTX Spark N1X`.
 The proof runs one pinned CUDA workload and capacity query through the provider abstraction; Docker supplies its GPU flag and Podman supplies its NVIDIA CDI device without a separate model-selection path.
 Missing, malformed, or insufficient proof capacity retains the `qwen3.5:9b` fallback.

--- a/docs/inference/set-up-ollama.mdx
+++ b/docs/inference/set-up-ollama.mdx
@@ -365,7 +365,9 @@ If no installed known tag fits, NemoClaw displays starter choices and warns when
 After a model fails validation, NemoClaw excludes it from the next installed-model menu.
 
 On Windows on Arm N1X systems with a Snapdragon X processor, automatic selection omits the 30B and 35B starter models and selects `qwen3.5:9b`.
-On a WSL RTX Spark N1x, NemoClaw can select an installed `qwen3.6:35b` only when the Windows product identity qualifies and the selected Docker or Podman provider's CUDA proof reports at least 30,000 MiB available.
+On a WSL RTX Spark N1x, NemoClaw can select an installed `qwen3.6:35b` only when the selected Docker or Podman provider's CUDA proof reports at least 30,000 MiB available.
+The proof must validate exactly one GPU.
+NemoClaw treats the host as N1x when that GPU's normalized identity is `NVIDIA RTX Spark N1X` or `NVIDIA RTX Spark N1X (6144-core Blackwell RTX GPU)`, or when the Windows chassis model reports `RTX Spark N1X`.
 The proof runs one pinned CUDA workload and capacity query through the provider abstraction; Docker supplies its GPU flag and Podman supplies its NVIDIA CDI device without a separate model-selection path.
 Missing, malformed, or insufficient proof capacity retains the `qwen3.5:9b` fallback.
 This safeguard only changes automatic selection.

--- a/docs/inference/set-up-ollama.mdx
+++ b/docs/inference/set-up-ollama.mdx
@@ -367,7 +367,8 @@ After a model fails validation, NemoClaw excludes it from the next installed-mod
 On Windows on Arm N1X systems with a Snapdragon X processor, automatic selection omits the 30B and 35B starter models and selects `qwen3.5:9b`.
 On a WSL RTX Spark N1x, NemoClaw can select an installed `qwen3.6:35b` only when the selected Docker or Podman provider's CUDA proof reports at least 30,000 MiB available.
 NemoClaw runs the proof only when `nvidia-smi` reports exactly one GPU row.
-NemoClaw treats the host as N1x when that GPU's normalized identity is `NVIDIA RTX Spark N1X` or `NVIDIA RTX Spark N1X (6144-core Blackwell RTX GPU)`, or when the Windows chassis model reports `RTX Spark N1X`.
+The host qualifies for this selection when the GPU's normalized identity is `NVIDIA RTX Spark N1X` or `NVIDIA RTX Spark N1X (6144-core Blackwell RTX GPU)`, or when the Windows chassis model reports `RTX Spark N1X`.
+The chassis model qualifies only this Ollama model selection; it does not establish N1x WSL identity for system readiness or managed llama.cpp selection.
 The proof runs one pinned CUDA workload and capacity query through the provider abstraction; Docker supplies its GPU flag and Podman supplies its NVIDIA CDI device without a separate model-selection path.
 Missing, malformed, or insufficient proof capacity retains the `qwen3.5:9b` fallback.
 This safeguard only changes automatic selection.

--- a/src/lib/inference/nim.gpu-proof-plausible-name.test.ts
+++ b/src/lib/inference/nim.gpu-proof-plausible-name.test.ts
@@ -148,18 +148,63 @@ describe("detectGpu CUDA proof for a plausible, non-placeholder NVIDIA GPU name 
     },
   );
 
-  it("keeps an unqualified Windows product compute-constrained despite the GPU name (#10954)", () => {
+  it.each([
+    ["an OEM chassis model", false],
+    ["an inconclusive chassis probe", null],
+  ])(
+    "selects the largest installed Ollama model on a proven RTX Spark N1X GPU with %s",
+    (_label, n1xWslProduct) => {
+      onWsl2Arm64WithoutKernelInterface(() => {
+        const gpu = detectGpu({
+          proveArm64ContainerGpu: passingProver({
+            totalMemoryMB: 31_168,
+            availableMemoryMB: 30_345,
+          }),
+          runCaptureImpl: makeRunCapture(`${PLAUSIBLE_NAME}, 31168, 30345\n`),
+          isWsl: true,
+          n1xWslProduct,
+        });
+        expect(gpu).toMatchObject({
+          platform: "n1x",
+          totalMemoryMB: 31_168,
+          availableMemoryMB: 30_345,
+          n1xWslProduct,
+        });
+        expect(gpu).not.toHaveProperty("computeConstrained");
+        expect(selectDefaultOllamaModel(["qwen3.5:9b", "qwen3.6:35b"], gpu)).toBe("qwen3.6:35b");
+      });
+    },
+  );
+
+  it("selects the largest installed Ollama model when only the Windows chassis model identifies RTX Spark N1X", () => {
     onWsl2Arm64WithoutKernelInterface(() => {
       const gpu = detectGpu({
         proveArm64ContainerGpu: passingProver({
           totalMemoryMB: 63_936,
           availableMemoryMB: 60_000,
         }),
-        runCaptureImpl: makeRunCapture(`${PLAUSIBLE_NAME}, 63936, 60000\n`),
+        runCaptureImpl: makeRunCapture("NVIDIA RTX Spark N1X Laptop GPU, 63936, 60000\n"),
+        isWsl: true,
+        n1xWslProduct: true,
+      });
+      expect(gpu).toMatchObject({ platform: "linux", n1xWslProduct: true });
+      expect(gpu).not.toHaveProperty("computeConstrained");
+      expect(selectDefaultOllamaModel(["qwen3.5:9b", "qwen3.6:35b"], gpu)).toBe("qwen3.6:35b");
+    });
+  });
+
+  it("keeps a placeholder GPU name compute-constrained when the chassis model does not qualify", () => {
+    onWsl2Arm64WithoutKernelInterface(() => {
+      const gpu = detectGpu({
+        proveArm64ContainerGpu: passingProver({
+          totalMemoryMB: 63_936,
+          availableMemoryMB: 60_000,
+        }),
+        runCaptureImpl: makeRunCapture("NVIDIA JMJWOA-Generic-GPU, 63936, 60000\n"),
         isWsl: true,
         n1xWslProduct: false,
       });
-      expect(gpu).toMatchObject({ computeConstrained: true });
+      expect(gpu).toMatchObject({ platform: "linux", computeConstrained: true });
       expect(selectDefaultOllamaModel(["qwen3.5:9b", "qwen3.6:35b"], gpu)).toBe("qwen3.5:9b");
     });
   });

--- a/src/lib/inference/nim.ts
+++ b/src/lib/inference/nim.ts
@@ -633,11 +633,15 @@ export function detectGpu(deps: DetectGpuDeps = {}): GpuDetection | null {
         // a mixed-GPU host would otherwise be misreported as `Nx <firstName>`.
         const allSameName = !!firstName && trusted.every((p: ParsedGpu) => p.name === firstName);
         const verifiedCapacity = boundedCudaProof?.verifiedCapacity;
+        // OEM N1X units report chassis models such as `SKU 1` or `83N7`, so
+        // the proof-backed GPU identity qualifies on its own; the chassis
+        // observation remains an alternative for a GPU name outside the
+        // accepted N1X identities.
         const n1xWslOllamaEligible =
           containerGpuProofPassed &&
           verifiedCapacity !== undefined &&
           verifiedCapacity.availableMemoryMB >= 30_000 &&
-          deps.n1xWslProduct === true;
+          (platform === "n1x" || deps.n1xWslProduct === true);
         // Keep the 30B/35B timeout protection except for the planned
         // identity-qualified WSL RTX Spark N1X path (#10954).
         const computeConstrained =

--- a/src/lib/onboard/fatal-runtime-preflight.test.ts
+++ b/src/lib/onboard/fatal-runtime-preflight.test.ts
@@ -880,54 +880,67 @@ describe("readiness-gated runtime preflight", () => {
     expect(result.gpu?.n1xWslProduct).toBe(true);
   });
 
+  const ACCEPTED_N1X_GPU_NAME = "NVIDIA RTX Spark N1X (6144-core Blackwell RTX GPU)";
+  const UNLISTED_N1X_GPU_NAME = "NVIDIA RTX Spark N1X Laptop GPU";
+
+  async function runRealProviderPreflight(gpuName: string, n1xWslProduct: boolean | undefined) {
+    // The proof phase lets `detectGpu()` detect WSL itself, and the N1x
+    // classification requires WSL.
+    vi.stubEnv("WSL_DISTRO_NAME", "Ubuntu");
+    const captureHostCommand = vi
+      .fn()
+      .mockReturnValueOnce({
+        status: 0,
+        stdout: "Test PASSED\nNEMOCLAW_GPU_MEMORY_MIB=63936, 60000\n",
+        stderr: "",
+      })
+      .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" });
+    const provider = createDockerRuntimeProviderBundle({ captureHostCommand });
+    const runCaptureImpl = vi.fn((command: readonly string[]) =>
+      command[0] === "nvidia-smi" && command.some((arg) => arg.includes("name,memory.total"))
+        ? `${gpuName}, 999999, 999999\n`
+        : "",
+    );
+
+    const result = await withLinuxArm64(() =>
+      runReadinessGatedRuntimePreflight(
+        {},
+        {
+          nonInteractive: true,
+          collectGatewayReadiness: async () => collectedGatewayReadiness(),
+          assessHost: wslDockerDesktopHost,
+          runCaptureImpl,
+          collectN1xWslProduct: vi.fn(() => n1xWslProduct),
+          createArm64ContainerGpuProver: () =>
+            createArm64ContainerGpuProver({
+              platform: "linux",
+              arch: "arm64",
+              resolveRuntimeProvider: () => provider,
+              log: () => undefined,
+            }),
+          warnIfHostProxyMissesLoopback: vi.fn(),
+          assertRuntimeProviderHealthy: vi.fn(),
+          validateSandboxGpuPreflight: vi.fn(),
+        },
+      ),
+    );
+    return { gpu: result.gpu, captureHostCommand };
+  }
+
   it.each([
-    ["a qualifying chassis model", true],
-    ["an OEM chassis model", false],
-    ["an inconclusive chassis probe", undefined],
+    ["an accepted GPU identity and a qualifying chassis model", ACCEPTED_N1X_GPU_NAME, true, "n1x"],
+    ["an accepted GPU identity and an OEM chassis model", ACCEPTED_N1X_GPU_NAME, false, "n1x"],
+    [
+      "an accepted GPU identity and an inconclusive chassis probe",
+      ACCEPTED_N1X_GPU_NAME,
+      undefined,
+      "n1x",
+    ],
+    ["an unlisted GPU name and a qualifying chassis model", UNLISTED_N1X_GPU_NAME, true, "linux"],
   ])(
     "carries a real provider capture through real GPU detection to Ollama selection with %s",
-    async (_label, n1xWslProduct) => {
-      // The proof phase lets `detectGpu()` detect WSL itself, and the N1x
-      // classification requires WSL.
-      vi.stubEnv("WSL_DISTRO_NAME", "Ubuntu");
-      const captureHostCommand = vi
-        .fn()
-        .mockReturnValueOnce({
-          status: 0,
-          stdout: "Test PASSED\nNEMOCLAW_GPU_MEMORY_MIB=63936, 60000\n",
-          stderr: "",
-        })
-        .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" });
-      const provider = createDockerRuntimeProviderBundle({ captureHostCommand });
-      const gpuName = "NVIDIA RTX Spark N1X (6144-core Blackwell RTX GPU)";
-      const runCaptureImpl = vi.fn((command: readonly string[]) =>
-        command[0] === "nvidia-smi" && command.some((arg) => arg.includes("name,memory.total"))
-          ? `${gpuName}, 999999, 999999\n`
-          : "",
-      );
-
-      const result = await withLinuxArm64(() =>
-        runReadinessGatedRuntimePreflight(
-          {},
-          {
-            nonInteractive: true,
-            collectGatewayReadiness: async () => collectedGatewayReadiness(),
-            assessHost: wslDockerDesktopHost,
-            runCaptureImpl,
-            collectN1xWslProduct: vi.fn(() => n1xWslProduct),
-            createArm64ContainerGpuProver: () =>
-              createArm64ContainerGpuProver({
-                platform: "linux",
-                arch: "arm64",
-                resolveRuntimeProvider: () => provider,
-                log: () => undefined,
-              }),
-            warnIfHostProxyMissesLoopback: vi.fn(),
-            assertRuntimeProviderHealthy: vi.fn(),
-            validateSandboxGpuPreflight: vi.fn(),
-          },
-        ),
-      );
+    async (_label, gpuName, n1xWslProduct, platform) => {
+      const { gpu, captureHostCommand } = await runRealProviderPreflight(gpuName, n1xWslProduct);
 
       expect(captureHostCommand).toHaveBeenCalledTimes(2);
       expect(captureHostCommand).toHaveBeenNthCalledWith(
@@ -936,19 +949,30 @@ describe("readiness-gated runtime preflight", () => {
         expect.arrayContaining(["ps", "--all", "--no-trunc"]),
         expect.any(Number),
       );
-      expect(result.gpu).toMatchObject({
-        platform: "n1x",
+      expect(gpu).toMatchObject({
+        platform,
         containerGpuProof: { providerId: "docker", passed: true },
         n1xWslProduct: n1xWslProduct ?? null,
         totalMemoryMB: 63_936,
         availableMemoryMB: 60_000,
       });
-      expect(result.gpu?.computeConstrained).toBeUndefined();
-      expect(selectDefaultOllamaModel(["qwen3.5:9b", "qwen3.6:35b"], result.gpu)).toBe(
-        "qwen3.6:35b",
-      );
+      expect(gpu?.computeConstrained).toBeUndefined();
+      expect(selectDefaultOllamaModel(["qwen3.5:9b", "qwen3.6:35b"], gpu)).toBe("qwen3.6:35b");
     },
   );
+
+  it("keeps an unlisted GPU name compute-constrained through runtime preflight when the chassis model does not qualify", async () => {
+    const { gpu } = await runRealProviderPreflight(UNLISTED_N1X_GPU_NAME, false);
+
+    expect(gpu).toMatchObject({
+      platform: "linux",
+      containerGpuProof: { providerId: "docker", passed: true },
+      n1xWslProduct: false,
+      totalMemoryMB: 999_999,
+      computeConstrained: true,
+    });
+    expect(selectDefaultOllamaModel(["qwen3.5:9b", "qwen3.6:35b"], gpu)).toBe("qwen3.5:9b");
+  });
 
   it("preserves a failed bounded WSL GPU proof as an absent readiness capability (#7411)", async () => {
     const detectGpu = vi.fn((deps?: DetectGpuDeps): GpuDetection | null => {

--- a/src/lib/onboard/fatal-runtime-preflight.test.ts
+++ b/src/lib/onboard/fatal-runtime-preflight.test.ts
@@ -880,61 +880,75 @@ describe("readiness-gated runtime preflight", () => {
     expect(result.gpu?.n1xWslProduct).toBe(true);
   });
 
-  it("carries a real provider capture through real GPU detection to Ollama selection", async () => {
-    const captureHostCommand = vi
-      .fn()
-      .mockReturnValueOnce({
-        status: 0,
-        stdout: "Test PASSED\nNEMOCLAW_GPU_MEMORY_MIB=63936, 60000\n",
-        stderr: "",
-      })
-      .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" });
-    const provider = createDockerRuntimeProviderBundle({ captureHostCommand });
-    const gpuName = "NVIDIA RTX Spark N1X (6144-core Blackwell RTX GPU)";
-    const runCaptureImpl = vi.fn((command: readonly string[]) =>
-      command[0] === "nvidia-smi" && command.some((arg) => arg.includes("name,memory.total"))
-        ? `${gpuName}, 999999, 999999\n`
-        : "",
-    );
+  it.each([
+    ["a qualifying chassis model", true],
+    ["an OEM chassis model", false],
+    ["an inconclusive chassis probe", undefined],
+  ])(
+    "carries a real provider capture through real GPU detection to Ollama selection with %s",
+    async (_label, n1xWslProduct) => {
+      // The proof phase lets `detectGpu()` detect WSL itself, and the N1x
+      // classification requires WSL.
+      vi.stubEnv("WSL_DISTRO_NAME", "Ubuntu");
+      const captureHostCommand = vi
+        .fn()
+        .mockReturnValueOnce({
+          status: 0,
+          stdout: "Test PASSED\nNEMOCLAW_GPU_MEMORY_MIB=63936, 60000\n",
+          stderr: "",
+        })
+        .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" });
+      const provider = createDockerRuntimeProviderBundle({ captureHostCommand });
+      const gpuName = "NVIDIA RTX Spark N1X (6144-core Blackwell RTX GPU)";
+      const runCaptureImpl = vi.fn((command: readonly string[]) =>
+        command[0] === "nvidia-smi" && command.some((arg) => arg.includes("name,memory.total"))
+          ? `${gpuName}, 999999, 999999\n`
+          : "",
+      );
 
-    const result = await withLinuxArm64(() =>
-      runReadinessGatedRuntimePreflight(
-        {},
-        {
-          nonInteractive: true,
-          collectGatewayReadiness: async () => collectedGatewayReadiness(),
-          assessHost: wslDockerDesktopHost,
-          runCaptureImpl,
-          collectN1xWslProduct: vi.fn(() => true),
-          createArm64ContainerGpuProver: () =>
-            createArm64ContainerGpuProver({
-              platform: "linux",
-              arch: "arm64",
-              resolveRuntimeProvider: () => provider,
-              log: () => undefined,
-            }),
-          warnIfHostProxyMissesLoopback: vi.fn(),
-          assertRuntimeProviderHealthy: vi.fn(),
-          validateSandboxGpuPreflight: vi.fn(),
-        },
-      ),
-    );
+      const result = await withLinuxArm64(() =>
+        runReadinessGatedRuntimePreflight(
+          {},
+          {
+            nonInteractive: true,
+            collectGatewayReadiness: async () => collectedGatewayReadiness(),
+            assessHost: wslDockerDesktopHost,
+            runCaptureImpl,
+            collectN1xWslProduct: vi.fn(() => n1xWslProduct),
+            createArm64ContainerGpuProver: () =>
+              createArm64ContainerGpuProver({
+                platform: "linux",
+                arch: "arm64",
+                resolveRuntimeProvider: () => provider,
+                log: () => undefined,
+              }),
+            warnIfHostProxyMissesLoopback: vi.fn(),
+            assertRuntimeProviderHealthy: vi.fn(),
+            validateSandboxGpuPreflight: vi.fn(),
+          },
+        ),
+      );
 
-    expect(captureHostCommand).toHaveBeenCalledTimes(2);
-    expect(captureHostCommand).toHaveBeenNthCalledWith(
-      2,
-      "docker",
-      expect.arrayContaining(["ps", "--all", "--no-trunc"]),
-      expect.any(Number),
-    );
-    expect(result.gpu).toMatchObject({
-      containerGpuProof: { providerId: "docker", passed: true },
-      n1xWslProduct: true,
-      totalMemoryMB: 63_936,
-      availableMemoryMB: 60_000,
-    });
-    expect(selectDefaultOllamaModel(["qwen3.5:9b", "qwen3.6:35b"], result.gpu)).toBe("qwen3.6:35b");
-  });
+      expect(captureHostCommand).toHaveBeenCalledTimes(2);
+      expect(captureHostCommand).toHaveBeenNthCalledWith(
+        2,
+        "docker",
+        expect.arrayContaining(["ps", "--all", "--no-trunc"]),
+        expect.any(Number),
+      );
+      expect(result.gpu).toMatchObject({
+        platform: "n1x",
+        containerGpuProof: { providerId: "docker", passed: true },
+        n1xWslProduct: n1xWslProduct ?? null,
+        totalMemoryMB: 63_936,
+        availableMemoryMB: 60_000,
+      });
+      expect(result.gpu?.computeConstrained).toBeUndefined();
+      expect(selectDefaultOllamaModel(["qwen3.5:9b", "qwen3.6:35b"], result.gpu)).toBe(
+        "qwen3.6:35b",
+      );
+    },
+  );
 
   it("preserves a failed bounded WSL GPU proof as an absent readiness capability (#7411)", async () => {
     const detectGpu = vi.fn((deps?: DetectGpuDeps): GpuDetection | null => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome
On a Windows WSL RTX Spark N1x whose bounded CUDA proof passes with at least 30,000 MiB available, Express onboarding now ranks installed Ollama models by memory even when the Windows chassis model is an OEM string such as `SKU 1` or `83N7`. Before, the eligibility gate required the chassis model to report `RTX Spark N1X`, so the host stayed compute-constrained and onboarding loaded `qwen3.5:9b` while `qwen3.6:35b` was installed. A chassis model that reports `RTX Spark N1X` still qualifies a proof-backed GPU with another name.

## Reason
`n1xWslOllamaEligible` in `src/lib/inference/nim.ts` required `n1xWslProduct === true`, an observation of `Win32_ComputerSystem.Model` through PowerShell. Non-retail N1x units report OEM chassis models, and readiness does not require that observation, so the gate failed silently on hosts that had already passed the proof and capacity checks. The same proof-backed GPU identity already classifies the host as `n1x` for the rest of onboarding and for managed llama.cpp selection; the Ollama gate now accepts that identity as well.

### Related issues
Fixes #11516

## Changes
- `src/lib/inference/nim.ts`: admit the Ollama memory ranking when the proof passed, the verified capacity is at least 30,000 MiB, and either the GPU classification is `n1x` or the chassis observation qualifies. The chassis observation is still collected and reported as readiness evidence.
- `src/lib/inference/nim.gpu-proof-plausible-name.test.ts`: replace the test that expected an OEM chassis to stay compute-constrained with cases for an OEM chassis model and an inconclusive chassis probe on an accepted N1X GPU name, a chassis-only admission for a GPU name outside the accepted identities, and a placeholder GPU name that stays compute-constrained when the chassis model does not qualify. The low-capacity, missing-capacity, failed-proof, multiple-row, and provider cases are unchanged.
- `src/lib/onboard/fatal-runtime-preflight.test.ts`: run the real-provider caller-path test as a matrix of GPU name and chassis observation through `runReadinessGatedRuntimePreflight`: an accepted N1X GPU name with a qualifying, OEM, or inconclusive chassis observation, and a GPU name outside the accepted identities with a qualifying chassis model; each case asserts the platform classification, no `computeConstrained`, and the `qwen3.6:35b` selection. A negative case keeps the unlisted GPU name compute-constrained with `qwen3.5:9b` when the chassis model does not qualify, so each operand of the eligibility condition is proven alone at the preflight boundary.
- `docs/inference/set-up-ollama.mdx` and `docs/get-started/windows-preparation.mdx`: describe the either-identity condition, state that the proof runs only when `nvidia-smi` reports one GPU row, state that the chassis model qualifies only the Ollama model selection and does not establish N1x WSL identity, and scope the managed llama.cpp chassis statement to that selection.

No new mechanism. The gate already existed; the change widens its identity input to the classification the rest of onboarding uses.

## Verification
- `npx vitest run --project cli src/lib/onboard/fatal-runtime-preflight.test.ts src/lib/inference/nim.gpu-proof-plausible-name.test.ts` with `/proc/driver/nvidia` hidden through a `bwrap` tmpfs, matching CI hosts without an NVIDIA kernel driver — 62 passed
- The preflight suite with the base `nim.ts` — 2 failed (the accepted GPU name with an OEM chassis model and with an inconclusive chassis probe), 35 passed; `nim.ts` restored afterwards
- The preflight suite with the chassis operand removed from `n1xWslOllamaEligible` — 1 failed (the unlisted GPU name with a qualifying chassis model), 36 passed; `nim.ts` restored afterwards
- The preflight suite with a null chassis observation passed into the proof-phase `detectGpu` call — 5 failed, including the chassis-only and negative cases; `fatal-runtime-preflight.ts` restored afterwards
- `npm run test:changed` with `/proc/driver/nvidia` hidden — growth guardrails 7 passed; changed CLI suite 37 passed
- `npm run typecheck:cli` — passed with `NODE_OPTIONS=--max-old-space-size=8192`; the default heap aborted with `JavaScript heap out of memory` before reporting
- `npx oxlint` on the changed test file — 0 warnings, 0 errors; `oxfmt` applied
- `npm run checks:repository` — all checks passed
- `npm run docs` — not rerun; no documentation changed since the previous commit, which built with 0 errors and 5 pre-existing warnings
- `CI / Pull Request` — success on the previous commit; the current commit changes one test file
- `Images / Build, Test, and Publish Managed Images` — failed on the previous commit while rebuilding the Pi and Deep Agents Code bases with `E: Version '8.14.1-2+deb13u4' for 'curl' was not found`; the apt pin lives in `Dockerfile.base` files on `main`, outside this diff, and the same jobs fail on other branches
- Independent documentation writer review of the staged tree — Verdict PASS, Result docs-updated; no blocking finding; two pre-existing terminology notes deferred as out of scope
- The diff contains no secrets, API keys, or credentials

## Review notes
No physical N1x WSL run was performed; the reported capacity values (31,168 MiB total, 30,345 MiB available) are exercised through `detectGpu` and `selectDefaultOllamaModel` with fixture provers. Physical QA on an OEM N1x unit remains follow-up evidence.

---
<!-- DCO sign-off is required in this PR description. Every commit must appear as Verified in GitHub. -->
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved automatic Ollama model selection for WSL systems with RTX Spark N1X hardware.
  - Eligible systems can select the largest supported Ollama model when CUDA capability and at least 30,000 MB of available memory are verified.
  - Hardware qualification supports verified Windows chassis identification while keeping unconfirmed placeholder GPU names compute-constrained.

- **Documentation**
  - Clarified that chassis identification applies only to Ollama model selection, not overall system readiness or managed llama.cpp selection.
  - Updated RTX Spark N1X model-selection requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


