### PR TITLE
perf(test): overlap E2E progress outcome cases

### DIFF
--- a/test/e2e/support/e2e-progress-outcome.test.ts
+++ b/test/e2e/support/e2e-progress-outcome.test.ts
@@ -42,7 +42,8 @@ function runFixture(
       timeout: timeoutMs,
     },
     (error, stdout, stderr) => {
-      const signal = child.signalCode ?? error?.signal ?? null;
+      const signal =
+        child.signalCode ?? error?.signal ?? (error?.code === "ABORT_ERR" ? "SIGKILL" : null);
       finish({
         signal,
         status: signal ? null : Number(error?.code) || (error ? -1 : 0),
@@ -58,7 +59,7 @@ function runFixture(
   return resultPromise;
 }
 
-vi.setConfig({ maxConcurrency: 6 });
+vi.setConfig({ maxConcurrency: 7 });
 
 describe.concurrent("automatic E2E phase outcomes", () => {
   it("redacts target identities and explicit progress events before console output", async (context) => {
@@ -88,25 +89,42 @@ describe.concurrent("automatic E2E phase outcomes", () => {
     }
   });
 
-  it("reports the signal when a nested fixture exceeds its deadline", async (context) => {
-    const artifactDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-progress-signal-"));
-    try {
-      const result = await runFixture(
+  it(
+    "reports the signal when a nested fixture exceeds its deadline",
+    { timeout: 15_000 },
+    async (context) => {
+      const artifactDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-progress-signal-"));
+      const timeoutReady = path.join(artifactDir, "timeout-ready");
+      const deadline = new AbortController();
+      const resultPromise = runFixture(
         {
           ...process.env,
           E2E_ARTIFACT_DIR: artifactDir,
-          NEMOCLAW_E2E_PROGRESS_OUTCOME_FIXTURE: "cleanup-failed",
+          NEMOCLAW_E2E_PROGRESS_OUTCOME_FIXTURE: "cleanup-stalled",
+          NEMOCLAW_E2E_PROGRESS_TIMEOUT_READY: timeoutReady,
           NEMOCLAW_RUN_LIVE_E2E: "1",
         },
-        context,
-        50,
+        {
+          onTestFinished: (handler) => context.onTestFinished(handler),
+          signal: AbortSignal.any([context.signal, deadline.signal]),
+        },
       );
-      context.expect(result.status).toBeNull();
-      context.expect(result.signal).toBe("SIGKILL");
-    } finally {
-      fs.rmSync(artifactDir, { recursive: true, force: true });
-    }
-  });
+      try {
+        await vi.waitFor(() => context.expect(fs.existsSync(timeoutReady)).toBe(true), {
+          interval: 10,
+          timeout: 10_000,
+        });
+        deadline.abort();
+        const result = await resultPromise;
+        context.expect(result.status).toBeNull();
+        context.expect(result.signal).toBe("SIGKILL");
+      } finally {
+        deadline.abort();
+        await resultPromise;
+        fs.rmSync(artifactDir, { recursive: true, force: true });
+      }
+    },
+  );
 
   it.for([
     [

--- a/test/e2e/support/e2e-progress-outcome.test.ts
+++ b/test/e2e/support/e2e-progress-outcome.test.ts
@@ -6,7 +6,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { describe, it, vi } from "vitest";
+import { describe, it, type TestContext, vi } from "vitest";
 import { E2E_TEARDOWN_PHASE } from "../fixtures/e2e-test.ts";
 import { REPO_ROOT } from "../fixtures/paths.ts";
 import type { ProgressSummary } from "../fixtures/progress.ts";
@@ -15,57 +15,94 @@ const VITEST = path.join(REPO_ROOT, "node_modules", "vitest", "vitest.mjs");
 const FIXTURE = "test/e2e/support/fixtures/e2e-progress-outcome.fixture.test.ts";
 
 type RunFixtureResult = {
+  signal: NodeJS.Signals | null;
   status: number | null;
   stderr: string;
   stdout: string;
 };
 
-function runFixture(env: NodeJS.ProcessEnv): Promise<RunFixtureResult> {
-  return new Promise((resolve) => {
-    execFile(
-      process.execPath,
-      [VITEST, "run", "--project", "e2e-support", FIXTURE, "--reporter=default"],
-      {
-        cwd: REPO_ROOT,
-        encoding: "utf8",
-        env,
-        killSignal: "SIGKILL",
-        timeout: 20_000,
-      },
-      (error, stdout, stderr) => {
-        resolve({
-          status: error?.signal ? null : Number(error?.code) || (error ? -1 : 0),
-          stderr,
-          stdout,
-        });
-      },
-    );
+function runFixture(
+  env: NodeJS.ProcessEnv,
+  owner: Pick<TestContext, "onTestFinished" | "signal">,
+  timeoutMs = 20_000,
+): Promise<RunFixtureResult> {
+  let finish: (result: RunFixtureResult) => void = () => undefined;
+  const resultPromise = new Promise<RunFixtureResult>((resolve) => {
+    finish = resolve;
   });
+  const child = execFile(
+    process.execPath,
+    [VITEST, "run", "--project", "e2e-support", FIXTURE, "--reporter=default"],
+    {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+      env,
+      killSignal: "SIGKILL",
+      signal: owner.signal,
+      timeout: timeoutMs,
+    },
+    (error, stdout, stderr) => {
+      const signal = child.signalCode ?? error?.signal ?? null;
+      finish({
+        signal,
+        status: signal ? null : Number(error?.code) || (error ? -1 : 0),
+        stderr,
+        stdout,
+      });
+    },
+  );
+  owner.onTestFinished(async () => {
+    child.kill("SIGKILL");
+    await resultPromise;
+  });
+  return resultPromise;
 }
 
 vi.setConfig({ maxConcurrency: 4 });
 
 describe.concurrent("automatic E2E phase outcomes", () => {
-  it("redacts target identities and explicit progress events before console output", async ({
-    expect,
-  }) => {
+  it("redacts target identities and explicit progress events before console output", async (context) => {
     const artifactDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-progress-redaction-"));
     const secret = "progress-event-secret-value";
     try {
-      const result = await runFixture({
-        ...process.env,
-        E2E_ARTIFACT_DIR: artifactDir,
-        E2E_TARGET_ID: `redaction-target-${secret}`,
-        NEMOCLAW_E2E_PROGRESS_EVENT_SECRET: secret,
-        NEMOCLAW_E2E_PROGRESS_OUTCOME_FIXTURE: "redacted-event",
-        NEMOCLAW_RUN_LIVE_E2E: "1",
-      });
+      const result = await runFixture(
+        {
+          ...process.env,
+          E2E_ARTIFACT_DIR: artifactDir,
+          E2E_TARGET_ID: `redaction-target-${secret}`,
+          NEMOCLAW_E2E_PROGRESS_EVENT_SECRET: secret,
+          NEMOCLAW_E2E_PROGRESS_OUTCOME_FIXTURE: "redacted-event",
+          NEMOCLAW_RUN_LIVE_E2E: "1",
+        },
+        context,
+      );
 
       const output = `${result.stdout}\n${result.stderr}`;
+      const { expect } = context;
       expect(result.status, output).toBe(0);
       expect(output).not.toContain(secret);
       expect(output).toContain('target="redaction-target-[REDACTED]"');
       expect(output).toContain("event: retry cleanup for [REDACTED]");
+    } finally {
+      fs.rmSync(artifactDir, { recursive: true, force: true });
+    }
+  });
+
+  it("reports the signal when a nested fixture exceeds its deadline", async (context) => {
+    const artifactDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-progress-signal-"));
+    try {
+      const result = await runFixture(
+        {
+          ...process.env,
+          E2E_ARTIFACT_DIR: artifactDir,
+          NEMOCLAW_E2E_PROGRESS_OUTCOME_FIXTURE: "cleanup-failed",
+          NEMOCLAW_RUN_LIVE_E2E: "1",
+        },
+        context,
+        50,
+      );
+      context.expect(result.status).toBeNull();
+      context.expect(result.signal).toBe("SIGKILL");
     } finally {
       fs.rmSync(artifactDir, { recursive: true, force: true });
     }
@@ -114,17 +151,21 @@ describe.concurrent("automatic E2E phase outcomes", () => {
     { timeout: 30_000 },
     async (
       [mode, status, slug, phaseLabel, expectedOutcome, expectedTeardownOutcome, minimumDurationMs],
-      { expect },
+      context,
     ) => {
       const artifactDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-progress-outcome-"));
       try {
-        const result = await runFixture({
-          ...process.env,
-          E2E_ARTIFACT_DIR: artifactDir,
-          NEMOCLAW_E2E_PROGRESS_OUTCOME_FIXTURE: mode,
-          NEMOCLAW_RUN_LIVE_E2E: "1",
-        });
+        const result = await runFixture(
+          {
+            ...process.env,
+            E2E_ARTIFACT_DIR: artifactDir,
+            NEMOCLAW_E2E_PROGRESS_OUTCOME_FIXTURE: mode,
+            NEMOCLAW_RUN_LIVE_E2E: "1",
+          },
+          context,
+        );
 
+        const { expect } = context;
         expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(status);
         const summary = JSON.parse(
           fs.readFileSync(path.join(artifactDir, slug, "test-progress.json"), "utf8"),

--- a/test/e2e/support/e2e-progress-outcome.test.ts
+++ b/test/e2e/support/e2e-progress-outcome.test.ts
@@ -59,7 +59,7 @@ function runFixture(
   return resultPromise;
 }
 
-vi.setConfig({ maxConcurrency: 7 });
+vi.setConfig({ maxConcurrency: 7, testTimeout: 30_000 });
 
 describe.concurrent("automatic E2E phase outcomes", () => {
   it("redacts target identities and explicit progress events before console output", async (context) => {

--- a/test/e2e/support/e2e-progress-outcome.test.ts
+++ b/test/e2e/support/e2e-progress-outcome.test.ts
@@ -58,7 +58,7 @@ function runFixture(
   return resultPromise;
 }
 
-vi.setConfig({ maxConcurrency: 4 });
+vi.setConfig({ maxConcurrency: 6 });
 
 describe.concurrent("automatic E2E phase outcomes", () => {
   it("redacts target identities and explicit progress events before console output", async (context) => {

--- a/test/e2e/support/e2e-progress-outcome.test.ts
+++ b/test/e2e/support/e2e-progress-outcome.test.ts
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { spawnSync } from "node:child_process";
+import { execFile } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { describe, expect, it } from "vitest";
+import { describe, it, vi } from "vitest";
 import { E2E_TEARDOWN_PHASE } from "../fixtures/e2e-test.ts";
 import { REPO_ROOT } from "../fixtures/paths.ts";
 import type { ProgressSummary } from "../fixtures/progress.ts";
@@ -14,29 +14,52 @@ import type { ProgressSummary } from "../fixtures/progress.ts";
 const VITEST = path.join(REPO_ROOT, "node_modules", "vitest", "vitest.mjs");
 const FIXTURE = "test/e2e/support/fixtures/e2e-progress-outcome.fixture.test.ts";
 
-describe("automatic E2E phase outcomes", () => {
-  it("redacts target identities and explicit progress events before console output", () => {
+type RunFixtureResult = {
+  status: number | null;
+  stderr: string;
+  stdout: string;
+};
+
+function runFixture(env: NodeJS.ProcessEnv): Promise<RunFixtureResult> {
+  return new Promise((resolve) => {
+    execFile(
+      process.execPath,
+      [VITEST, "run", "--project", "e2e-support", FIXTURE, "--reporter=default"],
+      {
+        cwd: REPO_ROOT,
+        encoding: "utf8",
+        env,
+        killSignal: "SIGKILL",
+        timeout: 20_000,
+      },
+      (error, stdout, stderr) => {
+        resolve({
+          status: error?.signal ? null : Number(error?.code) || (error ? -1 : 0),
+          stderr,
+          stdout,
+        });
+      },
+    );
+  });
+}
+
+vi.setConfig({ maxConcurrency: 4 });
+
+describe.concurrent("automatic E2E phase outcomes", () => {
+  it("redacts target identities and explicit progress events before console output", async ({
+    expect,
+  }) => {
     const artifactDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-progress-redaction-"));
     const secret = "progress-event-secret-value";
     try {
-      const result = spawnSync(
-        process.execPath,
-        [VITEST, "run", "--project", "e2e-support", FIXTURE, "--reporter=default"],
-        {
-          cwd: REPO_ROOT,
-          encoding: "utf8",
-          killSignal: "SIGKILL",
-          timeout: 20_000,
-          env: {
-            ...process.env,
-            E2E_ARTIFACT_DIR: artifactDir,
-            E2E_TARGET_ID: `redaction-target-${secret}`,
-            NEMOCLAW_E2E_PROGRESS_EVENT_SECRET: secret,
-            NEMOCLAW_E2E_PROGRESS_OUTCOME_FIXTURE: "redacted-event",
-            NEMOCLAW_RUN_LIVE_E2E: "1",
-          },
-        },
-      );
+      const result = await runFixture({
+        ...process.env,
+        E2E_ARTIFACT_DIR: artifactDir,
+        E2E_TARGET_ID: `redaction-target-${secret}`,
+        NEMOCLAW_E2E_PROGRESS_EVENT_SECRET: secret,
+        NEMOCLAW_E2E_PROGRESS_OUTCOME_FIXTURE: "redacted-event",
+        NEMOCLAW_RUN_LIVE_E2E: "1",
+      });
 
       const output = `${result.stdout}\n${result.stderr}`;
       expect(result.status, output).toBe(0);
@@ -48,7 +71,7 @@ describe("automatic E2E phase outcomes", () => {
     }
   });
 
-  it.each([
+  it.for([
     [
       "failed",
       1,
@@ -88,33 +111,19 @@ describe("automatic E2E phase outcomes", () => {
     ],
   ] as const)(
     "records a real Vitest %s result on the originating phase",
-    (
-      mode,
-      status,
-      slug,
-      phaseLabel,
-      expectedOutcome,
-      expectedTeardownOutcome,
-      minimumDurationMs,
+    { timeout: 30_000 },
+    async (
+      [mode, status, slug, phaseLabel, expectedOutcome, expectedTeardownOutcome, minimumDurationMs],
+      { expect },
     ) => {
       const artifactDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-progress-outcome-"));
       try {
-        const result = spawnSync(
-          process.execPath,
-          [VITEST, "run", "--project", "e2e-support", FIXTURE, "--reporter=default"],
-          {
-            cwd: REPO_ROOT,
-            encoding: "utf8",
-            killSignal: "SIGKILL",
-            timeout: 20_000,
-            env: {
-              ...process.env,
-              E2E_ARTIFACT_DIR: artifactDir,
-              NEMOCLAW_E2E_PROGRESS_OUTCOME_FIXTURE: mode,
-              NEMOCLAW_RUN_LIVE_E2E: "1",
-            },
-          },
-        );
+        const result = await runFixture({
+          ...process.env,
+          E2E_ARTIFACT_DIR: artifactDir,
+          NEMOCLAW_E2E_PROGRESS_OUTCOME_FIXTURE: mode,
+          NEMOCLAW_RUN_LIVE_E2E: "1",
+        });
 
         expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(status);
         const summary = JSON.parse(
@@ -134,6 +143,5 @@ describe("automatic E2E phase outcomes", () => {
         fs.rmSync(artifactDir, { recursive: true, force: true });
       }
     },
-    30_000,
   );
 });

--- a/test/e2e/support/fixtures/e2e-progress-outcome.fixture.test.ts
+++ b/test/e2e/support/fixtures/e2e-progress-outcome.fixture.test.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import fs from "node:fs";
 import { setTimeout as sleep } from "node:timers/promises";
 
 import { test } from "../../fixtures/e2e-test.ts";
@@ -45,6 +46,24 @@ test.runIf(outcome === "cleanup-failed")(
     cleanup.add("deterministic cleanup failure", async () => {
       await sleep(25);
       throw new Error("deterministic cleanup failure");
+    });
+  },
+);
+
+test.runIf(outcome === "cleanup-stalled")(
+  "stalls after cleanup starts",
+  {
+    meta: {
+      e2ePhases: ["enter stalled cleanup case", "run stalled E2E cleanup"],
+    },
+  },
+  ({ cleanup, expect, progress }) => {
+    const timeoutReady = process.env.NEMOCLAW_E2E_PROGRESS_TIMEOUT_READY;
+    expect(timeoutReady, "timeout-ready marker path is required").toBeTruthy();
+    progress.phase("run stalled E2E cleanup");
+    cleanup.add("deterministic stalled cleanup", async () => {
+      fs.writeFileSync(timeoutReady!, "ready");
+      await sleep(60_000);
     });
   },
 );


### PR DESCRIPTION
## Outcome

The focused automatic E2E phase-outcome test body drops from 13.90s to 2.59s (81% faster). The current suite also covers a seventh process-lifecycle case. Production behavior is unchanged.

## Reason

The file launched isolated nested Vitest processes serially, leaving independent subprocess work idle behind the previous case.

## Changes

- Replace blocking fixture launches with an async helper that preserves exit status, termination signal, stdout, and stderr.
- Run all seven isolated cases in one bounded worker wave.
- Wait for the stalled-cleanup fixture's ready marker before applying its deadline, then verify `SIGKILL` and await child cleanup.
- Propagate owner cancellation and force-clean stalled children during teardown.
- Keep every case isolated in its own artifact directory with local cleanup.

## Verification

- Original clean-main benchmark — 6/6 passed in 13.90s.
- Current expanded suite — 7/7 passed on repeated final runs of 2.59s and 2.66s; the previous four-worker PR head took 4.08s and 4.33s, so filling the remaining worker slots removes another 37%.
- Shuffled run with seed `11620` — 7/7 passed in 2.66s.
- `NODE_OPTIONS=--max-old-space-size=8192 npm run typecheck:cli` — passed.
- `NODE_OPTIONS=--max-old-space-size=8192 npm run check:diff` — passed.
- Normal commit and pre-push hooks — passed.
- Diff reviewed for secrets, API keys, and credentials — none present.

Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded automated coverage for fixture termination, timeout handling, abort signals, and cleanup.
  - Added validation for processes terminated by `SIGKILL`.
  - Added coverage for cleanup that remains pending after a timeout.
  - Improved concurrent parameterized test coverage and assertion handling.
  - Added readiness checks and cleanup verification for stalled end-to-end scenarios.
  - Strengthened timeout and resource-cleanup validation for nested fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->