### PR TITLE
fix(onboard): bind CHAT_UI_URL dashboard port by loopback interface and persist external URL

### DIFF
--- a/src/commands/sandbox/dashboard-url.ts
+++ b/src/commands/sandbox/dashboard-url.ts
@@ -9,7 +9,9 @@ import type { SandboxEntry } from "../../lib/state/registry";
 
 type DashboardUrlRuntimeBridge = {
   fetchGatewayAuthTokenFromSandbox: (sandboxName: string) => string | null;
-  getSandbox: (sandboxName: string) => Pick<SandboxEntry, "agent" | "dashboardPort"> | null;
+  getSandbox: (
+    sandboxName: string,
+  ) => Pick<SandboxEntry, "agent" | "dashboardPort" | "dashboardExternalUrl"> | null;
   getAccessUrl?: (port: number) => string | null;
 };
 

--- a/src/lib/adapters/openshell/forward-service.test.ts
+++ b/src/lib/adapters/openshell/forward-service.test.ts
@@ -77,14 +77,49 @@ function createLinuxOwnerFixture(actualExecutable?: string) {
   return { procRoot, target: { ...target, executable } };
 }
 
+// A loopback forward (127.0.0.1 on 0x4965 = 18789) whose port is also bound on
+// an external interface by a different process (a reverse proxy). The external
+// entry's inode belongs to pid 9876; ownership must ignore it and count only
+// the loopback owner pid 4321 (#11439).
+function createLinuxOwnerFixtureWithExternalCoListener() {
+  const root = mkdtempSync(path.join(os.tmpdir(), "nemoclaw-forward-owner-ext-"));
+  temporaryDirectories.push(root);
+  const procRoot = path.join(root, "proc");
+  const binRoot = path.join(root, "bin");
+  mkdirSync(path.join(procRoot, "net"), { recursive: true });
+  mkdirSync(path.join(procRoot, "4321", "fd"), { recursive: true });
+  mkdirSync(path.join(procRoot, "9876", "fd"), { recursive: true });
+  mkdirSync(binRoot);
+  const executable = path.join(binRoot, "openshell");
+  writeFileSync(executable, "");
+  writeFileSync(
+    path.join(procRoot, "net", "tcp"),
+    // Loopback listener (0100007F) owned by the forward, plus an
+    // external-interface listener (0F90630A) owned by the reverse proxy.
+    "  0: 0100007F:4965 00000000:0000 0A 00000000:00000000 00:00000000 00000000  998 0 12345 1\n" +
+      "  1: 0F90630A:4965 00000000:0000 0A 00000000:00000000 00:00000000 00000000  998 0 55555 1\n",
+  );
+  writeFileSync(path.join(procRoot, "net", "tcp6"), "");
+  symlinkSync("socket:[12345]", path.join(procRoot, "4321", "fd", "7"));
+  symlinkSync("socket:[55555]", path.join(procRoot, "9876", "fd", "8"));
+  symlinkSync(executable, path.join(procRoot, "4321", "exe"));
+  return { procRoot, target: { ...target, executable } };
+}
+
+// Loopback forwards probe with `lsof -FpPn`, pairing each pid with its bind
+// endpoint so external-interface-only listeners are excluded (#11439).
+function loopbackListenerField(pid: string, port = 18_789): string {
+  return `p${pid}\nPTCP\nn127.0.0.1:${port}\n`;
+}
+
 function darwinOwnerProbe(
   commandLine: string,
-  finalListener = "4321\n",
+  finalListener = loopbackListenerField("4321"),
   executable = process.execPath,
 ) {
   return vi
     .fn()
-    .mockReturnValueOnce({ status: 0, stdout: "4321\n" })
+    .mockReturnValueOnce({ status: 0, stdout: loopbackListenerField("4321") })
     .mockReturnValueOnce({ status: 0, stdout: `${executable}\n/mach_kernel\n` })
     .mockReturnValueOnce({ status: 0, stdout: commandLine })
     .mockReturnValueOnce({ status: 0, stdout: finalListener });
@@ -255,7 +290,10 @@ describe("OpenShell forward service", () => {
   it("rejects a foreign Darwin executable even when it maps the trusted binary", () => {
     const expected = [ownerTarget.executable, ...buildForwardServiceArgs(ownerTarget)].join(" ");
     const responses = new Map([
-      [JSON.stringify(["lsof", "-ti4TCP:18789", "-sTCP:LISTEN"]), { status: 0, stdout: "4321\n" }],
+      [
+        JSON.stringify(["lsof", "-i4TCP:18789", "-sTCP:LISTEN", "-P", "-n", "-FpPn"]),
+        { status: 0, stdout: loopbackListenerField("4321") },
+      ],
       [
         JSON.stringify(["lsof", "-a", "-p", "4321", "-d", "txt", "-Fn"]),
         {
@@ -299,7 +337,7 @@ describe("OpenShell forward service", () => {
 
   it("rejects ambiguous or changing listener ownership", () => {
     const expected = [ownerTarget.executable, ...buildForwardServiceArgs(ownerTarget)].join(" ");
-    const probe = darwinOwnerProbe(`${expected}\n`, "9876\n");
+    const probe = darwinOwnerProbe(`${expected}\n`, loopbackListenerField("9876"));
 
     expect(isForwardServiceListenerOwner(ownerTarget, { platform: "darwin", probe })).toBe(false);
   });
@@ -312,7 +350,7 @@ describe("OpenShell forward service", () => {
 
     const psTimeout = vi
       .fn()
-      .mockReturnValueOnce({ status: 0, stdout: "4321\n" })
+      .mockReturnValueOnce({ status: 0, stdout: loopbackListenerField("4321") })
       .mockReturnValueOnce({ status: 0, stdout: `${process.execPath}\n/mach_kernel\n` })
       .mockReturnValueOnce({ status: null, stdout: "" });
     expect(
@@ -341,8 +379,68 @@ describe("OpenShell forward service", () => {
       }),
     ).toBe(true);
     expect(probe).toHaveBeenCalledTimes(3);
-    expect(probe).toHaveBeenCalledWith("lsof", ["-ti4TCP:18789", "-sTCP:LISTEN"]);
+    expect(probe).toHaveBeenCalledWith("lsof", [
+      "-i4TCP:18789",
+      "-sTCP:LISTEN",
+      "-P",
+      "-n",
+      "-FpPn",
+    ]);
     expect(probe).toHaveBeenCalledWith("ps", ["-ww", "-p", "4321", "-o", "args="]);
+  });
+
+  it("ignores an external-interface-only co-listener for a loopback forward (#11439)", () => {
+    const expected = [ownerTarget.executable, ...buildForwardServiceArgs(ownerTarget)].join(" ");
+    // Field-mode lsof reports the reverse proxy on an external interface plus
+    // NemoClaw's own loopback forward. Only the loopback pid may count.
+    const listenerField = `p3529439\nPTCP\nn10.63.144.115:18789\n` + loopbackListenerField("4321");
+    const probe = vi
+      .fn()
+      .mockReturnValueOnce({ status: 0, stdout: listenerField })
+      .mockReturnValueOnce({ status: 0, stdout: `${ownerTarget.executable}\n/mach_kernel\n` })
+      .mockReturnValueOnce({ status: 0, stdout: `${expected}\n` })
+      .mockReturnValueOnce({ status: 0, stdout: listenerField });
+
+    expect(isForwardServiceListenerOwner(ownerTarget, { platform: "darwin", probe })).toBe(true);
+  });
+
+  it("still rejects a genuine second loopback co-listener for a loopback forward", () => {
+    const listenerField = loopbackListenerField("4321") + loopbackListenerField("9999");
+    const probe = vi.fn().mockReturnValue({ status: 0, stdout: listenerField });
+
+    expect(isForwardServiceListenerOwner(ownerTarget, { platform: "darwin", probe })).toBe(false);
+  });
+
+  it("counts every interface for a remote-exposed (0.0.0.0) forward", () => {
+    const remoteTarget: ForwardServiceTarget = { ...ownerTarget, localHost: "0.0.0.0" };
+    // A 0.0.0.0 forward must keep the interface-agnostic `-ti` count so any
+    // co-listener still blocks ownership.
+    const probe = vi.fn().mockReturnValue({ status: 0, stdout: "4321\n3529439\n" });
+
+    expect(isForwardServiceListenerOwner(remoteTarget, { platform: "darwin", probe })).toBe(false);
+    expect(probe).toHaveBeenCalledWith("lsof", ["-ti4TCP:18789", "-sTCP:LISTEN"]);
+  });
+
+  it("ignores an external-interface-only /proc listener for a loopback forward (#11439)", () => {
+    const fixture = createLinuxOwnerFixtureWithExternalCoListener();
+    const expected = [fixture.target.executable, ...buildForwardServiceArgs(fixture.target)].join(
+      " ",
+    );
+    const responses = {
+      lsof: { status: null, stdout: "" },
+      ps: { status: 0, stdout: `${expected}\n` },
+    };
+    const probe = vi.fn(
+      (executable: string) => responses[executable as keyof typeof responses] ?? responses.lsof,
+    );
+
+    expect(
+      isForwardServiceListenerOwner(fixture.target, {
+        platform: "linux",
+        probe,
+        procRoot: fixture.procRoot,
+      }),
+    ).toBe(true);
   });
 
   it("rejects spoofed arguments when the Linux executable is different", () => {

--- a/src/lib/adapters/openshell/forward-service.ts
+++ b/src/lib/adapters/openshell/forward-service.ts
@@ -218,21 +218,68 @@ function captureProcess(executable: string, args: readonly string[]) {
   return { status: result.status, stdout: result.stdout ?? "" };
 }
 
-function lsofListenerPids(port: number, probe: ForwardServiceOwnerProbe): string[] | null {
-  const result = probe("lsof", [`-ti4TCP:${String(port)}`, "-sTCP:LISTEN"]);
-  if (result.status === null) return null;
-  if (result.status !== 0) return [];
-  return [
-    ...new Set(
-      result.stdout
-        .split(/\r?\n/u)
-        .map((line) => line.trim())
-        .filter(Boolean),
-    ),
-  ];
+/**
+ * A loopback forward binds `127.0.0.1`, so only loopback and wildcard listeners
+ * actually contend for that socket. An `lsof -n` NAME reporting a listener bound
+ * solely to an external interface (e.g. a TLS reverse proxy fronting
+ * `CHAT_UI_URL` on the same port number) does not, and must not count toward
+ * forward ownership on the loopback bind (#11439). Wildcard binds (`*`,
+ * `0.0.0.0`) include loopback and always count; docker-proxy / loopback
+ * detection (#3260) is preserved. When the forward itself binds `0.0.0.0`
+ * (operator-opted remote exposure), every listener on the port contends, so no
+ * filtering applies.
+ */
+function lsofNameContendsWithLoopback(name: string): boolean {
+  // NAME is the bind endpoint, e.g. "127.0.0.1:18789", "*:18789", or
+  // "10.0.0.5:18789". Strip the trailing ":port" (IPv4 only here).
+  const address = name.replace(/:\d+$/u, "");
+  if (address === "*" || address === "0.0.0.0") return true;
+  return address.startsWith("127.");
 }
 
-function linuxListenerPids(port: number, procRoot: string, workLimit: number): string[] {
+function lsofListenerPids(
+  port: number,
+  probe: ForwardServiceOwnerProbe,
+  loopbackOnly: boolean,
+): string[] | null {
+  if (!loopbackOnly) {
+    const result = probe("lsof", [`-ti4TCP:${String(port)}`, "-sTCP:LISTEN"]);
+    if (result.status === null) return null;
+    if (result.status !== 0) return [];
+    return [
+      ...new Set(
+        result.stdout
+          .split(/\r?\n/u)
+          .map((line) => line.trim())
+          .filter(Boolean),
+      ),
+    ];
+  }
+  // Field-mode output pairs each PID (`p<pid>`) with the bind endpoint
+  // (`n<addr>:<port>`) so external-interface-only listeners can be excluded
+  // before counting owners.
+  const result = probe("lsof", [`-i4TCP:${String(port)}`, "-sTCP:LISTEN", "-P", "-n", "-FpPn"]);
+  if (result.status === null) return null;
+  if (result.status !== 0) return [];
+  const pids = new Set<string>();
+  let currentPid: string | null = null;
+  for (const rawLine of result.stdout.split(/\r?\n/u)) {
+    const line = rawLine.trim();
+    if (line.startsWith("p")) {
+      currentPid = /^p[1-9]\d*$/u.test(line) ? line.slice(1) : null;
+    } else if (line.startsWith("n") && currentPid !== null) {
+      if (lsofNameContendsWithLoopback(line.slice(1))) pids.add(currentPid);
+    }
+  }
+  return [...pids];
+}
+
+function linuxListenerPids(
+  port: number,
+  procRoot: string,
+  workLimit: number,
+  loopbackOnly: boolean,
+): string[] {
   if (!Number.isSafeInteger(workLimit) || workLimit < 1) return [];
   const portSuffix = `:${port.toString(16).padStart(4, "0").toUpperCase()}`;
   const socketInodes = new Set<string>();
@@ -244,6 +291,17 @@ function linuxListenerPids(port: number, procRoot: string, workLimit: number): s
         fields[1]?.toUpperCase().endsWith(portSuffix) &&
         /^\d+$/u.test(fields[9] ?? "")
       ) {
+        // Local address is HEXIP:HEXPORT (little-endian IP). A loopback forward
+        // only contends with wildcard (`00000000`) or loopback (`7F......`)
+        // binds; an external-interface-only listener on the same port is
+        // ignored (#11439).
+        if (loopbackOnly) {
+          const hexIp = (fields[1] ?? "").split(":")[0]?.toUpperCase() ?? "";
+          const isWildcard = hexIp === "00000000";
+          // 127.0.0.0/8 → least-significant byte 0x7F in little-endian order.
+          const isLoopback = hexIp.length === 8 && hexIp.endsWith("7F");
+          if (!isWildcard && !isLoopback) continue;
+        }
         socketInodes.add(fields[9]);
       }
     }
@@ -284,10 +342,11 @@ function listenerPids(
   procRoot: string,
   procWorkLimit: number,
   probe: ForwardServiceOwnerProbe,
+  loopbackOnly: boolean,
 ): string[] {
-  const lsof = lsofListenerPids(port, probe);
+  const lsof = lsofListenerPids(port, probe, loopbackOnly);
   if (lsof !== null || platform !== "linux") return lsof ?? [];
-  return linuxListenerPids(port, procRoot, procWorkLimit);
+  return linuxListenerPids(port, procRoot, procWorkLimit, loopbackOnly);
 }
 
 function executableMatches(actualExecutable: string, expectedExecutable: string): boolean {
@@ -330,7 +389,19 @@ export function isForwardServiceListenerOwner(
   const probe = options.probe ?? captureProcess;
   const procRoot = options.procRoot ?? "/proc";
   const procWorkLimit = options.procWorkLimit ?? LINUX_PROC_WORK_LIMIT;
-  const before = listenerPids(target.localPort, platform, procRoot, procWorkLimit, probe);
+  // A loopback forward only owns the loopback socket; an external-interface-only
+  // listener on the same port number (e.g. a reverse proxy fronting CHAT_UI_URL)
+  // must not defeat ownership. A remote-exposed (`0.0.0.0`) forward keeps the
+  // interface-agnostic count so any co-listener still blocks ownership (#11439).
+  const loopbackOnly = target.localHost === "127.0.0.1";
+  const before = listenerPids(
+    target.localPort,
+    platform,
+    procRoot,
+    procWorkLimit,
+    probe,
+    loopbackOnly,
+  );
   const [pid] = before;
   if (before.length !== 1 || pid === undefined || !/^[1-9]\d*$/u.test(pid)) return false;
   if (!processExecutableMatches(pid, target, platform, procRoot, probe)) return false;
@@ -338,7 +409,14 @@ export function isForwardServiceListenerOwner(
   if (commandLine.status !== 0) return false;
   const expected = [target.executable, ...buildForwardServiceArgs(target)].join(" ");
   if (commandLine.stdout.trim() !== expected) return false;
-  const after = listenerPids(target.localPort, platform, procRoot, procWorkLimit, probe);
+  const after = listenerPids(
+    target.localPort,
+    platform,
+    procRoot,
+    procWorkLimit,
+    probe,
+    loopbackOnly,
+  );
   return after.length === 1 && after[0] === pid;
 }
 

--- a/src/lib/dashboard-url-command.test.ts
+++ b/src/lib/dashboard-url-command.test.ts
@@ -183,6 +183,52 @@ describe("dashboard-url command helpers", () => {
     expect(sinks.err).toEqual([]);
   });
 
+  it("prints the persisted external dashboard URL for a session-auth agent (#11439)", () => {
+    const sinks = makeSinks();
+
+    runDashboardUrlCommand(
+      "hermes",
+      { quiet: true },
+      {
+        fetchToken: () => null,
+        getSandbox: () => ({
+          agent: "hermes",
+          dashboardPort: 18789,
+          dashboardExternalUrl: "https://dash.example.com:18789",
+        }),
+        getAgentDashboardAuth: () => "session",
+        // A host access URL must not override the persisted external origin.
+        getAccessUrl: () => "http://172.22.1.1:18789",
+        log: sinks.log,
+        error: sinks.error,
+      },
+    );
+
+    expect(sinks.out).toEqual(["https://dash.example.com:18789/"]);
+  });
+
+  it("embeds the token in the persisted external dashboard URL for token-auth agents (#11439)", () => {
+    const sinks = makeSinks();
+
+    runDashboardUrlCommand(
+      "agent-ui",
+      { quiet: true },
+      {
+        fetchToken: () => "agent-token",
+        getSandbox: () => ({
+          agent: "agent-ui",
+          dashboardPort: 19001,
+          dashboardExternalUrl: "https://dash.example.com:19001",
+        }),
+        getAgentDashboardAuth: () => "url_token",
+        log: sinks.log,
+        error: sinks.error,
+      },
+    );
+
+    expect(sinks.out).toEqual(["https://dash.example.com:19001/#token=agent-token"]);
+  });
+
   it("fetches a token for non-OpenClaw agents with token-auth dashboards", () => {
     const sinks = makeSinks();
     const fetchToken = vi.fn(() => "agent-token");

--- a/src/lib/dashboard-url-command.ts
+++ b/src/lib/dashboard-url-command.ts
@@ -17,7 +17,9 @@ export interface DashboardUrlCommandDeps {
   /** Pull gateway.auth.token from the sandbox config (host-side helper). */
   fetchToken: (sandboxName: string) => string | null;
   /** Read sandbox metadata such as agent name and recorded dashboard port. */
-  getSandbox?: (sandboxName: string) => Pick<SandboxEntry, "agent" | "dashboardPort"> | null;
+  getSandbox?: (
+    sandboxName: string,
+  ) => Pick<SandboxEntry, "agent" | "dashboardPort" | "dashboardExternalUrl"> | null;
   /** Resolve the browser-facing dashboard base URL for this host, when known. */
   getAccessUrl?: (port: number) => string | null;
   /** Resolve a registered agent's dashboard auth contract. */
@@ -63,6 +65,21 @@ function resolveDashboardPort(sandbox: Pick<SandboxEntry, "dashboardPort"> | nul
   return typeof port === "number" && Number.isInteger(port) && port >= 1 && port <= 65535
     ? port
     : DASHBOARD_PORT;
+}
+
+/**
+ * Prefer the persisted external dashboard URL (the browser-facing HTTPS reverse
+ * proxy origin resolved from `CHAT_UI_URL` at onboard time) over any
+ * host-derived access URL, falling back to the loopback form only when no
+ * external origin was configured (#11439).
+ */
+function resolveDashboardBaseUrl(
+  sandbox: Pick<SandboxEntry, "dashboardExternalUrl"> | null,
+  accessUrl: string | null,
+): string | null {
+  const external = sandbox?.dashboardExternalUrl;
+  if (typeof external === "string" && external.length > 0) return external;
+  return accessUrl;
 }
 
 export function buildDashboardUrl(
@@ -141,7 +158,7 @@ export function runDashboardUrlCommand(
     for (const line of hint) log(line);
   };
 
-  let sandbox: Pick<SandboxEntry, "agent" | "dashboardPort"> | null = null;
+  let sandbox: Pick<SandboxEntry, "agent" | "dashboardPort" | "dashboardExternalUrl"> | null = null;
   if (deps.getSandbox) {
     try {
       sandbox = deps.getSandbox(sandboxName);
@@ -170,7 +187,7 @@ export function runDashboardUrlCommand(
   }
   if (dashboardAuth === "session" || dashboardAuth === "none") {
     const port = resolveDashboardPort(sandbox);
-    const accessUrl = deps.getAccessUrl?.(port) ?? null;
+    const accessUrl = resolveDashboardBaseUrl(sandbox, deps.getAccessUrl?.(port) ?? null);
     const url = buildPlainDashboardUrl(port, accessUrl ?? undefined);
     if (options.quiet) {
       log(url);
@@ -197,7 +214,7 @@ export function runDashboardUrlCommand(
   }
 
   const port = resolveDashboardPort(sandbox);
-  const accessUrl = deps.getAccessUrl?.(port) ?? null;
+  const accessUrl = resolveDashboardBaseUrl(sandbox, deps.getAccessUrl?.(port) ?? null);
   const url = buildDashboardUrl(token, port, accessUrl ?? undefined);
   if (options.quiet) {
     log(url);

--- a/src/lib/dashboard/url.test.ts
+++ b/src/lib/dashboard/url.test.ts
@@ -3,7 +3,12 @@
 
 import { describe, expect, it } from "vitest";
 
-import { rebindLoopbackDashboardUrlPort } from "./url";
+import {
+  isValidDashboardExternalUrl,
+  rebindLoopbackDashboardUrlPort,
+  resolveExternalDashboardUrl,
+  resolveExternalDashboardUrlForPort,
+} from "./url";
 
 describe("rebindLoopbackDashboardUrlPort", () => {
   it.each([
@@ -12,5 +17,72 @@ describe("rebindLoopbackDashboardUrlPort", () => {
     ["https://secure-link.example/dashboard", "https://secure-link.example/dashboard"],
   ] as const)("applies the loopback port policy to %s", (input, expected) => {
     expect(rebindLoopbackDashboardUrlPort(input, 29_443)).toBe(expected);
+  });
+});
+
+describe("resolveExternalDashboardUrl (#11439)", () => {
+  it("returns a genuine external origin, trimming a trailing slash", () => {
+    expect(resolveExternalDashboardUrl("https://dash.example.com:18789/")).toBe(
+      "https://dash.example.com:18789",
+    );
+    expect(resolveExternalDashboardUrl("https://dash.example.com:18789")).toBe(
+      "https://dash.example.com:18789",
+    );
+  });
+
+  it("returns null for loopback dashboard URLs (loopback reported from dashboardPort)", () => {
+    expect(resolveExternalDashboardUrl("http://127.0.0.1:18789")).toBeNull();
+    expect(resolveExternalDashboardUrl("http://localhost:18789/")).toBeNull();
+  });
+
+  it("returns null for empty or malformed input", () => {
+    expect(resolveExternalDashboardUrl(null)).toBeNull();
+    expect(resolveExternalDashboardUrl(undefined)).toBeNull();
+    expect(resolveExternalDashboardUrl("")).toBeNull();
+    expect(resolveExternalDashboardUrl("not a url")).toBeNull();
+  });
+
+  it("returns null for non-http(s), credentialed, or over-long origins so a persisted value can be read back", () => {
+    // These would otherwise be rejected at registry read time and brick list/status.
+    expect(resolveExternalDashboardUrl("ws://proxy.example.com:18789")).toBeNull();
+    expect(resolveExternalDashboardUrl("ftp://proxy.example.com:18789")).toBeNull();
+    expect(resolveExternalDashboardUrl("https://user:pass@dash.example.com:18789")).toBeNull();
+    expect(resolveExternalDashboardUrl(`https://dash.example.com/${"a".repeat(3000)}`)).toBeNull();
+  });
+});
+
+describe("isValidDashboardExternalUrl shared write/read predicate (#11439)", () => {
+  it("accepts absolute http(s) origins without credentials", () => {
+    expect(isValidDashboardExternalUrl("https://dash.example.com:18789")).toBe(true);
+    expect(isValidDashboardExternalUrl("http://dash.example.com/path")).toBe(true);
+  });
+
+  it("rejects non-http(s), credentialed, control-char, and over-long values", () => {
+    expect(isValidDashboardExternalUrl("ws://dash.example.com:18789")).toBe(false);
+    expect(isValidDashboardExternalUrl("https://user:pass@dash.example.com")).toBe(false);
+    expect(isValidDashboardExternalUrl("https://dash.example.com/\u0000")).toBe(false);
+    expect(isValidDashboardExternalUrl(`https://dash.example.com/${"a".repeat(3000)}`)).toBe(false);
+    expect(isValidDashboardExternalUrl("")).toBe(false);
+    expect(isValidDashboardExternalUrl("dash.example.com:18789")).toBe(false);
+  });
+});
+
+describe("resolveExternalDashboardUrlForPort (#11439)", () => {
+  it("rebinds the CHAT_UI_URL origin to the effective dashboard port", () => {
+    expect(resolveExternalDashboardUrlForPort("https://dash.example.com:18789", 18790)).toBe(
+      "https://dash.example.com:18790",
+    );
+  });
+
+  it("adds a scheme to a bare host:port origin before rebinding", () => {
+    expect(resolveExternalDashboardUrlForPort("dash.example.com:18789", 18790)).toBe(
+      "http://dash.example.com:18790",
+    );
+  });
+
+  it("returns null for a loopback or missing origin", () => {
+    expect(resolveExternalDashboardUrlForPort("http://127.0.0.1:18789", 18790)).toBeNull();
+    expect(resolveExternalDashboardUrlForPort(null, 18790)).toBeNull();
+    expect(resolveExternalDashboardUrlForPort("", 18790)).toBeNull();
   });
 });

--- a/src/lib/dashboard/url.ts
+++ b/src/lib/dashboard/url.ts
@@ -15,3 +15,78 @@ export function rebindLoopbackDashboardUrlPort(value: string, port: number): str
   parsed.port = String(port);
   return parsed.toString();
 }
+
+const CONTROL_CHARACTER = /[\u0000-\u001f\u007f]/u;
+
+/**
+ * A persistable external dashboard URL must be an absolute http(s) URL with a
+ * host and no embedded credentials, matching what onboarding derives from
+ * `CHAT_UI_URL`. This is the single source of truth shared by the writer
+ * (`resolveExternalDashboardUrl`) and the registry read-side validator so a
+ * value that persists can always be read back (#11439). Userinfo is rejected so
+ * an operator-facing address is never a secret; control characters and
+ * unbounded length are rejected as registry-hardening.
+ */
+export function isValidDashboardExternalUrl(value: string): boolean {
+  if (value.length === 0 || value.length > 2048 || CONTROL_CHARACTER.test(value)) return false;
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return false;
+  }
+  return (
+    (parsed.protocol === "http:" || parsed.protocol === "https:") &&
+    parsed.hostname.length > 0 &&
+    parsed.username === "" &&
+    parsed.password === ""
+  );
+}
+
+/**
+ * Resolve the external dashboard URL to persist from the operator's
+ * `CHAT_UI_URL`, rebinding its port to the effective dashboard port. Returns
+ * null when no external origin is configured, the origin is loopback, or the
+ * value is not a valid persistable external origin. Shared by the fresh-create,
+ * reuse/resume, and OpenClaw-forward persistence paths so all record the same
+ * value (#11439).
+ */
+export function resolveExternalDashboardUrlForPort(
+  chatUiUrlEnv: string | null | undefined,
+  effectivePort: number,
+): string | null {
+  if (!chatUiUrlEnv) return null;
+  const normalized = chatUiUrlEnv.includes("://") ? chatUiUrlEnv : `http://${chatUiUrlEnv}`;
+  let rebound: string;
+  try {
+    const parsed = new URL(normalized);
+    parsed.port = String(effectivePort);
+    rebound = parsed.toString();
+  } catch {
+    return null;
+  }
+  return resolveExternalDashboardUrl(rebound);
+}
+
+/**
+ * Return the browser-facing external dashboard URL to persist for a sandbox, or
+ * null when the resolved dashboard URL is a plain loopback address or is not a
+ * valid persistable external origin. A loopback URL adds nothing over the
+ * persisted `dashboardPort`, so only a genuine external origin (e.g. the HTTPS
+ * reverse proxy behind `CHAT_UI_URL`) is worth recording so `status`,
+ * `dashboard-url`, and `list` can report it later (#11439). The value is
+ * validated with the same predicate the registry read-side enforces, so a
+ * persisted value can always be read back. Malformed or non-http(s) input
+ * yields null.
+ */
+export function resolveExternalDashboardUrl(chatUiUrl: string | null | undefined): string | null {
+  if (!chatUiUrl) return null;
+  const normalized = chatUiUrl.replace(/\/$/, "");
+  if (!isValidDashboardExternalUrl(normalized)) return null;
+  try {
+    if (isLoopbackDashboardUrl(normalized)) return null;
+  } catch {
+    return null;
+  }
+  return normalized;
+}

--- a/src/lib/inventory/index.ts
+++ b/src/lib/inventory/index.ts
@@ -30,6 +30,8 @@ export interface SandboxEntry {
   messaging?: SandboxMessagingState | null;
   agent?: string | null;
   dashboardPort?: number | null;
+  /** Browser-facing external dashboard URL persisted from CHAT_UI_URL (#11439). */
+  dashboardExternalUrl?: string | null;
   // Passthrough of the durable registry reservation marker so list and status
   // hide registrations that have not committed their lifecycle yet.
   pendingRouteReservation?: true;
@@ -106,6 +108,8 @@ export interface SandboxInventoryRow {
   policies: string[];
   agent: string;
   dashboardPort?: number | null;
+  /** Browser-facing external dashboard URL when CHAT_UI_URL set an external origin (#11439). */
+  dashboardExternalUrl?: string | null;
   isDefault: boolean;
   activeSessionCount: number | null;
   // #5714: row recovered display-only from the live gateway. Its agent/GPU/
@@ -198,6 +202,8 @@ export interface StatusSandboxRow {
   agent: string;
   phase?: "pending" | "configuring" | "active";
   dashboardPort?: number | null;
+  /** Browser-facing external dashboard URL when CHAT_UI_URL set an external origin (#11439). */
+  dashboardExternalUrl?: string | null;
   isDefault: boolean;
 }
 
@@ -224,6 +230,19 @@ export interface StatusReport {
 function safeStatusString(value: string | null | undefined): string | null {
   if (typeof value !== "string" || value.length === 0) return null;
   return redactFull(value);
+}
+
+/**
+ * Resolve the persisted browser-facing external dashboard URL for a sandbox,
+ * or null when none was configured (loopback-only dashboards report the
+ * `dashboardPort`-derived loopback form instead). Redaction is not applied: the
+ * external URL is an operator-facing address, not a secret (#11439).
+ */
+function resolveDashboardExternalUrl(
+  sandbox: Pick<SandboxEntry, "dashboardExternalUrl">,
+): string | null {
+  const external = sandbox.dashboardExternalUrl;
+  return typeof external === "string" && external.length > 0 ? external : null;
 }
 
 function projectIncompleteOnboarding(
@@ -321,6 +340,9 @@ async function buildSandboxInventoryRow(
     policies: (await getPolicyPresets?.(sandbox.name)) ?? [],
     agent: resolveDisplayAgent(sandbox),
     ...(sandbox.dashboardPort != null ? { dashboardPort: sandbox.dashboardPort } : {}),
+    ...(resolveDashboardExternalUrl(sandbox) != null
+      ? { dashboardExternalUrl: resolveDashboardExternalUrl(sandbox) }
+      : {}),
     isDefault: sandbox.name === defaultSandbox,
     activeSessionCount,
     ...(sandbox.recoveredFromGateway ? { recoveredFromGateway: true } : {}),
@@ -462,7 +484,9 @@ export function renderSandboxInventoryText(
       if (providerDrifted) parts.push(`provider=${sandbox.provider || "unknown"}`);
       log(`      (live OpenShell gateway differs from onboarded: ${parts.join(", ")})`);
     }
-    if (sandbox.dashboardPort != null) {
+    if (sandbox.dashboardExternalUrl != null) {
+      log(`      dashboard: ${sandbox.dashboardExternalUrl}`);
+    } else if (sandbox.dashboardPort != null) {
       log(`      dashboard: http://127.0.0.1:${sandbox.dashboardPort}/`);
     }
   }
@@ -514,6 +538,9 @@ async function buildStatusSandboxRow(
     agent: redactFull(resolveDisplayAgent(sandbox)),
     ...(portablePhase ? { phase: portablePhase } : {}),
     ...(dashboardPort != null ? { dashboardPort } : {}),
+    ...(resolveDashboardExternalUrl(sandbox) != null
+      ? { dashboardExternalUrl: resolveDashboardExternalUrl(sandbox) }
+      : {}),
     isDefault,
   };
 }
@@ -676,6 +703,10 @@ export function showStatusCommand(deps: ShowStatusCommandDeps): void {
       const provider = liveProvider || inference.provider;
       const portSuffix = sb.dashboardPort != null ? ` :${sb.dashboardPort}` : "";
       log(`    ${sb.name}${def}${model ? ` (${model})` : ""}${portSuffix}`);
+      const externalDashboardUrl = resolveDashboardExternalUrl(sb);
+      if (externalDashboardUrl) {
+        log(`      Dashboard URL: ${externalDashboardUrl}`);
+      }
       const portablePhase = portablePhases.get(sb.name);
       if (portablePhase) log(`      agent: hermes  phase: ${portablePhase}`);
       if (isDefault && liveModel && liveModel !== inference.model) {

--- a/src/lib/onboard/created-sandbox-finalization.test.ts
+++ b/src/lib/onboard/created-sandbox-finalization.test.ts
@@ -1406,6 +1406,8 @@ describe("created sandbox completion actions", () => {
           imageTag: "hermes:test",
           hermesPortableLifecycle: schema5,
           dashboardPort: manageDashboard ? 8643 : 0,
+          // Loopback chatUiUrl -> no external URL persisted (#11439).
+          dashboardExternalUrl: null,
           lifecycleGeneration: "generation-1",
           lifecycleLiveIdentityFingerprint: "a".repeat(64),
           inferenceSelection: inferenceRouteReservation.authority.selection,

--- a/src/lib/onboard/created-sandbox-finalization.ts
+++ b/src/lib/onboard/created-sandbox-finalization.ts
@@ -7,6 +7,7 @@ import { isDeepStrictEqual } from "node:util";
 import { restoreRecreatedSandboxStateWithManagedAuthority } from "../actions/sandbox/snapshot/restore-authority";
 import type { OpenShellSandboxBufferedCommandExecutor } from "../adapters/openshell/sandbox-command";
 import * as buildContext from "../build-context";
+import { resolveExternalDashboardUrl } from "../dashboard/url";
 import { resolveSandboxImageTagFromCreateOutput } from "../domain/sandbox/image-tag";
 import type {
   OpenClawImagePluginInstall,
@@ -111,6 +112,7 @@ type RegistrationSeed = Omit<
   | "openclawImagePluginInstalls"
   | "hermesDashboardState"
   | "dashboardPort"
+  | "dashboardExternalUrl"
   | "lifecycleGeneration"
   | "lifecycleLiveIdentityFingerprint"
   | "inferenceRouteReservation"
@@ -362,6 +364,7 @@ export function createCreatedSandboxCompletionActions(
 ): CreatedSandboxCompletionActions {
   let chatUiUrl = options.dashboard.chatUiUrl;
   let dashboardPort = 0;
+  let dashboardExternalUrl: string | null = null;
   let hermesDashboardState = options.dashboard.initialHermesState;
   async function verifyCreatedProviderGpu(created: SandboxGpuCreateFlowResult): Promise<void> {
     await dockerGpuLocalInference.verifyGpuSandboxLocalInferenceAndCommitAfterReady(
@@ -401,6 +404,7 @@ export function createCreatedSandboxCompletionActions(
       );
     }
     process.env.CHAT_UI_URL = chatUiUrl;
+    dashboardExternalUrl = resolveExternalDashboardUrl(chatUiUrl);
     hermesDashboardState = options.dashboard.resolveHermesState(dashboardPort);
     deps.revalidateSandboxIdentity?.(
       `recording Hermes dashboard capability for sandbox '${options.finalization.sandboxName}'`,
@@ -507,6 +511,7 @@ export function createCreatedSandboxCompletionActions(
           openclawImagePluginInstalls,
           hermesDashboardState,
           dashboardPort,
+          dashboardExternalUrl,
           ...currentLifecycle,
           inferenceRouteReservation: verifiedInferenceRouteReservation,
           verifiedCreate,

--- a/src/lib/onboard/dashboard-port.test.ts
+++ b/src/lib/onboard/dashboard-port.test.ts
@@ -17,6 +17,7 @@ import {
   findAvailableDashboardPort,
   findDashboardForwardOwner,
   getRegistryOccupiedDashboardPorts,
+  lsofOutputBlocksLoopbackBind,
   preflightDashboardPortRangeAvailability,
   reserveCreateSandboxDashboardPort,
   reserveDashboardPort,
@@ -56,6 +57,55 @@ async function unusedLoopbackPort(): Promise<number> {
   await closeServer(server);
   return address.port;
 }
+
+describe("lsofOutputBlocksLoopbackBind interface-specific loopback probe (#11439)", () => {
+  const loopback = (port: number) =>
+    `COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME\nx 1 u 3u IPv4 1 0t0 TCP 127.0.0.1:${port} (LISTEN)`;
+  const external = (port: number) =>
+    `COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME\nsocat 1 u 6u IPv4 1 0t0 TCP 10.63.144.115:${port} (LISTEN)`;
+  const wildcard = (port: number) =>
+    `COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME\nx 1 u 3u IPv4 1 0t0 TCP *:${port} (LISTEN)`;
+
+  it("treats an external-interface-only listener as non-blocking for the loopback bind", () => {
+    expect(lsofOutputBlocksLoopbackBind(external(18789), 18789)).toBe(false);
+  });
+
+  it("treats a loopback listener as blocking", () => {
+    expect(lsofOutputBlocksLoopbackBind(loopback(18789), 18789)).toBe(true);
+  });
+
+  it("treats a wildcard 0.0.0.0 or star listener as blocking, preserving docker-proxy detection (#3260)", () => {
+    expect(lsofOutputBlocksLoopbackBind(wildcard(18789), 18789)).toBe(true);
+    expect(
+      lsofOutputBlocksLoopbackBind("x 1 u 3u IPv4 1 0t0 TCP 0.0.0.0:18789 (LISTEN)", 18789),
+    ).toBe(true);
+  });
+
+  it("treats an IPv6 loopback listener as blocking", () => {
+    expect(
+      lsofOutputBlocksLoopbackBind("x 1 u 3u IPv6 1 0t0 TCP [::1]:18789 (LISTEN)", 18789),
+    ).toBe(true);
+  });
+
+  it("only matches the requested port", () => {
+    expect(lsofOutputBlocksLoopbackBind(loopback(18790), 18789)).toBe(false);
+  });
+
+  it("returns false for empty or missing output", () => {
+    expect(lsofOutputBlocksLoopbackBind("", 18789)).toBe(false);
+    expect(lsofOutputBlocksLoopbackBind(null, 18789)).toBe(false);
+    expect(lsofOutputBlocksLoopbackBind(undefined, 18789)).toBe(false);
+  });
+
+  it("ignores non-LISTEN rows", () => {
+    expect(
+      lsofOutputBlocksLoopbackBind(
+        "x 1 u 3u IPv4 1 0t0 TCP 127.0.0.1:18789->10.0.0.2:5000 (ESTABLISHED)",
+        18789,
+      ),
+    ).toBe(false);
+  });
+});
 
 describe("findDashboardForwardOwner", () => {
   it("parses openshell forward list column format (#2169)", () => {

--- a/src/lib/onboard/dashboard-port.ts
+++ b/src/lib/onboard/dashboard-port.ts
@@ -125,26 +125,89 @@ export function probePortBoundSync(port: number): boolean {
 }
 
 /**
- * Synchronous check whether a TCP port has an active listener on the host.
+ * Classify an `lsof -n` NAME bind address as one that would block a loopback
+ * dashboard bind. NemoClaw binds its dashboard forward on `127.0.0.1`
+ * (see {@link reserveDashboardPort} and {@link probePortBoundSync}), so a
+ * listener only conflicts when it already owns the loopback interface or a
+ * wildcard address that includes it. A listener bound solely to an external
+ * interface (e.g. a TLS reverse proxy in front of `CHAT_UI_URL`) leaves the
+ * loopback socket free and must not be treated as blocking (#11439).
+ */
+function bindAddressBlocksLoopback(address: string): boolean {
+  const addr = address.replace(/^\[/, "").replace(/\]$/, "").toLowerCase();
+  // Wildcard binds (all interfaces) always include loopback.
+  if (addr === "*" || addr === "0.0.0.0" || addr === "::" || addr === "0:0:0:0:0:0:0:0") {
+    return true;
+  }
+  // IPv4 loopback (127.0.0.0/8) and IPv6 loopback (::1), including the
+  // IPv4-mapped form docker-proxy can report.
+  if (addr.startsWith("127.")) return true;
+  if (addr === "::1" || addr === "0:0:0:0:0:0:0:1") return true;
+  if (addr.startsWith("::ffff:127.")) return true;
+  return false;
+}
+
+/**
+ * Decide whether `lsof -sTCP:LISTEN -P -n` output shows a listener on `port`
+ * that would block a loopback dashboard bind. Only loopback and wildcard binds
+ * count; an external-interface-only listener does not. Returns false when no
+ * matching loopback/wildcard listener is present so callers fall through to the
+ * authoritative `127.0.0.1` bind probe (#11439). Preserves docker-proxy /
+ * loopback / `0.0.0.0` detection (#3260), which report wildcard or loopback
+ * addresses.
+ */
+export function lsofOutputBlocksLoopbackBind(
+  output: string | null | undefined,
+  port: number,
+): boolean {
+  if (!output) return false;
+  for (const rawLine of output.split("\n")) {
+    const line = rawLine.trim();
+    if (!/\(LISTEN\)$/.test(line)) continue;
+    // NAME column holds the bind endpoint, e.g. "TCP 127.0.0.1:18789 (LISTEN)",
+    // "TCP *:18789 (LISTEN)", or "TCP [::1]:18789 (LISTEN)".
+    const match = line.match(/\s(\S+):(\d+)\s+\(LISTEN\)$/);
+    if (!match) continue;
+    if (Number(match[2]) !== port) continue;
+    if (bindAddressBlocksLoopback(match[1])) return true;
+  }
+  return false;
+}
+
+/**
+ * Synchronous check whether a TCP port has an active listener that would block
+ * NemoClaw's dashboard bind.
+ *
+ * The default loopback dashboard forward binds `127.0.0.1`, so the decision is
+ * interface-specific: an external-interface-only listener on the same port
+ * number does not count. When `loopbackOnly` is false — an operator opted into a
+ * remote (`0.0.0.0`) bind via `NEMOCLAW_DASHBOARD_BIND` — the forward binds all
+ * interfaces, so any listener on the port (including an external-interface-only
+ * one) genuinely conflicts and counts (#3259, #11439).
  *
  * Detection chain — any positive signal short-circuits:
  *   1. `lsof` — finds listeners owned by the current user.
  *   2. `sudo -n lsof` — catches root-owned listeners (e.g., docker-proxy on
- *      macOS) that the unprivileged lsof can't see. Silently no-ops when
- *      the user can't escalate non-interactively.
- *   3. Node `net` bind probe — authoritative fallback when both lsof
- *      invocations come up empty, mirroring the direct ForwardTcp bind.
+ *      macOS) that the unprivileged lsof can't see. Silently no-ops when the
+ *      user can't escalate non-interactively.
+ *   3. Node `net` bind probe — authoritative `127.0.0.1` check, run whenever the
+ *      lsof invocations show no blocking listener, mirroring the direct
+ *      ForwardTcp loopback bind.
  *
  * Returns false (optimistic) when every probe is inconclusive. The detached
  * OpenShell launch performs the final bind check.
  */
-export function isPortBoundOnHost(port: number): boolean {
+export function isPortBoundOnHost(port: number, loopbackOnly = true): boolean {
+  const blocks = (output: ReturnType<RunCaptureFn>): boolean =>
+    loopbackOnly
+      ? lsofOutputBlocksLoopbackBind(output, port)
+      : Boolean(output && output.trim().length > 0);
   try {
     const out: ReturnType<RunCaptureFn> = runCapture(
       ["lsof", "-i", `:${port}`, "-sTCP:LISTEN", "-P", "-n"],
       { ignoreError: true },
     );
-    if (out && out.trim().length > 0) return true;
+    if (blocks(out)) return true;
   } catch {
     /* fall through to the next probe */
   }
@@ -154,7 +217,7 @@ export function isPortBoundOnHost(port: number): boolean {
       ["sudo", "-n", "lsof", "-i", `:${port}`, "-sTCP:LISTEN", "-P", "-n"],
       { ignoreError: true },
     );
-    if (sudoOut && sudoOut.trim().length > 0) return true;
+    if (blocks(sudoOut)) return true;
   } catch {
     /* fall through to the bind probe */
   }

--- a/src/lib/onboard/dashboard.ts
+++ b/src/lib/onboard/dashboard.ts
@@ -445,7 +445,13 @@ export function createOnboardDashboardHelpers(deps: OnboardDashboardDeps): Onboa
       ["forward", "list", "--gateway", forwardGateway],
       { ignoreError: true },
     );
-    const isPortBound = deps.isPortBoundOnHost ?? isPortBoundOnHost;
+    // The dashboard forward binds `127.0.0.1` by default, so an
+    // external-interface-only listener on the port does not conflict. When the
+    // operator opts into a remote (`0.0.0.0`) bind, every interface conflicts,
+    // so the host-port probe must count listeners on any interface (#3259, #11439).
+    const forwardBindsAllInterfaces = getDashboardForwardTarget(chatUiUrl).startsWith("0.0.0.0:");
+    const isPortBoundRaw = deps.isPortBoundOnHost ?? isPortBoundOnHost;
+    const isPortBound = (port: number): boolean => isPortBoundRaw(port, !forwardBindsAllInterfaces);
     const persistedPort = getPersistedDashboardPort(sandboxName, listSandboxes);
     const registryOccupiedPorts = new Map([
       ...getRegistryOccupiedDashboardPorts(sandboxName, listSandboxes),

--- a/src/lib/onboard/sandbox-registration.ts
+++ b/src/lib/onboard/sandbox-registration.ts
@@ -91,6 +91,12 @@ export interface CreatedSandboxRegistryEntryInput {
   /** True only when schema-5 receipt authority owns this Hermes registration. */
   hermesPortableLifecycle?: boolean;
   dashboardPort: number;
+  /**
+   * Browser-facing external dashboard URL resolved from `CHAT_UI_URL`, or null
+   * when the dashboard is a plain loopback address. Persisted so post-onboard
+   * commands can report the external origin (#11439).
+   */
+  dashboardExternalUrl?: string | null;
   dashboardRemoteBindPrepared?: boolean;
   lifecycleGeneration?: string;
   lifecycleLiveIdentityFingerprint?: string;
@@ -290,6 +296,9 @@ export function buildCreatedSandboxRegistryEntry(
             }))
         : undefined,
     dashboardPort: input.dashboardPort,
+    ...(input.dashboardExternalUrl != null
+      ? { dashboardExternalUrl: input.dashboardExternalUrl }
+      : {}),
     dashboardRemoteBindPrepared: input.dashboardRemoteBindPrepared === true,
     lifecycleGeneration: input.lifecycleGeneration,
     lifecycleLiveIdentityFingerprint: input.lifecycleLiveIdentityFingerprint,

--- a/src/lib/onboard/sandbox-reuse.test.ts
+++ b/src/lib/onboard/sandbox-reuse.test.ts
@@ -75,6 +75,8 @@ describe("applyReusedSandboxDashboardState", () => {
       hermesDashboardPort: enabled ? 18789 : undefined,
       hermesDashboardInternalPort: enabled ? 19119 : undefined,
       hermesDashboardTui: undefined,
+      // No external CHAT_UI_URL configured -> loopback stays the reported form.
+      dashboardExternalUrl: null,
       gatewayName: "nemoclaw",
       gatewayPort: 8080,
     });
@@ -83,6 +85,46 @@ describe("applyReusedSandboxDashboardState", () => {
     expect(ensureDashboardForward).toHaveBeenCalledWith("reuse-me", "http://127.0.0.1:18789", {
       reuseExistingForward: true,
     });
+  });
+
+  it("persists the external dashboard URL rebound to the effective port on reuse (#11439)", () => {
+    const updateSandbox = vi.fn();
+    const ensureDashboardForward = vi.fn(() => 18790);
+    const sandboxGpuConfig: SandboxGpuConfig = {
+      hostGpuDetected: false,
+      hostGpuPlatform: null,
+      sandboxGpuEnabled: false,
+      mode: "auto",
+      sandboxGpuDevice: null,
+      errors: [],
+    };
+
+    applyReusedSandboxDashboardState({
+      sandboxName: "reuse-me",
+      chatUiUrl: "http://127.0.0.1:18790",
+      env: { CHAT_UI_URL: "https://dash.example.com:18789" },
+      agent: loadAgent("hermes"),
+      model: "test-model",
+      provider: "openai-compatible",
+      selectionVerified: true,
+      sandboxGpuConfig,
+      gatewayName: "nemoclaw",
+      gatewayPort: 8080,
+      ensureDashboardForward,
+      hermesDashboardForwarding: {
+        resolveStateForPort: vi.fn(() => ({ enabled: false, config: null })),
+        ensureForState: vi.fn(),
+      },
+      updateSandbox,
+      updateReusedSandboxMetadata: vi.fn(),
+    });
+
+    expect(updateSandbox).toHaveBeenCalledWith(
+      "reuse-me",
+      expect.objectContaining({
+        dashboardExternalUrl: "https://dash.example.com:18790",
+      }),
+    );
   });
 
   it("skips dashboard forwarding while preserving reuse metadata for terminal agents", () => {

--- a/src/lib/onboard/sandbox-reuse.ts
+++ b/src/lib/onboard/sandbox-reuse.ts
@@ -4,6 +4,7 @@
 import type { AgentDefinition } from "../agent/defs";
 import type { SandboxEntry } from "../state/registry";
 import * as registry from "../state/registry";
+import { resolveExternalDashboardUrlForPort } from "../dashboard/url";
 import { canReuseDashboardForwardForAgent } from "./dashboard-runtime";
 import {
   getHermesDashboardRegistryFields,
@@ -135,6 +136,10 @@ export function applyReusedSandboxDashboardState(
   input: ReusedSandboxDashboardStateInput,
 ): ReusedSandboxDashboardStateResult {
   const manageDashboard = input.manageDashboard ?? true;
+  // Capture the operator's external origin before the loopback rewrite below
+  // overwrites `input.env.CHAT_UI_URL`, so the persisted external URL reflects
+  // the browser-facing address rather than the internal loopback bind (#11439).
+  const externalDashboardOrigin = input.env.CHAT_UI_URL;
   if (
     manageDashboard &&
     input.env.NEMOCLAW_DASHBOARD_BIND === "0.0.0.0" &&
@@ -191,8 +196,17 @@ export function applyReusedSandboxDashboardState(
   input.revalidateSandboxIdentity?.(
     `record reused dashboard state for sandbox '${input.sandboxName}'`,
   );
+  // Persist (or clear) the browser-facing external dashboard URL derived from
+  // the operator's `CHAT_UI_URL`, rebinding its port to the effective dashboard
+  // port, so a re-onboard that adds, changes, or removes an external origin
+  // keeps status/dashboard-url/list accurate rather than reporting a stale or
+  // missing URL (#11439). Only meaningful when this run manages the dashboard.
+  const externalDashboardUrl = manageDashboard
+    ? resolveExternalDashboardUrlForPort(externalDashboardOrigin, dashboardPort)
+    : null;
   (input.updateSandbox ?? registry.updateSandbox)(input.sandboxName, {
     ...getHermesDashboardRegistryFields(hermesDashboardState),
+    ...(manageDashboard ? { dashboardExternalUrl: externalDashboardUrl } : {}),
     gatewayName: input.gatewayName,
     gatewayPort: input.gatewayPort,
   });

--- a/src/lib/state/gateway-registry.test.ts
+++ b/src/lib/state/gateway-registry.test.ts
@@ -69,6 +69,63 @@ describe("host gateway registry index", () => {
     }
   });
 
+  it("rejects a malformed persisted dashboardExternalUrl (#11439)", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-gateway-index-exturl-"));
+    try {
+      const root = path.join(home, ".nemoclaw", "gateways", "9123");
+      fs.mkdirSync(root, { recursive: true });
+      fs.writeFileSync(
+        path.join(root, "sandboxes.json"),
+        JSON.stringify({
+          defaultSandbox: "instance-a",
+          sandboxes: {
+            "instance-a": {
+              name: "instance-a",
+              gatewayName: "nemoclaw-9123",
+              gatewayPort: 9123,
+              dashboardPort: 18789,
+              dashboardExternalUrl: "not a url",
+            },
+          },
+        }),
+      );
+
+      expect(() => listHostGatewayRegistryEntries(home)).toThrow(/invalid dashboardExternalUrl/);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts a valid persisted dashboardExternalUrl (#11439)", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-gateway-index-exturl-ok-"));
+    try {
+      const root = path.join(home, ".nemoclaw", "gateways", "9123");
+      fs.mkdirSync(root, { recursive: true });
+      fs.writeFileSync(
+        path.join(root, "sandboxes.json"),
+        JSON.stringify({
+          defaultSandbox: "instance-a",
+          sandboxes: {
+            "instance-a": {
+              name: "instance-a",
+              gatewayName: "nemoclaw-9123",
+              gatewayPort: 9123,
+              dashboardPort: 18789,
+              dashboardExternalUrl: "https://dash.example.com:18789",
+            },
+          },
+        }),
+      );
+
+      const entries = listHostGatewayRegistryEntries(home);
+
+      expect(entries).toHaveLength(1);
+      expect(entries[0].entry.dashboardExternalUrl).toBe("https://dash.example.com:18789");
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
   it("treats a zero persisted dashboard port as no dashboard instead of blocking the registry (#7020)", () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-gateway-index-zero-port-"));
     try {

--- a/src/lib/state/gateway-registry.ts
+++ b/src/lib/state/gateway-registry.ts
@@ -8,6 +8,7 @@ import { isErrnoException } from "../core/errno";
 import { isObjectRecord } from "../core/json-types";
 import { DEFAULT_GATEWAY_PORT } from "../core/ports";
 import { NAME_MAX_LENGTH, NAME_VALID_PATTERN } from "../name-validation";
+import { isValidDashboardExternalUrl } from "../dashboard/url";
 import { resolveGatewayName, resolveGatewayPortFromName } from "../onboard/gateway-binding";
 import { GATEWAYS_SUBDIR, nemoclawStateRoot } from "./state-root";
 
@@ -27,6 +28,7 @@ const MAX_GATEWAY_DIRECTORY_ENTRIES = 1024;
 export interface GatewayRegistryEntry extends Record<string, unknown> {
   name: string;
   dashboardPort?: number | null;
+  dashboardExternalUrl?: string | null;
   hermesApiPort?: number | null;
   gatewayName?: string | null;
   gatewayPort?: number | null;
@@ -112,6 +114,16 @@ function parseRegistry(filePath: string, raw: string): GatewayRegistryDocument {
       ) {
         throw stateError(`${filePath} has an invalid ${field} for sandbox ${JSON.stringify(name)}`);
       }
+    }
+    const externalUrl = value.dashboardExternalUrl;
+    if (
+      externalUrl !== undefined &&
+      externalUrl !== null &&
+      (typeof externalUrl !== "string" || !isValidDashboardExternalUrl(externalUrl))
+    ) {
+      throw stateError(
+        `${filePath} has an invalid dashboardExternalUrl for sandbox ${JSON.stringify(name)}`,
+      );
     }
     sandboxes[name] =
       value.dashboardPort === 0

--- a/src/lib/state/registry-normalization.test.ts
+++ b/src/lib/state/registry-normalization.test.ts
@@ -216,6 +216,40 @@ describe("sandbox registry normalization", () => {
     });
   });
 
+  it("round-trips the persisted external dashboard URL (#11439)", async () => {
+    const registry = await loadRegistryWith({});
+    registry.registerSandbox({
+      name: "proxied",
+      dashboardPort: 18_789,
+      dashboardExternalUrl: "https://dash.example.com:18789",
+    });
+
+    vi.resetModules();
+    const reloadedRegistry = await import("./registry");
+    expect(reloadedRegistry.getSandbox("proxied")).toMatchObject({
+      dashboardPort: 18_789,
+      dashboardExternalUrl: "https://dash.example.com:18789",
+    });
+  });
+
+  it("preserves a persisted external dashboard URL when only the port is updated (#11439)", async () => {
+    const registry = await loadRegistryWith({});
+    registry.registerSandbox({
+      name: "proxied",
+      dashboardPort: 18_789,
+      dashboardExternalUrl: "https://dash.example.com:18789",
+    });
+
+    // Mirror the non-clearing persistDashboardPort update: a loopback re-onboard
+    // must not overwrite the external URL with null.
+    registry.updateSandbox("proxied", { dashboardPort: 18_790 });
+
+    expect(registry.getSandbox("proxied")).toMatchObject({
+      dashboardPort: 18_790,
+      dashboardExternalUrl: "https://dash.example.com:18789",
+    });
+  });
+
   it("backfills a lifecycle generation only for the unchanged legacy Docker row (#8584)", async () => {
     const registry = await loadRegistryWith({});
     const { compareAndSetLegacySandboxLifecycleGeneration } =

--- a/src/lib/state/registry.ts
+++ b/src/lib/state/registry.ts
@@ -538,6 +538,7 @@ export function registerSandbox(
       hermesDashboardTui: entry.hermesDashboardTui === true ? true : undefined,
       hermesApiPort: entry.hermesApiPort ?? undefined,
       dashboardPort: entry.dashboardPort ?? undefined,
+      dashboardExternalUrl: entry.dashboardExternalUrl ?? undefined,
       dashboardRemoteBindPrepared: entry.dashboardRemoteBindPrepared === true ? true : undefined,
       gatewayName: entry.gatewayName ?? undefined,
       gatewayPort: entry.gatewayPort ?? undefined,

--- a/src/lib/state/registry/types.ts
+++ b/src/lib/state/registry/types.ts
@@ -149,6 +149,13 @@ export interface SandboxEntry extends Partial<InferenceSelection> {
    */
   hermesApiPort?: number | null;
   dashboardPort?: number | null;
+  /**
+   * Browser-facing external dashboard URL resolved from `CHAT_UI_URL` at
+   * onboard time (host + scheme with the effective dashboard port). Persisted
+   * only when an external origin was configured; a plain loopback dashboard is
+   * left unset and reported as `http://127.0.0.1:<dashboardPort>/` (#11439).
+   */
+  dashboardExternalUrl?: string | null;
   /** Remote dashboard exposure was included in the sandbox's generated config. */
   dashboardRemoteBindPrepared?: boolean;
   /** Generation proving which durable same-name recreate registered this row. */


### PR DESCRIPTION
## Outcome

Onboarding with `CHAT_UI_URL` pointed at an external HTTPS reverse proxy now
binds the dashboard to that same port instead of falling back to another port,
and `status`, `dashboard-url`, and `list --json` report the browser-facing
external URL. Before this change, an external-interface-only listener on the
`CHAT_UI_URL` port forced a silent port fallback (`! Port <p> is taken. Using
port <q> instead.`) even though the `127.0.0.1` socket NemoClaw needs was free,
and the external URL was never persisted so every post-onboard query reported
only `http://127.0.0.1:<fallback>/`.

## Reason

The dashboard-port probe and the OpenShell forward-ownership probe both matched
listeners on any interface (`lsof -i :<port>` / `lsof -ti4TCP:<port>`), so a TLS
reverse proxy bound only to an external interface looked like a conflict on the
loopback port NemoClaw actually binds. Separately, the resolved external
dashboard origin was computed for the one-time onboarding banner but never
recorded, so no later command could recover it.

### Related issues

Fixes #11439

## Changes

- `src/lib/onboard/dashboard-port.ts`: `isPortBoundOnHost(port, loopbackOnly=true)`
  decides loopback-bind availability from the `127.0.0.1` bind probe and a new
  `lsofOutputBlocksLoopbackBind` classifier that counts only loopback/wildcard
  listeners; an external-interface-only listener no longer forces a fallback.
  docker-proxy / `0.0.0.0` / `::` detection (#3260) is preserved.
- `src/lib/onboard/dashboard.ts`: passes `loopbackOnly=false` when the forward
  binds `0.0.0.0` (operator-opted remote exposure, #3259) so every interface
  still counts there.
- `src/lib/adapters/openshell/forward-service.ts`: the forward-ownership probe
  (`isForwardServiceListenerOwner`) is made interface-specific for loopback
  forwards (field-mode `lsof -FpPn` and `/proc/net/tcp` little-endian filtering),
  while a `0.0.0.0` forward keeps the interface-agnostic count.
- `src/lib/dashboard/url.ts`: `resolveExternalDashboardUrl` /
  `resolveExternalDashboardUrlForPort` derive the persistable external URL and a
  single shared `isValidDashboardExternalUrl` predicate (absolute http(s), host,
  no userinfo, no control chars, bounded length) gates both the writer and the
  registry read-side so a persisted value can always be read back.
- Persistence: `src/lib/state/registry/types.ts`, `gateway-registry.ts`,
  `registry.ts`, `onboard/created-sandbox-finalization.ts`,
  `onboard/sandbox-registration.ts`, and `onboard/sandbox-reuse.ts` persist
  `dashboardExternalUrl` on the fresh-create and reuse/resume paths;
  `registry.updateSandbox` remains non-clearing so a later port-only update never
  drops it.
- Surfacing: `src/lib/dashboard-url-command.ts` and `src/lib/inventory/index.ts`
  report the external URL in `dashboard-url`, `status`, and `list` (text + JSON),
  falling back to the loopback form only when no external origin was configured.
- Tests cover the interface-specific probes (external-only vs loopback vs
  wildcard vs `/proc` co-listener vs remote-bind), the shared URL predicate,
  registry validation + round-trip, non-clobbering port updates, reuse
  persistence, and dashboard-url rendering.

## Verification

Before/after E2E was run on the reporter's defect through the real worktree CLI
on a Linux host (yimoj-colossus-dev), standing up a `socat` TLS reverse proxy
bound only to the external interface (`10.63.144.115:18789`) forwarding to
`127.0.0.1:18789`, with the loopback interface confirmed free.

- BEFORE fix — `CHAT_UI_URL=https://<host>:18789 nemohermes onboard ... --fresh`
  → `! Port 18789 is taken. Using port 18798 instead.`; `dashboard-url` /
  `status` / `list --json` reported only `http://127.0.0.1:18798/`
  (`dashboardExternalUrl: null`). **reproduced**
- AFTER fix — same workflow → no fallback, `Deployment verified`, dashboard on
  18789; `dashboard-url` → `https://<host>:18789/`; `list --json` /
  `status --json` → `"dashboardExternalUrl":"https://<host>:18789"`, and `list` /
  `status` text show the external URL. **passed**
- `npx vitest run --project cli <9 changed-area test files>` — 247 passed
- `npx tsc -p tsconfig.cli.json` — passed (no new errors)
- `npx tsc -p tsconfig.src.json --noEmit` — passed
- `oxlint` + `oxfmt --check` on changed files — passed
- `npm run validate:pr` pre-push gate (repository checks, growth guardrails,
  commitlint, publication validation, TypeScript CLI) — passed

The broad `vitest run --project cli` run has 13 pre-existing failing test files
(corporate-CA / staged-Dockerfile fixtures) that reproduce identically on clean
`origin/main` with this change removed; they do not touch any file in this PR.

No secrets, API keys, or credentials are included in the diff.

## Review notes

The change also hardens a security-sensitive path: the OpenShell
forward-ownership probe. The interface-specific logic keeps ownership strict — a
genuine second loopback or wildcard co-listener still fails ownership; only an
external-interface-only listener on the same port number is excluded for a
loopback forward.

---

Signed-off-by: Yimo Jiang <yimoj@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * External dashboard URLs are detected, validated, persisted, and reused across sandbox creation and reuse.
  * Dashboard links prefer configured external URLs, with fallback to local access URLs.
  * Inventory and status views display external dashboard URLs when available.
* **Bug Fixes**
  * Improved port-conflict detection so external-interface listeners do not block localhost dashboard forwards.
  * Preserved conflict detection for wildcard and remotely exposed forwards.
  * Dashboard URLs now correctly retain authentication behavior for session- and token-authenticated dashboards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->