### PR TITLE
fix(onboard): reuse successful messaging refresh registration

### DIFF
--- a/src/lib/messaging/applier/openshell-provider.ts
+++ b/src/lib/messaging/applier/openshell-provider.ts
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { createHash } from "node:crypto";
+
 import type {
   OpenShellProviderAdapter,
   OpenShellProviderError,
@@ -878,45 +880,56 @@ async function configureRefreshes(
   const sleep = options.sleep ?? defaultSleep;
   const now = options.now ?? Date.now;
   for (const refresh of refreshes) {
+    const receiptKey = JSON.stringify([target, refresh.providerName, refresh.credentialKey]);
+    const previousReceipt = options.refreshReceipts?.get(receiptKey);
+    options.refreshReceipts?.delete(receiptKey);
+    const beforeRefresh = options.refreshReceipts
+      ? await refreshReceipt(refresh, target, providerAdapter)
+      : null;
+    const reuse = Boolean(previousReceipt && previousReceipt === beforeRefresh);
     options.revalidateSandboxIdentity?.(
       `configure gateway token minting for messaging provider ${JSON.stringify(refresh.providerName)}`,
     );
-    let configured: Awaited<ReturnType<OpenShellProviderAdapter["configureProviderRefresh"]>>;
-    try {
-      configured = await providerAdapter.configureProviderRefresh({
-        target,
-        providerName: refresh.providerName,
-        credentialKey: refresh.credentialKey,
-        strategy: refresh.strategy,
-        material: refresh.material,
-        secretMaterial: refresh.secretMaterial,
-      });
-    } catch (error) {
-      const message = redactStandaloneSecretsFull(
-        error instanceof Error ? error.message : String(error),
-      );
-      throw new MessagingProviderApplyError({
-        message: `Could not configure gateway token minting for messaging provider '${refresh.providerName}': ${message}`,
-        mutatedProviderNames: [refresh.providerName],
-      });
-    }
-    if (!configured.ok) {
-      throw new MessagingProviderApplyError({
-        message: `Could not configure gateway token minting for messaging provider '${refresh.providerName}': ${providerErrorMessage(configured.error)}`,
-        mutatedProviderNames: [refresh.providerName],
-      });
-    }
-    try {
-      options.revalidateSandboxIdentity?.(
-        `confirm gateway token minting configuration for messaging provider ${JSON.stringify(refresh.providerName)}`,
-      );
-    } catch (error) {
-      throw withMutationEvidence(error, [refresh.providerName], []);
+    if (!reuse) {
+      let configured: Awaited<ReturnType<OpenShellProviderAdapter["configureProviderRefresh"]>>;
+      try {
+        configured = await providerAdapter.configureProviderRefresh({
+          target,
+          providerName: refresh.providerName,
+          credentialKey: refresh.credentialKey,
+          strategy: refresh.strategy,
+          material: refresh.material,
+          secretMaterial: refresh.secretMaterial,
+        });
+      } catch (error) {
+        const message = redactStandaloneSecretsFull(
+          error instanceof Error ? error.message : String(error),
+        );
+        throw new MessagingProviderApplyError({
+          message: `Could not configure gateway token minting for messaging provider '${refresh.providerName}': ${message}`,
+          mutatedProviderNames: [refresh.providerName],
+        });
+      }
+      if (!configured.ok) {
+        throw new MessagingProviderApplyError({
+          message: `Could not configure gateway token minting for messaging provider '${refresh.providerName}': ${providerErrorMessage(configured.error)}`,
+          mutatedProviderNames: [refresh.providerName],
+        });
+      }
+      try {
+        options.revalidateSandboxIdentity?.(
+          `confirm gateway token minting configuration for messaging provider ${JSON.stringify(refresh.providerName)}`,
+        );
+      } catch (error) {
+        throw withMutationEvidence(error, [refresh.providerName], []);
+      }
     }
     options.log?.(`Waiting for the gateway to mint ${refresh.credentialKey}.`);
     const deadline = now() + REFRESH_DEADLINE_MS;
     let status: string | null = null;
     let observationError: OpenShellProviderError | null = null;
+    let receipt: string | null = null;
+    let ready = false;
     for (let attempt = 0; attempt < REFRESH_POLL_ATTEMPTS && now() < deadline; attempt += 1) {
       const observed = await providerAdapter.getProviderRefreshStatus({
         target,
@@ -930,23 +943,64 @@ async function configureRefreshes(
       } else {
         observationError = observed.error;
       }
-      if (status === "refreshed") break;
+      if (observed.ok && status === "refreshed") {
+        if (beforeRefresh) {
+          receipt = await refreshReceipt(refresh, target, providerAdapter).catch(
+            (error: unknown) => {
+              throw withMutationEvidence(error, reuse ? [] : [refresh.providerName], []);
+            },
+          );
+          if (reuse && receipt !== previousReceipt) {
+            throw new MessagingProviderApplyError({
+              message: `Messaging provider '${refresh.providerName}' changed while confirming its refresh registration.`,
+            });
+          }
+        }
+        ready = !beforeRefresh || Boolean(receipt && (reuse || receipt !== beforeRefresh));
+      }
+      if (ready) break;
       if (attempt + 1 < REFRESH_POLL_ATTEMPTS && now() < deadline) {
         await sleep(REFRESH_POLL_INTERVAL_MS);
       }
     }
-    if (status === "refreshed") continue;
+    if (ready) {
+      if (receipt) options.refreshReceipts?.set(receiptKey, receipt);
+      continue;
+    }
     if (observationError) {
       throw new MessagingProviderApplyError({
         message: `Could not observe gateway token minting for messaging provider '${refresh.providerName}': ${providerErrorMessage(observationError)}`,
-        mutatedProviderNames: [refresh.providerName],
+        mutatedProviderNames: reuse ? [] : [refresh.providerName],
       });
     }
     throw new MessagingProviderApplyError({
-      message: `Gateway token minting did not complete for messaging provider '${refresh.providerName}' (last status '${status ?? "unknown"}').`,
-      mutatedProviderNames: [refresh.providerName],
+      message:
+        status === "refreshed"
+          ? `Gateway reported a refresh without confirming a provider update for messaging provider '${refresh.providerName}'.`
+          : `Gateway token minting did not complete for messaging provider '${refresh.providerName}' (last status '${status ?? "unknown"}').`,
+      mutatedProviderNames: reuse ? [] : [refresh.providerName],
     });
   }
+}
+
+async function refreshReceipt(
+  refresh: MessagingProviderRefreshEphemeralInput,
+  target: OpenShellGatewayTarget,
+  providerAdapter: OpenShellProviderAdapter,
+): Promise<string | null> {
+  const observed = await providerAdapter.getProvider({
+    target,
+    providerName: refresh.providerName,
+  });
+  if (!observed.ok) {
+    throw new MessagingProviderApplyError({
+      message: `Could not inspect messaging provider '${refresh.providerName}': ${providerErrorMessage(observed.error)}`,
+    });
+  }
+  if (!observed.value.revision) return null;
+  return createHash("sha256")
+    .update(JSON.stringify([target, refresh, observed.value.revision]))
+    .digest("hex");
 }
 
 async function attachProviders(

--- a/src/lib/messaging/applier/types.ts
+++ b/src/lib/messaging/applier/types.ts
@@ -118,6 +118,8 @@ export type MessagingCredentialApplyOptions = MessagingSetupEnvOptions &
     target?: OpenShellGatewayTarget;
     definitions?: readonly MessagingCredentialProviderEphemeralInput[];
     refreshes?: readonly MessagingProviderRefreshEphemeralInput[];
+    /** Caller-owned, process-local hashes of successful refresh registrations. */
+    refreshReceipts?: Map<string, string>;
     requireCompleteBindings?: boolean;
     replaceExisting?: boolean;
     allowedSandboxes?: readonly string[];

--- a/src/lib/onboard/credential-provider-refresh-forwarding.test.ts
+++ b/src/lib/onboard/credential-provider-refresh-forwarding.test.ts
@@ -3,122 +3,165 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { MessagingSetupApplier } from "../messaging/applier/setup-applier";
-import type { SandboxMessagingPlan } from "../messaging/manifest";
-import type { Session } from "../state/onboard-session";
 import {
-  type CredentialProviderRegistrationDeps,
-  createCredentialProviderRegistration,
-} from "./credential-provider-registration";
-import { MESSAGING_BRIDGE_PENDING_VALUE } from "./messaging-bridge-provider";
+  credentialKey,
+  plan,
+  privateKey,
+  providerName,
+  refreshLifecycle,
+} from "../../../test/support/credential-provider-refresh";
+import { MessagingSetupApplier } from "../messaging/applier/setup-applier";
 
-const providerName = "alpha-googlechat-bridge";
+const providerRequest = {
+  target: { kind: "named" as const, gatewayName: "test-gateway" },
+  providerName,
+};
 
-function googleChatPlan(): SandboxMessagingPlan {
-  return {
-    schemaVersion: 1,
-    sandboxName: "alpha",
-    agent: "openclaw",
-    workflow: "onboard",
-    channels: [],
-    disabledChannels: [],
-    credentialBindings: [],
-    networkPolicy: { presets: [], entries: [] },
-    agentRender: [],
-    buildSteps: [],
-    stateUpdates: [],
-    healthChecks: [],
-  };
-}
+describe("onboarding provider refresh", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
 
-describe("onboarding provider refresh forwarding", () => {
-  afterEach(() => vi.restoreAllMocks());
+  it("registers once across staging and creation when refresh status precedes the provider write", async () => {
+    const flow = refreshLifecycle();
+    await flow.stage();
+    await expect(flow.materialize()).resolves.toEqual([providerName]);
 
-  it("forwards Google Chat refresh material to the messaging applier (#9806)", async () => {
-    const privateKey = "test-google-chat-private-key";
-    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
-    const serviceAccount = JSON.stringify({
-      client_email: "bot@example.test",
-      private_key: privateKey,
-    });
-    const session = { stagedCredentialProviders: [] } as unknown as Session;
-    const runOpenshell = vi.fn();
-    const deps: CredentialProviderRegistrationDeps = {
-      root: process.cwd(),
-      runOpenshell: runOpenshell as unknown as CredentialProviderRegistrationDeps["runOpenshell"],
-      getGatewayName: () => "test-gateway",
-      getCredential: (key) => (key === "GOOGLECHAT_SERVICE_ACCOUNT" ? serviceAccount : null),
-      updateSession: vi.fn(
-        (mutator: (current: Session) => Session | void): Session => mutator(session) ?? session,
-      ),
-      stagedLegacyValues: new Map(),
-      migratedLegacyKeys: new Set(),
-      persistMigratedLegacyKeys: vi.fn(),
-    };
-    const apply = vi.spyOn(MessagingSetupApplier, "applyCredentialsAtOpenShell").mockResolvedValue({
-      upserted: [],
-      reused: [
-        {
-          channelId: "googlechat",
-          credentialId: "GOOGLE_CHAT_ACCESS_TOKEN",
-          providerName,
-          envKey: "GOOGLE_CHAT_ACCESS_TOKEN",
-        },
+    expect(flow.adapter.createProvider).toHaveBeenCalledOnce();
+    expect(flow.adapter.deleteProvider).not.toHaveBeenCalled();
+    expect(flow.adapter.configureProviderRefresh).toHaveBeenCalledExactlyOnceWith({
+      ...providerRequest,
+      credentialKey,
+      strategy: "google_service_account_jwt",
+      material: [
+        { key: "client_email", value: "bot@example.test" },
+        { key: "scope", value: "https://www.googleapis.com/auth/chat.bot" },
       ],
-      missing: [],
-      replacedProviderNames: [],
-      providerNames: [providerName],
-      sandboxCreateProviderArgs: ["--provider", providerName],
+      secretMaterial: [{ key: "private_key", value: privateKey }],
     });
-    const registration = createCredentialProviderRegistration(deps);
-    const plan = googleChatPlan();
-
-    const providerNames = await registration.applyMessagingProviders(
-      [
-        {
-          name: providerName,
-          envKey: "GOOGLE_CHAT_ACCESS_TOKEN",
-          token: MESSAGING_BRIDGE_PENDING_VALUE,
-          providerType: "google-chat-bridge",
-        },
-      ],
-      {},
-      deps.runOpenshell,
-      plan,
-    );
-
-    expect(providerNames).toEqual([providerName]);
-    expect(apply).toHaveBeenCalledExactlyOnceWith(
-      plan,
-      expect.objectContaining({
-        refreshes: [
-          {
-            channelId: "googlechat",
-            providerName,
-            credentialKey: "GOOGLE_CHAT_ACCESS_TOKEN",
-            strategy: "google_service_account_jwt",
-            material: [
-              { key: "client_email", value: "bot@example.test" },
-              { key: "scope", value: "https://www.googleapis.com/auth/chat.bot" },
-            ],
-            secretMaterial: [{ key: "private_key", value: privateKey }],
-          },
-        ],
-      }),
-    );
-    const applyOptions = apply.mock.calls[0]?.[1];
-    expect(applyOptions?.refreshes?.flatMap(({ secretMaterial }) => secretMaterial)).toEqual([
-      { key: "private_key", value: privateKey },
+    expect(flow.session.stagedCredentialProviders).toEqual([providerName]);
+    expect([...flow.options().refreshReceipts!.values()]).toEqual([
+      expect.stringMatching(/^[a-f0-9]{64}$/u),
     ]);
-    expect(JSON.stringify(applyOptions).split(privateKey)).toHaveLength(2);
-    expect(JSON.stringify(applyOptions?.definitions)).not.toContain(privateKey);
     expect(
-      JSON.stringify(applyOptions?.refreshes?.flatMap(({ material }) => material)),
+      JSON.stringify([
+        plan,
+        flow.session,
+        flow.log.mock.calls,
+        [...flow.options().refreshReceipts!],
+        flow.options().definitions,
+        flow.options().refreshes![0].material,
+      ]),
     ).not.toContain(privateKey);
-    expect(JSON.stringify({ providerNames, diagnostics: consoleError.mock.calls })).not.toContain(
-      privateKey,
+  });
+
+  it.each([
+    ["secretMaterial", { key: "private_key", value: "replacement-key" }],
+    ["material", { key: "scope", value: "changed-scope" }],
+  ] as const)("reconfigures refresh when %s changes", async (field, entry) => {
+    const flow = refreshLifecycle();
+    await flow.stage();
+    const options = flow.options();
+
+    await expect(
+      MessagingSetupApplier.applyCredentialsAtOpenShell(plan, {
+        ...options,
+        refreshes: [{ ...options.refreshes![0], [field]: [entry] }],
+      }),
+    ).rejects.toThrow("last status 'configured'");
+    expect(flow.adapter.configureProviderRefresh).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not reuse a staged refresh on another gateway", async () => {
+    const flow = refreshLifecycle();
+    await flow.stage();
+
+    await expect(
+      MessagingSetupApplier.applyCredentialsAtOpenShell(plan, {
+        ...flow.options(),
+        target: { kind: "named", gatewayName: "other-gateway" },
+      }),
+    ).rejects.toThrow("last status 'configured'");
+    expect(flow.adapter.configureProviderRefresh).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not reuse a staged refresh after the provider revision changes", async () => {
+    const flow = refreshLifecycle();
+    await flow.stage();
+    await flow.adapter.updateProvider({ ...providerRequest, credentials: [], config: [] });
+
+    await expect(flow.materialize()).rejects.toThrow("last status 'configured'");
+    expect(flow.adapter.configureProviderRefresh).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects provider revision changes during reuse verification", async () => {
+    const flow = refreshLifecycle();
+    await flow.stage();
+    vi.mocked(flow.adapter.getProviderRefreshStatus).mockImplementationOnce(async () => {
+      await flow.adapter.updateProvider({ ...providerRequest, credentials: [], config: [] });
+      return { ok: true, value: { status: "refreshed" } };
+    });
+
+    await expect(flow.materialize()).rejects.toThrow(
+      "changed while confirming its refresh registration",
     );
-    expect(JSON.stringify({ plan, session })).not.toContain(privateKey);
-    expect(deps.persistMigratedLegacyKeys).not.toHaveBeenCalled();
+    expect(flow.adapter.configureProviderRefresh).toHaveBeenCalledOnce();
+  });
+
+  it("cleans up an initial pending mint without retaining a receipt", async () => {
+    const flow = refreshLifecycle();
+    vi.mocked(flow.adapter.getProviderRefreshStatus).mockResolvedValue({
+      ok: true,
+      value: { status: "configured" },
+    });
+
+    await expect(flow.stage()).rejects.toMatchObject({
+      message: expect.stringContaining("last status 'configured'"),
+      mutatedProviderNames: [],
+    });
+    expect(flow.options().refreshReceipts?.size).toBe(0);
+    expect(flow.adapter.configureProviderRefresh).toHaveBeenCalledOnce();
+    expect(flow.adapter.deleteProvider).toHaveBeenCalledOnce();
+  });
+
+  it("rejects a pending reused mint without deleting its provider", async () => {
+    const flow = refreshLifecycle();
+    await flow.stage();
+    vi.mocked(flow.adapter.getProviderRefreshStatus).mockResolvedValue({
+      ok: true,
+      value: { status: "configured" },
+    });
+
+    await expect(flow.materialize()).rejects.toMatchObject({
+      message: expect.stringContaining("last status 'configured'"),
+      mutatedProviderNames: [],
+    });
+    expect(flow.options().refreshReceipts?.size).toBe(0);
+    expect(flow.adapter.configureProviderRefresh).toHaveBeenCalledOnce();
+    expect(flow.adapter.deleteProvider).not.toHaveBeenCalled();
+  });
+
+  it("rejects a lost refresh observation while waiting for token publication", async () => {
+    const flow = refreshLifecycle();
+    const status = vi.mocked(flow.adapter.getProviderRefreshStatus);
+    const firstObservation = status.getMockImplementation()!;
+    status.mockResolvedValue({
+      ok: false,
+      error: { kind: "transport", reason: "unreachable", message: "gateway unavailable" },
+    });
+    status.mockImplementationOnce(firstObservation);
+
+    await expect(flow.stage()).rejects.toThrow("Could not observe gateway token minting");
+    expect(flow.options().refreshReceipts?.size).toBe(0);
+    expect(flow.adapter.configureProviderRefresh).toHaveBeenCalledOnce();
+    expect(flow.adapter.deleteProvider).toHaveBeenCalledOnce();
+  });
+
+  it("rejects refreshed status when the token never reaches the provider", async () => {
+    const flow = refreshLifecycle(false);
+    await expect(flow.stage()).rejects.toThrow("without confirming a provider update");
+    expect(flow.options().refreshReceipts?.size).toBe(0);
+    expect(flow.session.stagedCredentialProviders).toEqual([]);
   });
 });

--- a/src/lib/onboard/credential-provider-registration.ts
+++ b/src/lib/onboard/credential-provider-registration.ts
@@ -232,6 +232,7 @@ function validatePlannedCredentialProviderBindings(
 }
 
 export function createCredentialProviderRegistration(deps: CredentialProviderRegistrationDeps) {
+  const refreshReceipts = new Map<string, string>();
   const gatewayRunner = (gatewayName = deps.getGatewayName()) =>
     createGatewayScopedOpenshellRunner(deps.runOpenshell, gatewayName);
   async function upsertProvider(
@@ -293,6 +294,7 @@ export function createCredentialProviderRegistration(deps: CredentialProviderReg
       target: namedOpenShellGateway(gatewayName),
       definitions: application.definitions,
       refreshes: application.refreshes,
+      refreshReceipts,
       requireCompleteBindings: true,
       replaceExisting: options.replaceExisting,
       allowedSandboxes: options.allowedSandboxes,

--- a/test/support/credential-provider-refresh.ts
+++ b/test/support/credential-provider-refresh.ts
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { vi } from "vitest";
+
+import * as providerAdapters from "../../src/lib/adapters/openshell/provider-adapter-cli";
+import { applyCredentialsAtOpenShell } from "../../src/lib/messaging/applier/openshell-provider";
+import { MessagingSetupApplier } from "../../src/lib/messaging/applier/setup-applier";
+import type { SandboxMessagingPlan } from "../../src/lib/messaging/manifest";
+import type { Session } from "../../src/lib/state/onboard-session";
+import { createCredentialProviderRegistration } from "../../src/lib/onboard/credential-provider-registration";
+import { MESSAGING_BRIDGE_PENDING_VALUE } from "../../src/lib/onboard/messaging-bridge-provider";
+
+export const providerName = "alpha-googlechat-bridge";
+export const credentialKey = "GOOGLE_CHAT_ACCESS_TOKEN";
+export const privateKey = "test-google-chat-private-key";
+export const plan: SandboxMessagingPlan = {
+  schemaVersion: 1,
+  sandboxName: "alpha",
+  agent: "openclaw",
+  workflow: "onboard",
+  channels: [],
+  disabledChannels: [],
+  credentialBindings: [],
+  networkPolicy: { presets: [], entries: [] },
+  agentRender: [],
+  buildSteps: [],
+  stateUpdates: [],
+  healthChecks: [],
+};
+
+export function refreshLifecycle(publishToken = true) {
+  vi.stubEnv("GOOGLECHAT_SERVICE_ACCOUNT", undefined);
+  const tokenDef = {
+    name: providerName,
+    envKey: credentialKey,
+    token: MESSAGING_BRIDGE_PENDING_VALUE,
+    providerType: "google-chat-bridge",
+  };
+  let revision = 0;
+  let tokenExpiresAt = 0;
+  let status: string | null = null;
+  let writePending = false;
+  const adapter: providerAdapters.CliOpenShellProviderAdapter = {
+    ...providerAdapters.createCliOpenShellProviderAdapter({
+      run: () => {
+        throw new Error("Unexpected OpenShell command");
+      },
+    }),
+    getProvider: vi.fn(async () => {
+      if (!revision)
+        return {
+          ok: false as const,
+          error: {
+            kind: "command" as const,
+            reason: "not_found" as const,
+            message: "provider not found",
+          },
+        };
+      const value = {
+        name: providerName,
+        type: tokenDef.providerType,
+        credentialKeys: [credentialKey],
+        configKeys: [],
+        revision: { id: "provider-1", resourceVersion: revision },
+      };
+      if (writePending && publishToken) {
+        revision += 1;
+        writePending = false;
+      }
+      return { ok: true as const, value };
+    }),
+    createProvider: vi.fn(async () => {
+      revision = 1;
+      return { ok: true as const };
+    }),
+    updateProvider: vi.fn(async () => {
+      revision += 1;
+      return { ok: true as const };
+    }),
+    deleteProvider: vi.fn(async () => {
+      revision = 0;
+      return { ok: true as const };
+    }),
+    importProviderProfile: vi.fn(() => ({ ok: true as const })),
+    configureProviderRefresh: vi.fn(async () => {
+      status = "configured";
+      return { ok: true as const };
+    }),
+    getProviderRefreshStatus: vi.fn(async () => {
+      if (status === "configured" && tokenExpiresAt === 0) {
+        tokenExpiresAt = 3_600_000;
+        status = "refreshed";
+        writePending = true;
+      }
+      return { ok: true as const, value: { status } };
+    }),
+  };
+  vi.spyOn(providerAdapters, "createCliOpenShellProviderAdapter").mockReturnValue(adapter);
+  const apply = vi
+    .spyOn(MessagingSetupApplier, "applyCredentialsAtOpenShell")
+    .mockImplementation((input, options) =>
+      applyCredentialsAtOpenShell(input, { ...options, now: () => 0, sleep: async () => {} }),
+    );
+  vi.spyOn(MessagingSetupApplier, "readPlanFromEnv").mockReturnValue(plan);
+  const log = vi.spyOn(console, "error").mockImplementation(() => {});
+  const session = { stagedCredentialProviders: [] } as unknown as Session;
+  const registration = createCredentialProviderRegistration({
+    root: process.cwd(),
+    runOpenshell: vi.fn(),
+    getGatewayName: () => "test-gateway",
+    getCredential: () =>
+      JSON.stringify({ client_email: "bot@example.test", private_key: privateKey }),
+    updateSession: (mutator) => mutator(session) ?? session,
+    stagedLegacyValues: new Map(),
+    migratedLegacyKeys: new Set(),
+    persistMigratedLegacyKeys: vi.fn(),
+  });
+  const stage = () =>
+    registration.stageSandboxCredentialProviders(
+      {
+        sandboxName: "alpha",
+        enabledChannels: ["googlechat"],
+        webSearchConfig: null,
+        agent: { name: "openclaw" },
+        requiredBindings: [
+          { name: providerName, type: tokenDef.providerType, credentialEnv: credentialKey },
+        ],
+      },
+      async () => ({ messagingTokenDefs: [tokenDef] }),
+    );
+  const materialize = () =>
+    registration.applyMessagingProviders([tokenDef], {
+      replaceExisting: true,
+      allowedSandboxes: ["alpha"],
+    });
+  const options = () => apply.mock.calls[0]![1];
+  return { adapter, stage, materialize, options, session, log };
+}


### PR DESCRIPTION
## Outcome

Google Chat onboarding reuses the refresh registration completed during credential staging when sandbox creation applies the same configuration. This prevents the second configure call from resetting refresh status and causing onboarding to time out.

## Reason

Reconfiguring an existing refresh resets its status to `configured` while retaining the token expiry. OpenShell schedules the next mint from that expiry, but NemoClaw waits for it within a much shorter polling window.

### Related issues

Closes #11623

## Changes

- Share process-local, hashed refresh receipts between credential staging and sandbox creation. Reuse requires matching gateway, refresh inputs, and provider revision, followed by a readiness check.
- Wait for the provider update after a new configuration before retaining a receipt. This handles OpenShell reporting `refreshed` before writing the minted token.
- Reject failed observations without accepting a stale successful status.
- Cover the lifecycle with 10 focused regression cases. Keep the stateful gateway fake in `test/support` and conditional branching out of the test file.

## Verification

- `src/lib/onboard/credential-provider-refresh-forwarding.test.ts` — 10 tests passed.
- `node_modules/.bin/vitest run --project integration test/automation/pull-requests/growth-guardrails.test.ts` — 7 tests passed.
- `node --max-old-space-size=8192 node_modules/typescript/bin/tsc -p tsconfig.cli.json` — passed.
- Commit and push hooks passed, including publication validation, CLI typecheck, and gitleaks. GitHub reports commit `05a2659884a6e15d03adfccd9d4f746012a7cc26` as verified.
- Live source installation on Ubuntu 24.04.4 with OpenShell 0.0.116 and OpenClaw 2026.7.1 completed with one refresh configuration, and the user confirmed a Google Chat reply. The live-tested provider-applier and registration source match this commit.

No real credentials or tokens are included in the diff; test credentials are synthetic. The full test suite was not run.

## Review notes

The messaging and onboarding credential paths were self-reviewed against the regression tests. Independent security review remains pending.

Reuse evidence is limited to one process. Recovery of an already-failed onboarding session in a new process remains outside this change.

---

Signed-off-by: Hung Le <hple@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Refresh operations reuse confirmed registrations when provider state is unchanged, reducing redundant configuration.
  * Refreshes verify provider state changes and retain confirmation records for future operations.
  * Changes to refresh credentials or provider revisions trigger reconfiguration when required.
  * Uncertain outcomes are reported when refresh results cannot be conclusively verified.
  * Refresh operations now surface errors when required provider revision information is unavailable.
  * Sensitive refresh information remains protected during processing and reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->