### PR TITLE
perf(test): overlap native Podman cleanup cases

### DIFF
--- a/test/e2e/support/native-podman-setup-action.test.ts
+++ b/test/e2e/support/native-podman-setup-action.test.ts
@@ -1,14 +1,17 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { spawnSync } from "node:child_process";
+import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
+import { addAbortListener } from "node:events";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, type TestContext, vi } from "vitest";
 import YAML from "yaml";
+
+import { ownChildProcess } from "../../helpers/child-process-lifecycle.ts";
 
 import {
   validateNativePodmanRestoreAction,
@@ -18,6 +21,8 @@ import {
 const RESTORE_ACTION = path.resolve(".github/actions/restore-native-podman-e2e/action.yaml");
 const SETUP_ACTION = path.resolve(".github/actions/setup-native-podman-e2e/action.yaml");
 const FIXED_RESTORE_ROOT = "/usr/lib/nemoclaw-native-podman-e2e/docker-cli-restore";
+
+vi.setConfig({ maxConcurrency: 5 });
 
 function shellQuote(value: string): string {
   return `'${value.replaceAll("'", `'"'"'`)}'`;
@@ -36,7 +41,47 @@ function restoreRunScript(): string {
 
 type RestoreFixtureKind = "valid" | "regular-file" | "symlink";
 
-function runRestoreFixture(
+type CommandResult = {
+  readonly status: number | null;
+  readonly signal: NodeJS.Signals | null;
+  readonly stdout: string;
+  readonly stderr: string;
+};
+
+type ProcessOwner = Pick<TestContext, "signal" | "onTestFinished">;
+
+function runCommand(
+  ownerContext: ProcessOwner,
+  command: string,
+  args: readonly string[],
+  env: NodeJS.ProcessEnv,
+): Promise<CommandResult> {
+  ownerContext.signal.throwIfAborted();
+  return new Promise((resolve) => {
+    const child = execFile(
+      command,
+      [...args],
+      { encoding: "utf8", env, killSignal: "SIGKILL", timeout: 15_000 },
+      (error, stdout, stderr) => {
+        void owner.closed.then(() =>
+          resolve({
+            status: error ? (typeof error.code === "number" ? error.code : null) : 0,
+            signal: child.signalCode ?? error?.signal ?? null,
+            stdout,
+            stderr,
+          }),
+        );
+      },
+    );
+    const owner = ownChildProcess(child);
+    ownerContext.onTestFinished(owner.terminate);
+    const abort = addAbortListener(ownerContext.signal, () => child.kill("SIGKILL"));
+    child.once("close", () => abort[Symbol.dispose]());
+  });
+}
+
+async function runRestoreFixture(
+  ownerContext: ProcessOwner,
   kind: RestoreFixtureKind,
   serviceActiveState = "active",
   socketActiveState = "active",
@@ -133,9 +178,11 @@ function runRestoreFixture(
       "/usr/bin/docker | /usr/local/bin/docker | /snap/bin/docker) ;;",
       `${destination}) ;;`,
     );
-  const result = spawnSync("bash", ["--noprofile", "--norc", "-c", `${commandShims}\n${script}`], {
-    encoding: "utf8",
-    env: {
+  const result = await runCommand(
+    ownerContext,
+    "bash",
+    ["--noprofile", "--norc", "-c", `${commandShims}\n${script}`],
+    {
       ...process.env,
       NODE_BINARY: process.execPath,
       DOCKER_SERVICE_STATE: serviceState,
@@ -145,7 +192,7 @@ function runRestoreFixture(
       PATH: `${path.dirname(destination)}:${process.env.PATH ?? "/usr/bin:/bin"}`,
       SYSTEMCTL_LOG: systemctlLog,
     },
-  });
+  );
   return {
     destination,
     expectedSha256,
@@ -162,7 +209,8 @@ function writeExecutable(filePath: string, source: string): void {
   fs.writeFileSync(filePath, source, { mode: 0o700 });
 }
 
-function runPodmanCleanupFixture(
+async function runPodmanCleanupFixture(
+  ownerContext: ProcessOwner,
   withDockerState: boolean,
   podmanStopFails = false,
   withUnrelatedServiceUnit = false,
@@ -335,9 +383,11 @@ esac
       "/usr/bin/docker | /usr/local/bin/docker | /snap/bin/docker) ;;",
       `${destination}) ;;`,
     );
-  const result = spawnSync("bash", ["--noprofile", "--norc", "-c", `${commandShims}\n${script}`], {
-    encoding: "utf8",
-    env: {
+  const result = await runCommand(
+    ownerContext,
+    "bash",
+    ["--noprofile", "--norc", "-c", `${commandShims}\n${script}`],
+    {
       ...process.env,
       HOME: home,
       LOOPBACK_STATE: loopbackState,
@@ -348,7 +398,7 @@ esac
       RUNNER_TEMP: runnerTemp,
       SYSTEMCTL_LOG: systemctlLog,
     },
-  });
+  );
   return {
     destination,
     expectedSha256,
@@ -451,7 +501,7 @@ describe("native Podman E2E setup boundary", () => {
     }
   });
 
-  it("restores unchanged Docker runtime state and retires its authority (#11014)", () => {
+  it.concurrent("restores unchanged Docker runtime state and retires its authority (#11014)", async (context) => {
     const {
       destination,
       expectedSha256,
@@ -461,7 +511,7 @@ describe("native Podman E2E setup boundary", () => {
       serviceState,
       socketState,
       systemctlLog,
-    } = runRestoreFixture("valid");
+    } = await runRestoreFixture(context, "valid");
 
     try {
       expect(result.status, result.stderr).toBe(0);
@@ -469,10 +519,12 @@ describe("native Podman E2E setup boundary", () => {
         expectedSha256,
       );
       expect(
-        spawnSync("bash", ["--noprofile", "--norc", "-c", "command -v docker"], {
-          encoding: "utf8",
-          env: { ...process.env, PATH: `${path.dirname(destination)}:/usr/bin:/bin` },
-        }).stdout.trim(),
+        (
+          await runCommand(context, "bash", ["--noprofile", "--norc", "-c", "command -v docker"], {
+            ...process.env,
+            PATH: `${path.dirname(destination)}:/usr/bin:/bin`,
+          })
+        ).stdout.trim(),
       ).toBe(destination);
       expect(fs.existsSync(restoreRoot)).toBe(false);
       expect(fs.readFileSync(serviceState, "utf8").trim()).toBe("active");
@@ -483,10 +535,10 @@ describe("native Podman E2E setup boundary", () => {
     }
   });
 
-  it.each(["regular-file", "symlink"] as const)(
+  it.concurrent.for(["regular-file", "symlink"] as const)(
     "rejects a tampered %s restore source without modifying the Docker destination",
-    (kind) => {
-      const { destination, result, root } = runRestoreFixture(kind);
+    async (kind, context) => {
+      const { destination, result, root } = await runRestoreFixture(context, kind);
 
       try {
         expect(result.status).not.toBe(0);
@@ -497,8 +549,8 @@ describe("native Podman E2E setup boundary", () => {
     },
   );
 
-  it("keeps Docker services inactive when they were inactive before isolation (#11014)", () => {
-    const fixture = runRestoreFixture("valid", "inactive", "inactive");
+  it.concurrent("keeps Docker services inactive when they were inactive before isolation (#11014)", async (context) => {
+    const fixture = await runRestoreFixture(context, "valid", "inactive", "inactive");
 
     try {
       expect(fixture.result.status, fixture.result.stderr).toBe(0);
@@ -509,8 +561,15 @@ describe("native Podman E2E setup boundary", () => {
     }
   });
 
-  it("restores absent Docker units when is-enabled returns no text (#11014)", () => {
-    const fixture = runRestoreFixture("valid", "inactive", "inactive", "not-found", "not-found");
+  it.concurrent("restores absent Docker units when is-enabled returns no text (#11014)", async (context) => {
+    const fixture = await runRestoreFixture(
+      context,
+      "valid",
+      "inactive",
+      "inactive",
+      "not-found",
+      "not-found",
+    );
 
     try {
       expect(fixture.result.status, fixture.result.stderr).toBe(0);
@@ -524,39 +583,42 @@ describe("native Podman E2E setup boundary", () => {
     }
   });
 
-  it.each([
+  it.concurrent.for([
     ["after complete setup", true],
     ["after setup fails before Docker-state capture", false],
-  ] as const)("removes native Podman runner resources %s (#11014)", (_label, withDockerState) => {
-    const fixture = runPodmanCleanupFixture(withDockerState);
+  ] as const)(
+    "removes native Podman runner resources %s (#11014)",
+    async ([_label, withDockerState], context) => {
+      const fixture = await runPodmanCleanupFixture(context, withDockerState);
 
-    try {
-      expect(fixture.result.status, fixture.result.stderr).toBe(0);
-      expect(fs.existsSync(fixture.toolchainRoot)).toBe(false);
-      expect(fs.existsSync(fixture.storageDirectory)).toBe(false);
-      expect(fs.existsSync(fixture.serviceUnitDirectory)).toBe(false);
-      expect(fs.existsSync(path.join(fixture.runtimeDirectory, "podman"))).toBe(false);
-      expect(fs.existsSync(fixture.loopbackState)).toBe(false);
-      expect(fs.existsSync(fixture.helperRoot)).toBe(false);
-      expect(fs.existsSync(path.join(fixture.runnerTemp, "native-podman-e2e-toolchain"))).toBe(
-        false,
-      );
-      expect(fs.existsSync(fixture.destination)).toBe(withDockerState);
-      expect(
-        withDockerState
-          ? createHash("sha256").update(fs.readFileSync(fixture.destination)).digest("hex")
-          : null,
-      ).toBe(withDockerState ? fixture.expectedSha256 : null);
-      expect(fs.readFileSync(fixture.systemctlLog, "utf8")).toContain(
-        "--user stop nemoclaw-native-podman-e2e.socket nemoclaw-native-podman-e2e.service",
-      );
-    } finally {
-      fs.rmSync(fixture.root, { force: true, recursive: true });
-    }
-  });
+      try {
+        expect(fixture.result.status, fixture.result.stderr).toBe(0);
+        expect(fs.existsSync(fixture.toolchainRoot)).toBe(false);
+        expect(fs.existsSync(fixture.storageDirectory)).toBe(false);
+        expect(fs.existsSync(fixture.serviceUnitDirectory)).toBe(false);
+        expect(fs.existsSync(path.join(fixture.runtimeDirectory, "podman"))).toBe(false);
+        expect(fs.existsSync(fixture.loopbackState)).toBe(false);
+        expect(fs.existsSync(fixture.helperRoot)).toBe(false);
+        expect(fs.existsSync(path.join(fixture.runnerTemp, "native-podman-e2e-toolchain"))).toBe(
+          false,
+        );
+        expect(fs.existsSync(fixture.destination)).toBe(withDockerState);
+        expect(
+          withDockerState
+            ? createHash("sha256").update(fs.readFileSync(fixture.destination)).digest("hex")
+            : null,
+        ).toBe(withDockerState ? fixture.expectedSha256 : null);
+        expect(fs.readFileSync(fixture.systemctlLog, "utf8")).toContain(
+          "--user stop nemoclaw-native-podman-e2e.socket nemoclaw-native-podman-e2e.service",
+        );
+      } finally {
+        fs.rmSync(fixture.root, { force: true, recursive: true });
+      }
+    },
+  );
 
-  it("preserves unrelated user units while completing native Podman cleanup", () => {
-    const fixture = runPodmanCleanupFixture(true, false, true);
+  it.concurrent("preserves unrelated user units while completing native Podman cleanup", async (context) => {
+    const fixture = await runPodmanCleanupFixture(context, true, false, true);
     const unrelatedServiceUnit = path.join(fixture.serviceUnitDirectory, "unrelated.service");
 
     try {
@@ -574,8 +636,8 @@ describe("native Podman E2E setup boundary", () => {
     }
   });
 
-  it("preserves recovery authority when the native Podman service survives stop (#11014)", () => {
-    const fixture = runPodmanCleanupFixture(true, true);
+  it.concurrent("preserves recovery authority when the native Podman service survives stop (#11014)", async (context) => {
+    const fixture = await runPodmanCleanupFixture(context, true, true);
 
     try {
       expect(fixture.result.status).not.toBe(0);
@@ -596,8 +658,8 @@ describe("native Podman E2E setup boundary", () => {
     }
   });
 
-  it("rejects a restore record that cannot prove the prior Docker service state (#11014)", () => {
-    const fixture = runRestoreFixture("valid", "activating");
+  it.concurrent("rejects a restore record that cannot prove the prior Docker service state (#11014)", async (context) => {
+    const fixture = await runRestoreFixture(context, "valid", "activating");
 
     try {
       expect(fixture.result.status).not.toBe(0);

--- a/test/e2e/support/native-podman-setup-action.test.ts
+++ b/test/e2e/support/native-podman-setup-action.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { execFile } from "node:child_process";
+import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import { addAbortListener } from "node:events";
 import fs from "node:fs";
@@ -11,7 +11,7 @@ import path from "node:path";
 import { describe, expect, it, type TestContext, vi } from "vitest";
 import YAML from "yaml";
 
-import { ownChildProcess } from "../../helpers/child-process-lifecycle.ts";
+import { superviseChild } from "../../helpers/process-supervisor.ts";
 
 import {
   validateNativePodmanRestoreAction,
@@ -51,7 +51,7 @@ type CommandResult = {
 
 type ProcessOwner = Pick<TestContext, "signal" | "onTestFinished">;
 
-function runCommand(
+async function runCommand(
   ownerContext: ProcessOwner,
   command: string,
   args: readonly string[],
@@ -59,42 +59,39 @@ function runCommand(
   timeoutMs = 15_000,
 ): Promise<CommandResult> {
   ownerContext.signal.throwIfAborted();
-  return new Promise((resolve) => {
-    const child = execFile(
-      command,
-      [...args],
-      { encoding: "utf8", env },
-      (error, stdout, stderr) => {
-        void owner.closed.then(() =>
-          resolve({
-            status: error ? (typeof error.code === "number" ? error.code : null) : 0,
-            signal: child.signalCode ?? error?.signal ?? null,
-            timedOut,
-            stdout,
-            stderr,
-          }),
-        );
-      },
-    );
-    const owner = ownChildProcess(child);
-    let timedOut = false;
-    const timeout = setTimeout(() => {
-      timedOut = child.exitCode === null && child.signalCode === null && child.kill("SIGKILL");
-    }, timeoutMs);
-    timeout.unref();
-    ownerContext.onTestFinished(async () => {
-      clearTimeout(timeout);
-      await owner.terminate();
-    });
-    const abort = addAbortListener(ownerContext.signal, () => {
-      clearTimeout(timeout);
-      child.kill("SIGKILL");
-    });
-    child.once("close", () => {
-      clearTimeout(timeout);
-      abort[Symbol.dispose]();
-    });
+  let stdout = "";
+  let stderr = "";
+  const child = spawn(command, [...args], { detached: true, env });
+  const finishController = new AbortController();
+  const abort = addAbortListener(ownerContext.signal, () => finishController.abort());
+  const supervision = superviseChild(child, {
+    killGraceMs: 0,
+    onStderr: (chunk) => {
+      stderr += chunk;
+    },
+    onStdout: (chunk) => {
+      stdout += chunk;
+    },
+    signal: finishController.signal,
+    timeoutMs,
   });
+  ownerContext.onTestFinished(async () => {
+    finishController.abort();
+    await supervision;
+  });
+
+  try {
+    const result = await supervision;
+    return {
+      status: result.exitCode,
+      signal: result.signal,
+      timedOut: result.timedOut,
+      stdout,
+      stderr,
+    };
+  } finally {
+    abort[Symbol.dispose]();
+  }
 }
 
 async function runRestoreFixture(
@@ -539,18 +536,55 @@ describe("native Podman E2E setup boundary", () => {
     expect(result.timedOut).toBe(false);
   });
 
-  it.concurrent("reports hard timeouts separately from cancellation", async (context) => {
+  it.concurrent("terminates a timed-out subprocess group", async (context) => {
+    const startedAt = Date.now();
     const result = await runCommand(
       context,
-      process.execPath,
-      ["-e", "setInterval(() => {}, 1_000)"],
+      "bash",
+      ["--noprofile", "--norc", "-c", "sleep 30; echo unreachable"],
       process.env,
-      20,
+      100,
     );
 
     expect(result.status).toBeNull();
-    expect(result.signal).toBe("SIGKILL");
+    expect(result.signal).not.toBeNull();
     expect(result.timedOut).toBe(true);
+    expect(result.stdout).not.toContain("unreachable");
+    expect(Date.now() - startedAt).toBeLessThan(2_000);
+  });
+
+  it.concurrent("reports external cancellation separately from timeout", async (context) => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-podman-cancel-"));
+    const readyFile = path.join(root, "ready");
+    const controller = new AbortController();
+    const ownerContext: ProcessOwner = {
+      onTestFinished: (cleanup, timeout) => context.onTestFinished(cleanup, timeout),
+      signal: controller.signal,
+    };
+
+    try {
+      const resultPromise = runCommand(
+        ownerContext,
+        process.execPath,
+        [
+          "-e",
+          'const fs = require("node:fs"); fs.writeFileSync(process.argv[1], "ready"); process.on("SIGTERM", () => {}); setInterval(() => {}, 1_000);',
+          readyFile,
+        ],
+        process.env,
+        2_000,
+      );
+      await vi.waitFor(() => expect(fs.existsSync(readyFile)).toBe(true));
+      controller.abort();
+      const result = await resultPromise;
+
+      expect(result.status).toBeNull();
+      expect(result.signal).toBe("SIGKILL");
+      expect(result.timedOut).toBe(false);
+    } finally {
+      controller.abort();
+      fs.rmSync(root, { force: true, recursive: true });
+    }
   });
 
   it.concurrent("restores unchanged Docker runtime state and retires its authority (#11014)", async (context) => {

--- a/test/e2e/support/native-podman-setup-action.test.ts
+++ b/test/e2e/support/native-podman-setup-action.test.ts
@@ -21,6 +21,8 @@ import {
 const RESTORE_ACTION = path.resolve(".github/actions/restore-native-podman-e2e/action.yaml");
 const SETUP_ACTION = path.resolve(".github/actions/setup-native-podman-e2e/action.yaml");
 const FIXED_RESTORE_ROOT = "/usr/lib/nemoclaw-native-podman-e2e/docker-cli-restore";
+const COMMAND_OUTPUT_LIMIT = 64 * 1024;
+const OUTPUT_TRUNCATION_MARKER = "\n[output truncated]\n";
 
 vi.setConfig({ maxConcurrency: 5 });
 
@@ -51,6 +53,20 @@ type CommandResult = {
 
 type ProcessOwner = Pick<TestContext, "signal" | "onTestFinished">;
 
+type OutputCapture = {
+  text: string;
+  truncated: boolean;
+};
+
+function appendOutput(capture: OutputCapture, chunk: string): void {
+  const next = capture.truncated ? capture.text : capture.text + chunk;
+  const truncated = capture.truncated || next.length > COMMAND_OUTPUT_LIMIT;
+  capture.text = truncated
+    ? `${next.slice(0, COMMAND_OUTPUT_LIMIT - OUTPUT_TRUNCATION_MARKER.length)}${OUTPUT_TRUNCATION_MARKER}`
+    : next;
+  capture.truncated = truncated;
+}
+
 async function runCommand(
   ownerContext: ProcessOwner,
   command: string,
@@ -59,18 +75,18 @@ async function runCommand(
   timeoutMs = 15_000,
 ): Promise<CommandResult> {
   ownerContext.signal.throwIfAborted();
-  let stdout = "";
-  let stderr = "";
+  const stdout: OutputCapture = { text: "", truncated: false };
+  const stderr: OutputCapture = { text: "", truncated: false };
   const child = spawn(command, [...args], { detached: true, env });
   const finishController = new AbortController();
   const abort = addAbortListener(ownerContext.signal, () => finishController.abort());
   const supervision = superviseChild(child, {
     killGraceMs: 0,
     onStderr: (chunk) => {
-      stderr += chunk;
+      appendOutput(stderr, chunk);
     },
     onStdout: (chunk) => {
-      stdout += chunk;
+      appendOutput(stdout, chunk);
     },
     signal: finishController.signal,
     timeoutMs,
@@ -86,8 +102,8 @@ async function runCommand(
       status: result.exitCode,
       signal: result.signal,
       timedOut: result.timedOut,
-      stdout,
-      stderr,
+      stdout: stdout.text,
+      stderr: stderr.text,
     };
   } finally {
     abort[Symbol.dispose]();
@@ -568,7 +584,7 @@ describe("native Podman E2E setup boundary", () => {
         process.execPath,
         [
           "-e",
-          'const fs = require("node:fs"); fs.writeFileSync(process.argv[1], "ready"); process.on("SIGTERM", () => {}); setInterval(() => {}, 1_000);',
+          'const fs = require("node:fs"); process.on("SIGTERM", () => {}); fs.writeFileSync(process.argv[1], "ready"); setInterval(() => {}, 1_000);',
           readyFile,
         ],
         process.env,
@@ -585,6 +601,24 @@ describe("native Podman E2E setup boundary", () => {
       controller.abort();
       fs.rmSync(root, { force: true, recursive: true });
     }
+  });
+
+  it.concurrent("bounds captured subprocess output", async (context) => {
+    const result = await runCommand(
+      context,
+      process.execPath,
+      [
+        "-e",
+        `process.stdout.write("o".repeat(${COMMAND_OUTPUT_LIMIT + 1_024})); process.stderr.write("e".repeat(${COMMAND_OUTPUT_LIMIT + 1_024}));`,
+      ],
+      process.env,
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toHaveLength(COMMAND_OUTPUT_LIMIT);
+    expect(result.stderr).toHaveLength(COMMAND_OUTPUT_LIMIT);
+    expect(result.stdout.endsWith(OUTPUT_TRUNCATION_MARKER)).toBe(true);
+    expect(result.stderr.endsWith(OUTPUT_TRUNCATION_MARKER)).toBe(true);
   });
 
   it.concurrent("restores unchanged Docker runtime state and retires its authority (#11014)", async (context) => {

--- a/test/e2e/support/native-podman-setup-action.test.ts
+++ b/test/e2e/support/native-podman-setup-action.test.ts
@@ -44,6 +44,7 @@ type RestoreFixtureKind = "valid" | "regular-file" | "symlink";
 type CommandResult = {
   readonly status: number | null;
   readonly signal: NodeJS.Signals | null;
+  readonly timedOut: boolean;
   readonly stdout: string;
   readonly stderr: string;
 };
@@ -55,18 +56,20 @@ function runCommand(
   command: string,
   args: readonly string[],
   env: NodeJS.ProcessEnv,
+  timeoutMs = 15_000,
 ): Promise<CommandResult> {
   ownerContext.signal.throwIfAborted();
   return new Promise((resolve) => {
     const child = execFile(
       command,
       [...args],
-      { encoding: "utf8", env, killSignal: "SIGKILL", timeout: 15_000 },
+      { encoding: "utf8", env },
       (error, stdout, stderr) => {
         void owner.closed.then(() =>
           resolve({
             status: error ? (typeof error.code === "number" ? error.code : null) : 0,
             signal: child.signalCode ?? error?.signal ?? null,
+            timedOut,
             stdout,
             stderr,
           }),
@@ -74,9 +77,24 @@ function runCommand(
       },
     );
     const owner = ownChildProcess(child);
-    ownerContext.onTestFinished(owner.terminate);
-    const abort = addAbortListener(ownerContext.signal, () => child.kill("SIGKILL"));
-    child.once("close", () => abort[Symbol.dispose]());
+    let timedOut = false;
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+    }, timeoutMs);
+    timeout.unref();
+    ownerContext.onTestFinished(async () => {
+      clearTimeout(timeout);
+      await owner.terminate();
+    });
+    const abort = addAbortListener(ownerContext.signal, () => {
+      clearTimeout(timeout);
+      child.kill("SIGKILL");
+    });
+    child.once("close", () => {
+      clearTimeout(timeout);
+      abort[Symbol.dispose]();
+    });
   });
 }
 
@@ -511,6 +529,21 @@ describe("native Podman E2E setup boundary", () => {
 
     expect(result.status).toBeNull();
     expect(result.signal).toBe("SIGTERM");
+    expect(result.timedOut).toBe(false);
+  });
+
+  it.concurrent("reports hard timeouts separately from cancellation", async (context) => {
+    const result = await runCommand(
+      context,
+      process.execPath,
+      ["-e", "setInterval(() => {}, 1_000)"],
+      process.env,
+      20,
+    );
+
+    expect(result.status).toBeNull();
+    expect(result.signal).toBe("SIGKILL");
+    expect(result.timedOut).toBe(true);
   });
 
   it.concurrent("restores unchanged Docker runtime state and retires its authority (#11014)", async (context) => {

--- a/test/e2e/support/native-podman-setup-action.test.ts
+++ b/test/e2e/support/native-podman-setup-action.test.ts
@@ -79,8 +79,7 @@ function runCommand(
     const owner = ownChildProcess(child);
     let timedOut = false;
     const timeout = setTimeout(() => {
-      timedOut = true;
-      child.kill("SIGKILL");
+      timedOut = child.exitCode === null && child.signalCode === null && child.kill("SIGKILL");
     }, timeoutMs);
     timeout.unref();
     ownerContext.onTestFinished(async () => {
@@ -529,6 +528,14 @@ describe("native Podman E2E setup boundary", () => {
 
     expect(result.status).toBeNull();
     expect(result.signal).toBe("SIGTERM");
+    expect(result.timedOut).toBe(false);
+  });
+
+  it.concurrent("does not report a timeout after a normal exit", async (context) => {
+    const result = await runCommand(context, process.execPath, ["-e", ""], process.env, 1_000);
+
+    expect(result.status).toBe(0);
+    expect(result.signal).toBeNull();
     expect(result.timedOut).toBe(false);
   });
 

--- a/test/e2e/support/native-podman-setup-action.test.ts
+++ b/test/e2e/support/native-podman-setup-action.test.ts
@@ -501,6 +501,18 @@ describe("native Podman E2E setup boundary", () => {
     }
   });
 
+  it.concurrent("reports signal termination without an exit status", async (context) => {
+    const result = await runCommand(
+      context,
+      "bash",
+      ["--noprofile", "--norc", "-c", "kill -TERM $$"],
+      process.env,
+    );
+
+    expect(result.status).toBeNull();
+    expect(result.signal).toBe("SIGTERM");
+  });
+
   it.concurrent("restores unchanged Docker runtime state and retires its authority (#11014)", async (context) => {
     const {
       destination,

--- a/test/e2e/support/native-podman-setup-action.test.ts
+++ b/test/e2e/support/native-podman-setup-action.test.ts
@@ -7,6 +7,7 @@ import { addAbortListener } from "node:events";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { StringDecoder } from "node:string_decoder";
 
 import { describe, expect, it, type TestContext, vi } from "vitest";
 import YAML from "yaml";
@@ -60,9 +61,14 @@ type OutputCapture = {
 
 function appendOutput(capture: OutputCapture, chunk: string): void {
   const next = capture.truncated ? capture.text : capture.text + chunk;
-  const truncated = capture.truncated || next.length > COMMAND_OUTPUT_LIMIT;
+  const truncated = capture.truncated || Buffer.byteLength(next, "utf8") > COMMAND_OUTPUT_LIMIT;
   capture.text = truncated
-    ? `${next.slice(0, COMMAND_OUTPUT_LIMIT - OUTPUT_TRUNCATION_MARKER.length)}${OUTPUT_TRUNCATION_MARKER}`
+    ? `${new StringDecoder("utf8").write(
+        Buffer.from(next).subarray(
+          0,
+          COMMAND_OUTPUT_LIMIT - Buffer.byteLength(OUTPUT_TRUNCATION_MARKER, "utf8"),
+        ),
+      )}${OUTPUT_TRUNCATION_MARKER}`
     : next;
   capture.truncated = truncated;
 }
@@ -557,15 +563,13 @@ describe("native Podman E2E setup boundary", () => {
     const result = await runCommand(
       context,
       "bash",
-      ["--noprofile", "--norc", "-c", "sleep 30; echo unreachable"],
+      ["--noprofile", "--norc", "-c", "sleep 30"],
       process.env,
       100,
     );
 
-    expect(result.status).toBeNull();
-    expect(result.signal).not.toBeNull();
+    expect(result.status).not.toBe(0);
     expect(result.timedOut).toBe(true);
-    expect(result.stdout).not.toContain("unreachable");
     expect(Date.now() - startedAt).toBeLessThan(2_000);
   });
 
@@ -609,16 +613,18 @@ describe("native Podman E2E setup boundary", () => {
       process.execPath,
       [
         "-e",
-        `process.stdout.write("o".repeat(${COMMAND_OUTPUT_LIMIT + 1_024})); process.stderr.write("e".repeat(${COMMAND_OUTPUT_LIMIT + 1_024}));`,
+        `process.stdout.write("€".repeat(${Math.ceil(COMMAND_OUTPUT_LIMIT / 3) + 1_024})); process.stderr.write("€".repeat(${Math.ceil(COMMAND_OUTPUT_LIMIT / 3) + 1_024}));`,
       ],
       process.env,
     );
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toHaveLength(COMMAND_OUTPUT_LIMIT);
-    expect(result.stderr).toHaveLength(COMMAND_OUTPUT_LIMIT);
+    expect(Buffer.byteLength(result.stdout, "utf8")).toBeLessThanOrEqual(COMMAND_OUTPUT_LIMIT);
+    expect(Buffer.byteLength(result.stderr, "utf8")).toBeLessThanOrEqual(COMMAND_OUTPUT_LIMIT);
     expect(result.stdout.endsWith(OUTPUT_TRUNCATION_MARKER)).toBe(true);
     expect(result.stderr.endsWith(OUTPUT_TRUNCATION_MARKER)).toBe(true);
+    expect(result.stdout).not.toContain("�");
+    expect(result.stderr).not.toContain("�");
   });
 
   it.concurrent("restores unchanged Docker runtime state and retires its authority (#11014)", async (context) => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

The native Podman setup boundary suite drops from 5.65s to 3.32s (41% faster) while preserving all existing cases and extending coverage to 21 cases. This changes test execution only; production actions and behavior are unchanged.

## Reason

Independent restore and cleanup fixtures used unique temporary roots but launched their Bash subprocesses synchronously, forcing every case to wait for the previous one.

## Changes

- Replace blocking fixture launches with async, detached `spawn` calls managed by the shared process supervisor.
- Preserve exit status, termination signal, timeout state, stdout, stderr, a 15-second hard timeout, owner cancellation, and whole-process-group teardown.
- Run isolated restore and cleanup cases concurrently with a five-process cap.
- Use `it.concurrent.for` where parameterized cases need their owning Vitest context.
- Cover Bash descendant cleanup and external cancellation separately from timeout.
- Bound captured stdout and stderr to 64 KiB of UTF-8 per stream with a truncation marker.

## Verification

- Clean `origin/main` focused baseline — 16/16 passed in 5.65s test time.
- Focused final candidate — 21/21 passed in 3.32s test time (41% faster than the matched baseline).
- Shuffled candidate (`--sequence.shuffle --sequence.seed=11625`) — 21/21 passed in 2.99s test time.
- `NODE_OPTIONS=--max-old-space-size=8192 npm run build:cli` — passed.
- `NODE_OPTIONS=--max-old-space-size=8192 npm run typecheck:cli` — passed after building the CLI and plugin artifacts.
- Normal commit and pre-push hooks — passed, including formatting, growth guardrails, publication validation, and CLI TypeScript.
- GitHub commit verification — all commits through `5d865cc780` are Verified.
- Diff inspection — no secrets, API keys, or credentials.

## Review notes

All required CI, security scans, CodeRabbit, and the nine-specialist PR Review Advisor are green on the final head. The repository-required documentation check found no user-facing update is needed. The production native-Podman setup and restore actions are untouched. Awaiting one requested human approval.

---
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of interrupted, timed-out, and cancelled processes.
  - Ensured descendant processes are fully terminated during cleanup.
  - Cleanup failures now produce clear failure status and diagnostic output.
  - Improved output capture and truncation consistency for long-running operations.
  - Process launch and diagnostic probes now consistently report cleanup failures alongside other errors.

- **Tests**
  - Expanded coverage for process termination, cancellation, timeouts, cleanup, recovery, output limits, and service-state handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->