### PR TITLE
fix(uninstall): reject malformed adapter pid files

### DIFF
--- a/src/lib/actions/uninstall/openrouter-runtime-adapter-cleanup.test.ts
+++ b/src/lib/actions/uninstall/openrouter-runtime-adapter-cleanup.test.ts
@@ -10,9 +10,9 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   type RunResult,
+  runUninstallPlan as runUninstallPlanBase,
   type UninstallRunDeps,
   type UninstallRunOptions,
-  runUninstallPlan as runUninstallPlanBase,
 } from "./run-plan";
 
 function ok(stdout = ""): RunResult {
@@ -300,6 +300,47 @@ describe("runtime adapter uninstall cleanup", () => {
       expect(fs.existsSync(path.join(tmpHome, ".nemoclaw", "bedrock-runtime-adapter.json"))).toBe(
         true,
       );
+    } finally {
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    ["suffix junk", "44323abc"],
+    ["extra line", "44323\njunk"],
+  ])("ignores a malformed persisted adapter PID file with %s", (_label, pidText) => {
+    const killed: number[] = [];
+    const exited = new Set<number>();
+    const tmpHome = fs.mkdtempSync(
+      path.join(os.tmpdir(), "nemoclaw-uninstall-test-openrouter-bad-pidfile-"),
+    );
+    const pidFile = path.join(tmpHome, ".nemoclaw", "openrouter-runtime-adapter.pid");
+    fs.mkdirSync(path.dirname(pidFile), { recursive: true });
+    fs.writeFileSync(pidFile, pidText);
+
+    try {
+      const stub = psStub("44323", { exited });
+      const result = runUninstallPlan(
+        { assumeYes: true, deleteModels: false, keepOpenShell: true },
+        {
+          commandExists: () => true,
+          env: { HOME: tmpHome, LOGNAME: "testuser" } as NodeJS.ProcessEnv,
+          existsSync: (target) => target === pidFile,
+          isTty: false,
+          kill: (pid) => {
+            killed.push(pid);
+            exited.add(pid);
+            return true;
+          },
+          log: vi.fn(),
+          rmSync: vi.fn(),
+          run: runStub({ ps: stub }),
+          runDocker: () => ok(""),
+        },
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(killed).not.toContain(44323);
     } finally {
       fs.rmSync(tmpHome, { recursive: true, force: true });
     }

--- a/src/lib/actions/uninstall/openrouter-runtime-adapter-cleanup.ts
+++ b/src/lib/actions/uninstall/openrouter-runtime-adapter-cleanup.ts
@@ -28,6 +28,7 @@ import {
   writeDurablePrivateBedrockRuntimeJson,
 } from "../../inference/bedrock-runtime/lifecycle";
 import { BEDROCK_RUNTIME_ADAPTER_PROCESS_MATCHER } from "../../inference/bedrock-runtime";
+import { parseLocalAdapterPidText } from "../../inference/local-adapter-lifecycle";
 
 interface RuntimeAdapterCleanupRuntime extends BedrockRuntimeAdapterProcessRuntime {
   commandExists: (command: string) => boolean;
@@ -164,9 +165,8 @@ function stopRuntimeAdapter(
   const pidFile = path.join(paths.nemoclawStateDir, descriptor.pidFile);
   if (runtime.existsSync(pidFile)) {
     try {
-      const raw = fs.readFileSync(pidFile, "utf-8").trim();
-      const pid = Number.parseInt(raw, 10);
-      if (Number.isFinite(pid) && pid > 0 && isRuntimeAdapterPid(pid, runtime, descriptor)) {
+      const pid = parseLocalAdapterPidText(fs.readFileSync(pidFile, "utf-8"));
+      if (pid !== null && isRuntimeAdapterPid(pid, runtime, descriptor)) {
         if (tryStopRuntimeAdapterPid(pid, runtime, descriptor)) stopped.add(pid);
       }
     } catch {

--- a/src/lib/inference/local-adapter-lifecycle.test.ts
+++ b/src/lib/inference/local-adapter-lifecycle.test.ts
@@ -116,6 +116,34 @@ describe("local adapter lifecycle", () => {
   });
 
   it.each([
+    ["plain digits", "123"],
+    ["digits with newline", "123\n"],
+    ["digits with CRLF", "123\r\n"],
+  ])("loads a persisted PID from %s", (_label, raw) => {
+    const pidPath = path.join(tempDir(), "adapter.pid");
+    fs.writeFileSync(pidPath, raw);
+
+    expect(loadLocalAdapterPid(pidPath)).toBe(123);
+  });
+
+  it.each([
+    ["suffix junk", "123abc"],
+    ["extra line", "123\njunk"],
+    ["internal whitespace", "12 3"],
+    ["zero", "0"],
+    ["negative", "-1"],
+    ["empty", ""],
+    ["multiple trailing newlines", "123\n\n"],
+    ["leading whitespace", " 123"],
+    ["trailing whitespace", "123 "],
+  ])("rejects malformed persisted PID text with %s", (_label, raw) => {
+    const pidPath = path.join(tempDir(), "adapter.pid");
+    fs.writeFileSync(pidPath, raw);
+
+    expect(loadLocalAdapterPid(pidPath)).toBeNull();
+  });
+
+  it.each([
     "ollama-auth-proxy.js",
     "ollama-auth-proxy.mts",
   ])("guards PID cleanup for the supported %s script", (scriptName) => {

--- a/src/lib/inference/local-adapter-lifecycle.ts
+++ b/src/lib/inference/local-adapter-lifecycle.ts
@@ -192,11 +192,22 @@ export function persistLocalAdapterPid(filePath: string, pid: number | null | un
   writeLocalAdapterSecretFile(filePath, String(pid));
 }
 
+export function parseLocalAdapterPidText(raw: string): number | null {
+  const match = /^(\d+)(?:\r?\n)?$/.exec(raw);
+  if (!match) return null;
+  const digits = match[1];
+  if (digits === undefined) return null;
+  const pid = Number(digits);
+  return Number.isSafeInteger(pid) && pid > 0 ? pid : null;
+}
+
 export function loadLocalAdapterPid(filePath: string): number | null {
-  const raw = readLocalAdapterTextFile(filePath);
-  if (!raw) return null;
-  const pid = Number.parseInt(raw, 10);
-  return Number.isInteger(pid) && pid > 0 ? pid : null;
+  try {
+    if (!fs.existsSync(filePath)) return null;
+    return parseLocalAdapterPidText(fs.readFileSync(filePath, "utf8"));
+  } catch {
+    return null;
+  }
 }
 
 export function isLocalAdapterProcess(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome
Malformed persisted adapter PID files no longer partially parse as valid process IDs. Valid PID files that contain only digits with an optional final newline or CRLF continue to load normally.

## Reason
The previous loader used partial numeric parsing, so content such as `123abc` or `123\njunk` could be treated as PID `123`. Adapter cleanup should only act on canonical PID evidence before it considers signaling a process.

## Changes
- Add a strict parser for local adapter PID file text.
- Use the strict parser in local adapter PID loading.
- Reuse the strict parser for OpenRouter and HTTPS Pin runtime adapter uninstall cleanup.
- Add focused tests for valid PID text and malformed suffix, multiline, whitespace, zero, negative, and empty PID content.

## Verification
- GitHub commit verification for `a5fe3b6bb` — `verified: true`, reason `valid`.
- Windows: `npm run build:cli; npx vitest run --project cli src/lib/inference/local-adapter-lifecycle.test.ts -t "loads a persisted PID|rejects malformed persisted PID"` — passed, 12 tests.
- DGX Spark Linux/aarch64, Node `v22.22.2`, npm `10.9.7`: `npm run build:cli` — passed.
- DGX Spark Linux/aarch64: `npx vitest run --project cli src/lib/inference/local-adapter-lifecycle.test.ts src/lib/actions/uninstall/openrouter-runtime-adapter-cleanup.test.ts` — passed, 43 tests.
- DGX Spark Linux/aarch64: `npm run check:diff` — passed.
- DGX Spark Linux/aarch64: `git diff --check` — passed.
- No secrets, API keys, or credentials committed.

## Review notes
Sensitive-path context: this changes cleanup evidence parsing before local adapter processes can be signaled. Documentation writer review returned `no-docs-needed` for commit `a5fe3b6bb`; `HEAD:AGENTS.md` was `dd3528f6e`.

---
<!-- DCO sign-off is required in this PR description. Every commit must appear as Verified in GitHub. -->
Signed-off-by: HwangJohn <angelic805@gmail.com>
